### PR TITLE
Use a different action to setup swift on Linux.

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build:
     name: Format check
-    runs-on: ubuntu-latest
+    runs-on: macos-13
     steps:
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build:
     name: Format check
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/cache@v3
       with:
@@ -36,9 +36,10 @@ jobs:
     - run: git config --global core.autocrlf input
 
     - name: Setup swift
-      uses: swift-actions/setup-swift@v1
-      with:
-        swift-version: "5.8"
+      uses: sersoft-gmbh/swifty-linux-action@v2
+        with:
+          release-version: '5.8'
+          github-token: ${{secrets.GITHUB_TOKEN}}
 
     - name: Swift version
       run: swift --version

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -37,9 +37,9 @@ jobs:
 
     - name: Setup swift
       uses: sersoft-gmbh/swifty-linux-action@v2
-        with:
-          release-version: '5.8'
-          github-token: ${{secrets.GITHUB_TOKEN}}
+      with:
+        release-version: '5.8'
+        github-token: ${{secrets.GITHUB_TOKEN}}
 
     - name: Swift version
       run: swift --version

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -36,10 +36,9 @@ jobs:
     - run: git config --global core.autocrlf input
 
     - name: Setup swift
-      uses: sersoft-gmbh/swifty-linux-action@v2
+      uses: slashmo/install-swift@v0.1.0
       with:
-        release-version: '5.8'
-        github-token: ${{secrets.GITHUB_TOKEN}}
+        version: 5.8
 
     - name: Swift version
       run: swift --version

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -36,7 +36,7 @@ jobs:
     - run: git config --global core.autocrlf input
 
     - name: Setup swift
-      uses: slashmo/install-swift@v0.1.0
+      uses: slashmo/install-swift@v0.4.0
       with:
         version: 5.8
 


### PR DESCRIPTION
An attempt to stomp out the spurious format-check failures we've been seeing, that [die in setup-swift](https://github.com/swift-actions/setup-swift/issues/591).

An alternative would be to run the format check on MacOS, but that's expected to be slower.  This analysis <https://github.com/swift-actions/setup-swift/issues/591#issuecomment-1684602660> explains why I think it would work.

Another alternative would be to run it on Linux in the devcontainer, where Swift is already set up.