### PR TITLE
Add some insurance against spurious failures in doc extraction.

### DIFF
--- a/.github/workflows/doc-extraction.yml
+++ b/.github/workflows/doc-extraction.yml
@@ -85,7 +85,7 @@ jobs:
         export PKG_CONFIG_PATH
         for TARGET in ${EXTRACTION_TARGETS}; do
           mkdir -p _site/docc/"$TARGET"
-          swift package --allow-writing-to-directory ./_site \
+          Tools/retry-once swift package --allow-writing-to-directory ./_site \
           generate-documentation \
           --target "$TARGET" \
           --output-path _site/docc/"${TARGET}" \

--- a/Tools/retry-once
+++ b/Tools/retry-once
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash -e
+# retry-once command... executes command... and if it fails, executes it again.
+# because we seem to get spurious failures in various places with GitHub actions,
+"$@" || "$@"


### PR DESCRIPTION
Either Github actions or swift package manager is causing some build jobs to die non-deterministically without a diagnostic.  Retry these jobs once before reporting failure.