### PR TITLE
SPM `--parallel` test / GH action interaction demo

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
       uses: devcontainers/ci@v0.3
       with:
         runCmd: |
-          swift build --enable-code-coverage --build-tests -c ${{ matrix.configuration }}  ${{ matrix.host.build-options }} &&
+          swift build --build-tests -c ${{ matrix.configuration }}  ${{ matrix.host.build-options }} &&
           swift test -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
 
     - name: Check code coverage

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
         host: [
           { type: linux, os: ubuntu-latest,
 	    build-options: "-v --build-tests -Xswiftc -enable-testing",
-	    test-options: "-v --enable-code-coverage"
+	    test-options: "--parallel -v --enable-code-coverage"
 	  }
         ]
         configuration: [ "debug", "release" ]
@@ -62,7 +62,7 @@ jobs:
   	    type: macos, os: macos-latest,
             build-options: "-v --build-tests -Xswiftc -enable-testing",
 	    # No coverage support on MacOS
-	    test-options: "-v"
+	    test-options: "--parallel -v"
 	  }
         ]
         swift: [

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,11 +35,11 @@ jobs:
 
     - run: git config --global core.autocrlf input
 
-    - name: Build and run devcontainer task
+    - name: Build and Test
       uses: devcontainers/ci@v0.3
       with:
-        runCmd: | 
-          swift build -v -c ${{ matrix.configuration }}
+        runCmd: |
+          swift build --build-tests -v -c ${{ matrix.configuration }} &&
           swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
 
     - name: Check code coverage
@@ -85,12 +85,12 @@ jobs:
 
     - name: Configure pkgconfig
       run: |
-        swift package resolve
-        sudo .build/checkouts/Swifty-LLVM/Tools/make-pkgconfig.sh /usr/local/lib/pkgconfig/llvm.pc
+        swift package resolve &&
+        sudo .build/checkouts/Swifty-LLVM/Tools/make-pkgconfig.sh /usr/local/lib/pkgconfig/llvm.pc &&
         cat /usr/local/lib/pkgconfig/llvm.pc
 
     - name: Build (${{ matrix.configuration }})
-      run: swift build -v -c ${{ matrix.configuration }}
+      run: swift build --build-tests -v -c ${{ matrix.configuration }}
 
     - name: Test (${{ matrix.configuration }})
       run: swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,10 @@ jobs:
       fail-fast: false
       matrix:
         host: [
-          { type: linux, os: ubuntu-latest, test-options: "-Xswiftc -enable-testing --enable-code-coverage" }
+          { type: linux, os: ubuntu-latest,
+	    build-options: "-v --build-tests -Xswiftc -enable-testing",
+	    test-options: "-v --enable-code-coverage"
+	  }
         ]
         configuration: [ "debug", "release" ]
 
@@ -39,8 +42,8 @@ jobs:
       uses: devcontainers/ci@v0.3
       with:
         runCmd: |
-          swift build --build-tests -v -c ${{ matrix.configuration }} &&
-          swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
+          swift build --enable-code-coverage --build-tests -c ${{ matrix.configuration }}  ${{ matrix.host.build-options }} &&
+          swift test -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
 
     - name: Check code coverage
       uses: mattpolzin/swift-codecov-action@0.7.3
@@ -55,7 +58,12 @@ jobs:
       fail-fast: false
       matrix:
         host: [
-          { type: macos, os: macos-latest, test-options: "-Xswiftc -enable-testing --enable-code-coverage" }
+          {
+  	    type: macos, os: macos-latest,
+            build-options: " -v --build-tests -Xswiftc -enable-testing",
+	    # No coverage support on MacOS
+	    test-options: "-v"
+	  }
         ]
         swift: [
           { version: "5.8" }
@@ -83,14 +91,18 @@ jobs:
 
     - run: llvm-config --version
 
-    - name: Configure pkgconfig
+    - name: Generate LLVM pkgconfig file
       run: |
         swift package resolve &&
-        sudo .build/checkouts/Swifty-LLVM/Tools/make-pkgconfig.sh /usr/local/lib/pkgconfig/llvm.pc &&
-        cat /usr/local/lib/pkgconfig/llvm.pc
+        .build/checkouts/Swifty-LLVM/Tools/make-pkgconfig.sh llvm.pc &&
+        cat llvm.pc
 
     - name: Build (${{ matrix.configuration }})
-      run: swift build --build-tests -v -c ${{ matrix.configuration }}
+      run: |
+        export PKG_CONFIG_PATH=$PWD &&
+        swift build -c ${{ matrix.configuration }} ${{ matrix.host.build-options }}
 
     - name: Test (${{ matrix.configuration }})
-      run: swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
+      run: |
+        export PKG_CONFIG_PATH=$PWD &&
+        swift test -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
       uses: devcontainers/ci@v0.3
       with:
         runCmd: |
-          swift build --build-tests -c ${{ matrix.configuration }}  ${{ matrix.host.build-options }} &&
+          swift build -c ${{ matrix.configuration }}  ${{ matrix.host.build-options }} &&
           swift test -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
 
     - name: Check code coverage
@@ -60,7 +60,7 @@ jobs:
         host: [
           {
   	    type: macos, os: macos-latest,
-            build-options: " -v --build-tests -Xswiftc -enable-testing",
+            build-options: "-v --build-tests -Xswiftc -enable-testing",
 	    # No coverage support on MacOS
 	    test-options: "-v"
 	  }

--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Utils
-import ValModule
 
 /// An abstract syntax tree.
 public struct AST {


### PR DESCRIPTION
This PR demonstrates how using `swift test --parallel` in a GH action can fail.  As you can see, the previous commit in the chain passed CI, but this one, which only adds the `--parallel` option, fails on both Linux and MacOS.  I believe there's some nondeterminism involved here.