### PR TITLE
Spell check GitHub action

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,13 @@
+name: Spell check
+on: [pull_request, push]
+
+jobs:
+  run:
+    name: Spell Check using typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v3
+
+    - name: Check spelling of file.txt
+      uses: crate-ci/typos@v1.0.4

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+inout = "inout" # Mutable projection keyword
+olt = "olt" # Abbreviation for "ordered less than"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,17 @@ You will need to manually [synchronize it](https://docs.github.com/en/pull-reque
 Make sure your changes do not break anything by running all existing tests.
 We also ask that you write tests for the code you want to contribute.
 
+Ensure your changes do not intruduce any spelling errors. We use [typos-action]
+to ensure no mistakes creep in. To run locally, [install typos] and run `typos`
+to run a check and `typos -w` to automatically apply suggestions. If you run
+into any false positives see the [typos false positives documentation].
+
 Before issuing a pull request we ask that you squash all your commits into a single logical commit that describes your contribution.
 We may ask you to commit additional changes while your pull request is under review.
 Once everything looks good, squash those additional commits before merging.
 
 Do not hesitate to reach out if you are lost in the process.
+
+[typos-action]: https://github.com/marketplace/actions/typos-action
+[install typos]: https://github.com/crate-ci/typos#install
+[typos false positives documentation]: https://github.com/crate-ci/typos#false-positives

--- a/Docs/DefiniteInitialization.md
+++ b/Docs/DefiniteInitialization.md
@@ -1,6 +1,6 @@
 # Definite (De)Initialization
 
-Definite (De)Initialization (DI, a.k.a. [definite assignment analyis](https://en.wikipedia.org/wiki/Definite_assignment_analysis) is a mandatory transformation pass that is applied on Hylo's intermediate representation, before code generation.
+Definite (De)Initialization (DI, a.k.a. [definite assignment analysis](https://en.wikipedia.org/wiki/Definite_assignment_analysis) is a mandatory transformation pass that is applied on Hylo's intermediate representation, before code generation.
 This pass ensures that all objects are initialized before use (definite initialization) and deinitialized before the end of their storage's lifetime (definite deinitialization), inserting additional instructions if necessary.
 
 The pass is expected to run early in the IR transformation pipeline, after __Implicit Return Insertion__ and __Unreachable Code Elimination__.

--- a/Docs/RemoteParts.md
+++ b/Docs/RemoteParts.md
@@ -24,7 +24,7 @@ The compiler should emit a warning if a remote part is taken as a parameter of a
 Local `var` bindings operate differently than stored `var` properties.
 When we assign into a local `var`, the value that it held is destroyed (unless we do the `copy(into:)` optimization).
 When we assign into a stored `var`, the value of its container is modified in place.
-The thoeretical rationale is that a dotted access is always projection: the LHS of `foo.bar = 2` is not actually a `var`.
+The theoretical rationale is that a dotted access is always projection: the LHS of `foo.bar = 2` is not actually a `var`.
 Example:
 
 ```

--- a/Docs/Subscripts.md
+++ b/Docs/Subscripts.md
@@ -133,7 +133,7 @@ These two restrictions serve two goals:
 1. Guarantee that continuations cannot break control flow and cannot.
 2. Handle overlapping projections that do not nest.
 
-One over-approximation of a continuation's scope is the dominance frontier of the basic block in which the projection starts, excluding the instructions before the start of the projeciton.
+One over-approximation of a continuation's scope is the dominance frontier of the basic block in which the projection starts, excluding the instructions before the start of the projection.
 In the above example, the continuation associated with `t` would contain all instructions in `loop.body` after the definition of `%t`.
 
 Using dominance frontiers also obviates the difficulty to identify definitions may escape a continuation.

--- a/Library/Hylo/LibC.hylo
+++ b/Library/Hylo/LibC.hylo
@@ -18,7 +18,7 @@ public fun fatal_error() -> Never
 @ffi("fdopen")
 public fun fdopen(_ descriptor: Int, _ mode: RawPointer) -> RawPointer
 
-/// Writes to `stream` the contents of `data`, which containts `count` elements of `size` bytes,
+/// Writes to `stream` the contents of `data`, which contains `count` elements of `size` bytes,
 /// returning the number of elements written.
 @ffi("fwrite")
 public fun fwrite(_ data: RawPointer, _ size: Int, _ count: Int, _ stream: RawPointer) -> Int

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ That integrated terminal is connected to the Devcontainer, as if by ssh.
 Use the `make-pkgconfig` tool to configure LLVM's library description (see steps 3 in [prerequisites](#prerequisites)).
 You can now run `swift test -c release` to build and test for Linux.
 
-The Hylo repository files are mounted into the container, so any changes made locally (in VSCode or in other editors) will be automatically propagated into the Devcontainer. However, if you need to modifiy any of the files in the `.devcontainer` directory, you will need to rebuild the container with `> Dev Containers: Rebuild and Reopen in Container`.
+The Hylo repository files are mounted into the container, so any changes made locally (in VSCode or in other editors) will be automatically propagated into the Devcontainer. However, if you need to modify any of the files in the `.devcontainer` directory, you will need to rebuild the container with `> Dev Containers: Rebuild and Reopen in Container`.
 
 ## Implementation status
 

--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -35,7 +35,7 @@ public struct LLVMProgram {
     }
   }
 
-  /// Applies the mandatory IR simplication passes on each module in `self`.
+  /// Applies the mandatory IR simplification passes on each module in `self`.
   public mutating func applyMandatoryPasses() {
     for k in llvmModules.keys {
       llvmModules[k]!.runDefaultModulePasses(optimization: .none, for: target)

--- a/Sources/Core/AST/BundledNode.swift
+++ b/Sources/Core/AST/BundledNode.swift
@@ -23,7 +23,7 @@ public struct BundledNode<T: NodeIDProtocol, P: Program> {
 
   /// The scope in which the node resides.
   ///
-  /// - Requres: `self` does not identify a module.
+  /// - Requires: `self` does not identify a module.
   public var scope: AnyScopeID {
     container.nodeToScope[id]!
   }

--- a/Sources/Core/AST/Expr/RemoteExpr.swift
+++ b/Sources/Core/AST/Expr/RemoteExpr.swift
@@ -12,7 +12,7 @@ public struct RemoteExpr: Expr {
   /// The expression of the projected type.
   public let operand: AnyExprID
 
-  /// Creates an isntance with the given properties.
+  /// Creates an instance with the given properties.
   public init(
     introducerSite: SourceRange,
     convention: SourceRepresentable<AccessEffect>,

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -320,7 +320,7 @@ private func mathFlags(_ stream: inout ArraySlice<Substring>) -> NativeInstructi
   return result
 }
 
-/// Returns an overlflow behavior parsed from `stream` or `.ignore` if none can be parsed.
+/// Returns an overflow behavior parsed from `stream` or `.ignore` if none can be parsed.
 private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> LLVM.OverflowBehavior {
   switch stream.first {
   case "nuw":

--- a/Sources/Core/CompileTimeValues/GenericArguments.swift
+++ b/Sources/Core/CompileTimeValues/GenericArguments.swift
@@ -69,7 +69,7 @@ public struct GenericArguments {
   ///
   /// - Requires: `self` does not define a value for any of the values defined in `suffix`.
   public mutating func append(_ suffix: Self) {
-    // Note: `merging` perserves order.
+    // Note: `merging` preserves order.
     contents.merge(suffix.contents, uniquingKeysWith: { (_, _) in unreachable() })
   }
 

--- a/Sources/Core/Types/ExistentialType.swift
+++ b/Sources/Core/Types/ExistentialType.swift
@@ -44,7 +44,7 @@ public struct ExistentialType: TypeProtocol {
     self.interface = interface
     self.constraints = constraints
 
-    // TODO: Consider the flags of the types in the cosntraints?
+    // TODO: Consider the flags of the types in the constraints?
     self.flags = interface.flags
   }
 

--- a/Sources/Core/Types/ParameterType.swift
+++ b/Sources/Core/Types/ParameterType.swift
@@ -1,6 +1,6 @@
 import Utils
 
-/// The type of a paramter in a lambda, method, or subscript type.
+/// The type of a parameter in a lambda, method, or subscript type.
 public struct ParameterType: TypeProtocol {
 
   /// The passing convention of the parameter.

--- a/Sources/Core/Types/TypeFlags.swift
+++ b/Sources/Core/Types/TypeFlags.swift
@@ -35,7 +35,7 @@ public struct TypeFlags: Hashable {
     existential = existential | flags.existential
   }
 
-  /// Retuns a set of flags in which `flags` have been inserted.
+  /// Returns a set of flags in which `flags` have been inserted.
   public func inserting(_ flags: TypeFlags) -> TypeFlags {
     var newFlags = self
     newFlags.insert(flags)
@@ -48,7 +48,7 @@ public struct TypeFlags: Hashable {
     existential = existential & ~flags.existential
   }
 
-  /// Retuns a set of flags in which `flags` have been removed.
+  /// Returns a set of flags in which `flags` have been removed.
   public func removing(_ flags: TypeFlags) -> TypeFlags {
     var newFlags = self
     newFlags.remove(flags)
@@ -61,7 +61,7 @@ public struct TypeFlags: Hashable {
     existential = existential | flags.existential
   }
 
-  /// Retuns a set of flags in which `flags` have been merged.
+  /// Returns a set of flags in which `flags` have been merged.
   public func merging(_ flags: TypeFlags) -> TypeFlags {
     var newFlags = self
     newFlags.merge(flags)

--- a/Sources/Driver/HyloCommand.swift
+++ b/Sources/Driver/HyloCommand.swift
@@ -229,7 +229,7 @@ public struct Driver: ParsableCommand {
     #endif
   }
 
-  /// Returns `true` if type inference related to `n`, which is in `p`, whould be traced.
+  /// Returns `true` if type inference related to `n`, which is in `p`, would be traced.
   private func shouldTraceInference(_ n: AnyNodeID, _ p: TypedProgram) -> Bool {
     if let s = inferenceTracingSite {
       return s.bounds.contains(p[n].site.first())
@@ -239,7 +239,7 @@ public struct Driver: ParsableCommand {
   }
 
   /// Returns `program` lowered to Hylo IR, accumulating diagnostics in `log` and throwing if an
-  /// error occured.
+  /// error occurred.
   ///
   /// Mandatory IR passes are applied unless `self.outputType` is `.rawIR`.
   private func lower(
@@ -258,7 +258,7 @@ public struct Driver: ParsableCommand {
   }
 
   /// Returns `m`, which is `program`, lowered to Hylo IR, accumulating diagnostics in `log` and
-  /// throwing if an error occured.
+  /// throwing if an error occurred.
   ///
   /// Mandatory IR passes are applied unless `self.outputType` is `.rawIR`.
   private func lower(

--- a/Sources/FrontEnd/AST+UseCollection.swift
+++ b/Sources/FrontEnd/AST+UseCollection.swift
@@ -22,7 +22,7 @@ private struct UseVisitor: ASTWalkObserver {
   private(set) var uses: [(NameExpr.ID, AccessEffect)] = []
 
   /// Records a use of `n` that with mutability `k`.
-  private mutating func recordOccurence(_ k: AccessEffect, _ n: NameExpr.ID) {
+  private mutating func recordOccurrence(_ k: AccessEffect, _ n: NameExpr.ID) {
     uses.append((n, k))
   }
 
@@ -55,7 +55,7 @@ private struct UseVisitor: ASTWalkObserver {
 
   private mutating func visit(inoutExpr e: InoutExpr.ID, in ast: AST) -> Bool {
     if let x = root(ast[e].subject, in: ast) {
-      recordOccurence(.inout, x)
+      recordOccurrence(.inout, x)
       return false
     } else {
       return true
@@ -64,7 +64,7 @@ private struct UseVisitor: ASTWalkObserver {
 
   private mutating func visit(nameExpr e: NameExpr.ID, in ast: AST) -> Bool {
     if ast[e].domain == .none {
-      recordOccurence(.let, e)
+      recordOccurrence(.let, e)
       return false
     } else {
       return true

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -3054,7 +3054,7 @@ public enum Parser {
 
 }
 
-/// The attributes and modifiers preceeding a declaration.
+/// The attributes and modifiers preceding a declaration.
 struct DeclPrologue {
 
   /// Indicates whether the prologue is empty.
@@ -3364,7 +3364,7 @@ private func inContext<Base: Combinator>(
   WrapInContext(context: context, base: base)
 }
 
-/// Creates a combinator that applies `base` only if its input is not preceeded by whitespaces.
+/// Creates a combinator that applies `base` only if its input is not preceded by whitespaces.
 private func withoutLeadingWhitespace<Base: Combinator>(
   _ base: Base
 ) -> Apply<ParserState, Base.Element>
@@ -3372,7 +3372,7 @@ where Base.Context == ParserState {
   Apply({ (state) in try state.hasLeadingWhitespace ? nil : base.parse(&state) })
 }
 
-/// Creates a combinator that applies `base` only if its input is not preceeded by newlines.
+/// Creates a combinator that applies `base` only if its input is not preceded by newlines.
 private func onSameLine<Base: Combinator>(
   _ base: Base
 ) -> Apply<ParserState, Base.Element>

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1682,7 +1682,7 @@ public enum Parser {
 
     case .remote:
       // Remote type expression.
-      return try parseRemotExpr(in: &state).map(AnyExprID.init)
+      return try parseRemoteExpr(in: &state).map(AnyExprID.init)
 
     case .spawn:
       // Spawn expression.
@@ -2072,7 +2072,7 @@ public enum Parser {
     return .block(s)
   }
 
-  private static func parseRemotExpr(
+  private static func parseRemoteExpr(
     in state: inout ParserState
   ) throws -> RemoteExpr.ID? {
     guard let introducer = state.take(.remote) else { return nil }
@@ -2184,7 +2184,7 @@ public enum Parser {
     guard let opener = state.take(.lBrack) else { return nil }
 
     // Parse the environment, if any.
-    let environement = try parseExpr(in: &state)
+    let environment = try parseExpr(in: &state)
 
     // If we don't find the closing bracket, backtrack and parse a compound literal.
     if state.take(.rBrack) == nil {
@@ -2196,7 +2196,7 @@ public enum Parser {
     if !state.isNext(.lParen) {
       let expr = state.insert(
         BufferLiteralExpr(
-          elements: environement != nil ? [environement!] : [],
+          elements: environment != nil ? [environment!] : [],
           site: state.range(from: opener.site.start)))
       return AnyExprID(expr)
     }
@@ -2223,7 +2223,7 @@ public enum Parser {
 
     // Synthesize the environment as an empty tuple if we parsed `[]`.
     let s = state.lexer.sourceCode.emptyRange(at: opener.site.start)
-    let e = environement ?? AnyExprID(state.insert(TupleTypeExpr(elements: [], site: s)))
+    let e = environment ?? AnyExprID(state.insert(TupleTypeExpr(elements: [], site: s)))
 
     let expr = state.insert(
       LambdaTypeExpr(

--- a/Sources/FrontEnd/Parse/ParserState.swift
+++ b/Sources/FrontEnd/Parse/ParserState.swift
@@ -201,7 +201,7 @@ struct ParserState {
   }
 
   /// Consumes and returns the next token, only if it has the specified kind and if it is not
-  /// preceeded by any whitespace.
+  /// preceded by any whitespace.
   mutating func takeWithoutSkippingWhitespace(_ kind: Token.Kind) -> Token? {
     if hasLeadingWhitespace { return nil }
     return take(kind)

--- a/Sources/FrontEnd/Parse/Token.swift
+++ b/Sources/FrontEnd/Parse/Token.swift
@@ -148,7 +148,7 @@ public struct Token {
     }
   }
 
-  /// Indicates whether `self` may be at the begining of a declaration.
+  /// Indicates whether `self` may be at the beginning of a declaration.
   public var mayBeginDecl: Bool {
     switch kind {
     case .`conformance`,
@@ -177,7 +177,7 @@ public struct Token {
     }
   }
 
-  /// Indicates whether `self` may be at the begining of a control statement.
+  /// Indicates whether `self` may be at the beginning of a control statement.
   public var mayBeginCtrlStmt: Bool {
     switch kind {
     case .break, .continue, .for, .if, .lBrace, .return, .while:

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -194,9 +194,9 @@ struct ConstraintSystem {
     // Process structural and built-in conformances.
     switch goal.concept {
     case checker.program.ast.movableTrait:
-      return goal.model.isBuiltin ? .success : solve(structualConformance: goal)
+      return goal.model.isBuiltin ? .success : solve(structuralConformance: goal)
     case checker.program.ast.deinitializableTrait:
-      return goal.model.isBuiltin ? .success : solve(structualConformance: goal)
+      return goal.model.isBuiltin ? .success : solve(structuralConformance: goal)
     case checker.program.ast.foreignConvertibleTrait:
       return goal.model.isBuiltin ? .success : .failure(failureToSolve(goal))
     default:
@@ -209,14 +209,14 @@ struct ConstraintSystem {
   /// if `goal.model` isn't a structural type.
   ///
   /// - Requires: `goal.model` is not a type variable.
-  private mutating func solve(structualConformance goal: ConformanceConstraint) -> Outcome {
+  private mutating func solve(structuralConformance goal: ConformanceConstraint) -> Outcome {
     assert(!goal.model.isTypeVariable)
 
     switch goal.model.base {
     case let t as TupleType:
-      return delegate(structualConformance: goal, for: t.elements.lazy.map(\.type))
+      return delegate(structuralConformance: goal, for: t.elements.lazy.map(\.type))
     case let t as UnionType:
-      return delegate(structualConformance: goal, for: t.elements)
+      return delegate(structuralConformance: goal, for: t.elements)
     default:
       return .failure(failureToSolve(goal))
     }
@@ -225,7 +225,7 @@ struct ConstraintSystem {
   /// Returns the outcome of breaking down `goal`, which is a structural conformance constraint,
   /// into a set containing a conformance constraint for each type in `elements`.
   private mutating func delegate<S: Collection<AnyType>>(
-    structualConformance goal: ConformanceConstraint, for elements: S
+    structuralConformance goal: ConformanceConstraint, for elements: S
   ) -> Outcome {
     if elements.isEmpty {
       return .success
@@ -474,7 +474,7 @@ struct ConstraintSystem {
     return .product([s], failureToSolve(goal))
   }
 
-  /// Returns a clousre diagnosing a failure to solve `goal`.
+  /// Returns a closure diagnosing a failure to solve `goal`.
   private mutating func failureToSolve(_ goal: SubtypingConstraint) -> DiagnoseFailure {
     { (d, m, _) in
       let (l, r) = (m.reify(goal.left), m.reify(goal.right))
@@ -604,7 +604,7 @@ struct ConstraintSystem {
       return delegate(to: [s])
 
     default:
-      // TODO: Handle bound generic typess
+      // TODO: Handle bound generic types
       break
     }
 
@@ -649,7 +649,7 @@ struct ConstraintSystem {
     return delegate(to: subordinates)
   }
 
-  /// Returns a clousre diagnosing a failure to solve `g` because of an invalid callee.
+  /// Returns a closure diagnosing a failure to solve `g` because of an invalid callee.
   private mutating func invalidCallee(_ g: CallConstraint) -> DiagnoseFailure {
     { (d, m, _) in
       if g.isArrow {
@@ -746,7 +746,7 @@ struct ConstraintSystem {
   /// systems configured with `configureSubSystem` returns the best solution of each exploration.
   ///
   /// - Parameters:
-  ///   - g: the goal whose choices whould be explored; must denote a constraint of type `T`.
+  ///   - g: the goal whose choices would be explored; must denote a constraint of type `T`.
   ///   - checker: an instance used to query type relations and resolve names.
   ///   - configureSubSystem: A closure that prepares a constraint system using one of `g`'s
   ///     choices and returns the identities of the goals added to that system.

--- a/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
@@ -3,7 +3,7 @@ import Core
 /// The context in which a component of a name expression gets resolved.
 ///
 /// This structure is used during name resolution to identify the type of which an entity is member
-/// and the generic arguments captured by that entity. The followin invariants are maintained:
+/// and the generic arguments captured by that entity. The following invariants are maintained:
 /// - `arguments` contains the arguments of `type`'s generic parameters (if any) and the arguments
 ///   to generic parameters captured by the scope in which name resolution takes place.
 /// - if `type` is a bound generic type, `type.arguments[k] = arguments[k]` for all keys in `type`.

--- a/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
@@ -14,7 +14,7 @@ enum NameResolutionResult {
 
   /// Name resolution couldn't complete because the first component of the expression couldn't be
   /// resolved without type inference. The payload contains the type of the resolved part, unless
-  /// it was left implicit, and the remaning unresolved components.
+  /// it was left implicit, and the remaining unresolved components.
   ///
   /// - Invariant: `components` is not empty.
   case canceled(AnyType?, _ components: [NameExpr.ID])

--- a/Sources/FrontEnd/TypeChecking/Solution.swift
+++ b/Sources/FrontEnd/TypeChecking/Solution.swift
@@ -98,7 +98,7 @@ extension Solution: CustomStringConvertible {
       result.append("  \(k) : \(v)\n")
     }
 
-    result.append("penalities: \(penalties)\n")
+    result.append("penalties: \(penalties)\n")
 
     result.append("diagnostics: \(diagnostics.elements.count)\n")
 

--- a/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
+++ b/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
@@ -66,7 +66,7 @@ struct SubstitutionMap {
     storage[walked] = substitution
   }
 
-  /// Subtitutes each type variable occuring in `type` by its corresponding substitution in `self`,
+  /// Substitutes each type variable occurring in `type` by its corresponding substitution in `self`,
   /// apply `substitutionPolicy` to deal with free variables.
   ///
   /// The default substitution policy is `substituteByError` because we typically use `reify` after
@@ -102,7 +102,7 @@ struct SubstitutionMap {
     }
   }
 
-  /// Returns `r` where each type variable occuring in its generic arguments of `r` are replaced by
+  /// Returns `r` where each type variable occurring in its generic arguments of `r` are replaced by
   /// their corresponding value in `self`, applying `substitutionPolicy` to handle free variables.
   func reify(
     _ r: DeclReference, withVariables substitutionPolicy: SubstitutionPolicy

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -398,7 +398,7 @@ struct TypeChecker {
   /// if type checking failed.
   ///
   /// Type checking typically consists of visiting a declaration to generate proof obligations that
-  /// are then discharged by solving type constrants and/or type checking additional declarations.
+  /// are then discharged by solving type constraints and/or type checking additional declarations.
   ///
   /// - Parameters:
   ///   - d: The declaration to type check.
@@ -1508,7 +1508,7 @@ struct TypeChecker {
 
     assert(program[d].receiver == nil)
     let captures = uncheckedCaptureTypes(of: d)
-    let e = TupleType(captures.explict + captures.implicit)
+    let e = TupleType(captures.explicit + captures.implicit)
     return ^LambdaType(environment: ^e, inputs: inputs, output: output)
   }
 
@@ -1654,7 +1654,7 @@ struct TypeChecker {
       e = TupleType([.init(label: "self", type: ^RemoteType(.yielded, r))])
     } else {
       let captures = uncheckedCaptureTypes(of: d)
-      e = TupleType(captures.explict + captures.implicit)
+      e = TupleType(captures.explicit + captures.implicit)
     }
 
     return ^SubscriptType(
@@ -1721,7 +1721,7 @@ struct TypeChecker {
   /// - Requires: `d` is not a member declaration.
   private mutating func uncheckedCaptureTypes<T: CapturingDecl>(
     of d: T.ID
-  ) -> (explict: [TupleType.Element], implicit: [TupleType.Element]) {
+  ) -> (explicit: [TupleType.Element], implicit: [TupleType.Element]) {
     let e = explicitCaptures(program[d].explicitCaptures, of: d)
     let i = implicitCaptures(of: d, ignoring: Set(e.map(\.label!)))
     return (e, i)
@@ -1893,7 +1893,7 @@ struct TypeChecker {
 
   /// Returns the implicit captures found in the body of `d`.
   private mutating func implicitCaptures<T: Decl & LexicalScope>(
-    of d: T.ID, ignoring explictCaptures: Set<String>
+    of d: T.ID, ignoring explicitCaptures: Set<String>
   ) -> [TupleType.Element] {
     // Only local declarations have captures.
     if !program.isLocal(d) {
@@ -1904,8 +1904,8 @@ struct TypeChecker {
     var captureToStemAndEffect: [AnyDeclID: (stem: String, effect: AccessEffect)] = [:]
     for (name, mutability) in program.ast.uses(in: AnyDeclID(d)) {
       guard
-        let (stem, pick) = lookupImplicitCapture(name, occuringIn: d),
-        !explictCaptures.contains(stem)
+        let (stem, pick) = lookupImplicitCapture(name, occurringIn: d),
+        !explicitCaptures.contains(stem)
       else { continue }
 
       modify(&captureToStemAndEffect[pick, default: (stem, .let)]) { (x) in
@@ -2118,7 +2118,7 @@ struct TypeChecker {
     }
   }
 
-  /// Evalutes and returns the parameter annotations of `e`.ns.
+  /// Evaluates and returns the parameter annotations of `e`.ns.
   private mutating func evalParameterAnnotations(
     of e: LambdaTypeExpr.ID
   ) -> [CallableTypeParameter] {
@@ -2134,7 +2134,7 @@ struct TypeChecker {
   ///
   /// The value of `d`'s explicit return type annotation is returned if it is defined. Otherwise,
   /// a fresh type variable is returned if `d` appears in an expression context (i.e., `d` is the
-  /// underlyng declaration of a lambda). Otherwise, `.void` is returned.
+  /// underlying declaration of a lambda). Otherwise, `.void` is returned.
   private mutating func evalReturnTypeAnnotation(of d: FunctionDecl.ID) -> AnyType {
     if let o = program[d].output {
       return evalTypeAnnotation(o)
@@ -2530,11 +2530,11 @@ struct TypeChecker {
   /// Returns the stem and declaration of `c`, which occurs in `d`, or `nil` if either `c` doesn't
   /// have to be captured or lookup failed.
   private mutating func lookupImplicitCapture<T: Decl & LexicalScope>(
-    _ c: NameExpr.ID, occuringIn d: T.ID
+    _ c: NameExpr.ID, occurringIn d: T.ID
   ) -> (stem: String, decl: AnyDeclID)? {
     let n = program[c].name
     var candidates = lookup(unqualified: n.value.stem, in: program[c].scope)
-    candidates.removeAll(where: { isCaptured(referenceTo: $0, occuringIn: AnyScopeID(d)) })
+    candidates.removeAll(where: { isCaptured(referenceTo: $0, occurringIn: AnyScopeID(d)) })
     if candidates.isEmpty { return nil }
 
     guard let pick = candidates.uniqueElement else {
@@ -2977,7 +2977,7 @@ struct TypeChecker {
   }
 
   /// Returns the declarations of `name` interpreted as a compiler-known type alias (e.g., `Never`
-  /// or `Union<A, B>`) specialized by `arguments`, or `nil` if an error occured.
+  /// or `Union<A, B>`) specialized by `arguments`, or `nil` if an error occurred.
   private mutating func resolve(
     compilerKnownAlias name: SourceRepresentable<Name>,
     specializedBy arguments: [any CompileTimeValue],
@@ -3175,7 +3175,7 @@ struct TypeChecker {
 
   /// Returns `true` if references to `d` are captured if they occur in `scopeOfUse`.
   private mutating func isCaptured(
-    referenceTo d: AnyDeclID, occuringIn scopeOfUse: AnyScopeID
+    referenceTo d: AnyDeclID, occurringIn scopeOfUse: AnyScopeID
   ) -> Bool {
     if program.isContained(program[d].scope, in: scopeOfUse) { return false }
     if program.isGlobal(d) { return false }
@@ -3681,7 +3681,7 @@ struct TypeChecker {
     let inputs = uncheckedInputTypes(of: e, withHint: h)
 
     let captures = uncheckedCaptureTypes(of: d)
-    let environment = TupleType(captures.explict + captures.implicit)
+    let environment = TupleType(captures.explicit + captures.implicit)
 
     let output = inferredReturnType(of: e, withHint: h?.output, updating: &obligations)
     if output.isError {
@@ -4370,7 +4370,7 @@ struct TypeChecker {
   /// `scopeOfUse`, instantiating generic type constraints at `site`.
   ///
   /// `t1` is more specific than `t2` if both are callable types with the same labels and `t1`
-  /// accepts stricly less arguments than `t2`.
+  /// accepts strictly less arguments than `t2`.
   private mutating func compareSpecificity(
     _ lhs: AnyType, _ rhs: AnyType, in scopeOfUse: AnyScopeID, at site: SourceRange
   ) -> StrictPartialOrdering {
@@ -4471,7 +4471,7 @@ struct TypeChecker {
 
   /// Creates a fresh type variable.
   ///
-  /// The returned instance is unique accress concurrent type checker instances.
+  /// The returned instance is unique access concurrent type checker instances.
   mutating func freshVariable() -> TypeVariable {
     defer { nextFreshVariableIdentifier += 1 }
     return .init(nextFreshVariableIdentifier)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -989,7 +989,7 @@ struct TypeChecker {
     }
 
     /// Returns a concrete or syntheszed implementation of requirement `r` in `concept` for `model`
-    /// exposed ot `scopeOfUse`, or `nil` if no such implementation exist.
+    /// exposed to `scopeOfUse`, or `nil` if no such implementation exist.
     func implementation(of r: AnyDeclID) {
       // FIXME: remove me
       if r.kind == AssociatedTypeDecl.self { return }

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -415,7 +415,7 @@ public struct TypedProgram {
     return checker.scopeExtended(by: d)
   }
 
-  /// Returns the modules visibles to `s`:
+  /// Returns the modules visible to `s`:
   private func modules(exposedTo s: AnyScopeID) -> Set<ModuleDecl.ID> {
     if let m = ModuleDecl.ID(s) {
       return [m]

--- a/Sources/IR/AbstractTypeLayout.swift
+++ b/Sources/IR/AbstractTypeLayout.swift
@@ -40,7 +40,7 @@ public struct AbstractTypeLayout {
     offset(of: n).map({ self[$0] })
   }
 
-  /// Returns the offset of the stored poperty named `n` or `nil` if no such property exists.
+  /// Returns the offset of the stored property named `n` or `nil` if no such property exists.
   public func offset(of n: String) -> Int? {
     properties.firstIndex(where: { $0.label == n })
   }

--- a/Sources/IR/Analysis/AbstractInterpreter.swift
+++ b/Sources/IR/Analysis/AbstractInterpreter.swift
@@ -8,7 +8,7 @@ struct AbstractInterpreter<Domain: AbstractDomain> {
   /// The knowledge of the abstract interpreter about a single block.
   typealias BlockState = (sources: Set<Function.Blocks.Address>, before: Context, after: Context)
 
-  /// A map fron function block to the context of the abstract interpreter before and after the
+  /// A map from function block to the context of the abstract interpreter before and after the
   /// evaluation of its instructions.
   typealias State = [Function.Blocks.Address: BlockState]
 

--- a/Sources/IR/Analysis/ControlFlowGraph.swift
+++ b/Sources/IR/Analysis/ControlFlowGraph.swift
@@ -24,7 +24,7 @@ struct ControlFlowGraph {
 
   }
 
-  /// The way a control-flow relation is represeted internally.
+  /// The way a control-flow relation is represented internally.
   private typealias Relation = DirectedGraph<Vertex, Label>
 
   /// The relation encoded by the graph.

--- a/Sources/IR/Analysis/DominatorTree.swift
+++ b/Sources/IR/Analysis/DominatorTree.swift
@@ -6,8 +6,8 @@ import Utils
 /// - A block `b1` in a control-flow graph *dominates* a block `b2` if every path from the entry to
 ///   `b2` must go through `b1`. By definition, every node dominates itself.
 /// - A block `b1` *strictly dominates* a block `b2` if `b1` dominates `b2` and `b1 != b2`.
-/// - A block `b1` is the *immediately dominates* a block `b2` if `b1` stricly dominates `b2` and
-///   there is no block `b3` that stricly dominates `b2`.
+/// - A block `b1` is the *immediately dominates* a block `b2` if `b1` strictly dominates `b2` and
+///   there is no block `b3` that strictly dominates `b2`.
 ///
 /// A dominator tree encodes the dominance relation of a control graph as a tree where a node is
 /// a basic blocks and its children are those it immediately dominates.

--- a/Sources/IR/Analysis/Lifetime.swift
+++ b/Sources/IR/Analysis/Lifetime.swift
@@ -4,7 +4,7 @@ import Utils
 ///
 /// A lifetime rooted at a definition `d` is a region starting immediately after `d` and covering
 /// a set of uses dominated by `d`. The "upper boundaries" of a lifetime are the program points
-/// immediately after the uses seqenced last in that region.
+/// immediately after the uses sequenced last in that region.
 ///
 /// - Note: The definition of an operand `o` isn't part of `o`'s lifetime.
 struct Lifetime {
@@ -94,7 +94,7 @@ extension Module {
     // al.'s "Computing Liveness Sets for SSA-Form Programs".
 
     // Find all blocks in which the operand is being used.
-    var occurences = uses[operand, default: []].reduce(
+    var occurrences = uses[operand, default: []].reduce(
       into: Set<Function.Blocks.Address>(),
       { (blocks, use) in blocks.insert(use.user.block) })
 
@@ -102,19 +102,19 @@ extension Module {
     let cfg = functions[site.function]!.cfg()
     var approximateCoverage: [Function.Blocks.Address: (isLiveIn: Bool, isLiveOut: Bool)] = [:]
     while true {
-      guard let occurence = occurences.popFirst() else { break }
+      guard let occurrence = occurrences.popFirst() else { break }
 
-      // `occurence` is the defining block.
-      if site.address == occurence { continue }
+      // `occurrence` is the defining block.
+      if site.address == occurrence { continue }
 
       // We already propagated liveness to the block's live-in set.
-      if approximateCoverage[occurence]?.isLiveIn ?? false { continue }
+      if approximateCoverage[occurrence]?.isLiveIn ?? false { continue }
 
       // Mark that the definition is live at the block's entry and propagate to its predecessors.
-      approximateCoverage[occurence, default: (false, false)].isLiveIn = true
-      for predecessor in cfg.predecessors(of: occurence) {
+      approximateCoverage[occurrence, default: (false, false)].isLiveIn = true
+      for predecessor in cfg.predecessors(of: occurrence) {
         approximateCoverage[predecessor, default: (false, false)].isLiveOut = true
-        occurences.insert(predecessor)
+        occurrences.insert(predecessor)
       }
     }
 

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -135,7 +135,7 @@ extension Module {
 
     let sourceModule = ir.modules[ir.module(defining: f)]!
     var rewrittenBlocks: [Block.ID: Block.ID] = [:]
-    var rewrittenIntructions: [InstructionID: InstructionID] = [:]
+    var rewrittenInstructions: [InstructionID: InstructionID] = [:]
 
     for b in sourceModule[f].blocks.addresses {
       let source = Block.ID(f, b)
@@ -227,7 +227,7 @@ extension Module {
       default:
         UNIMPLEMENTED()
       }
-      rewrittenIntructions[i] = InstructionID(b, self[b].instructions.lastAddress!)
+      rewrittenInstructions[i] = InstructionID(b, self[b].instructions.lastAddress!)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
@@ -498,7 +498,7 @@ extension Module {
       case .parameter(let b, let i):
         return .parameter(rewrittenBlocks[b]!, i)
       case .register(let s):
-        return .register(rewrittenIntructions[s]!)
+        return .register(rewrittenInstructions[s]!)
       }
     }
   }

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -672,7 +672,7 @@ extension Context {
 
 }
 
-/// A map fron function block to the context of the abstract interpreter before and after the
+/// A map from function block to the context of the abstract interpreter before and after the
 /// evaluation of its instructions.
 private typealias Contexts = [Function.Blocks.Address: (before: Context, after: Context)]
 

--- a/Sources/IR/Analysis/Module+Ownership.swift
+++ b/Sources/IR/Analysis/Module+Ownership.swift
@@ -59,7 +59,7 @@ extension Module {
       // Access is expected to be reified at this stage.
       let request = s.capabilities.uniqueElement!
 
-      // Skip the instruction if an error occured upstream.
+      // Skip the instruction if an error occurred upstream.
       guard context.locals[s.source] != nil else {
         assert(diagnostics.containsError)
         return
@@ -104,7 +104,7 @@ extension Module {
         }
       }
 
-      // Don't set the locals if an error occured to avoid cascading errors downstream.
+      // Don't set the locals if an error occurred to avoid cascading errors downstream.
       if !hasConflict {
         context.locals[.register(i)] = context.locals[s.source]!
       }
@@ -153,7 +153,7 @@ extension Module {
     func interpret(endBorrow i: InstructionID, in context: inout Context) {
       let end = self[i] as! EndAccess
 
-      // Skip the instruction if an error occured upstream.
+      // Skip the instruction if an error occurred upstream.
       guard context.locals[end.start] != nil else {
         assert(diagnostics.containsError)
         return
@@ -183,7 +183,7 @@ extension Module {
     func interpret(endProject i: InstructionID, in context: inout Context) {
       let s = self[i] as! EndProject
 
-      // Skip the instruction if an error occured upstream.
+      // Skip the instruction if an error occurred upstream.
       guard context.locals[s.start] != nil else {
         assert(diagnostics.containsError)
         return
@@ -258,7 +258,7 @@ extension Module {
         UNIMPLEMENTED()
       }
 
-      // Skip the instruction if an error occured upstream.
+      // Skip the instruction if an error occurred upstream.
       guard let base = context.locals[s.recordAddress] else {
         assert(diagnostics.containsError)
         return

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -341,7 +341,7 @@ struct Emitter {
     let explicit = program[bundle].explicitCaptures
     let implicit = program[bundle].implicitCaptures
 
-    // Exlicit captures appear first.
+    // Explicit captures appear first.
     for (i, c) in explicit.enumerated() {
       locals[c] = .parameter(entry, i)
     }
@@ -1149,7 +1149,7 @@ struct Emitter {
     case .down:
       emitStore(downcast: e, to: storage)
     case .pointerConversion:
-      unreachable("pointer to address conversion evalutes to a lvalue")
+      unreachable("pointer to address conversion evaluates to a lvalue")
     }
   }
 
@@ -2173,7 +2173,7 @@ struct Emitter {
   }
 
   /// Returns the projection the property declared by `d`, specialized with `specialization` and
-  /// bound to `reciever`, inserting IR anchored at `site`.
+  /// bound to `receiver`, inserting IR anchored at `site`.
   private mutating func emitComputedProperty(
     boundTo receiver: Operand, declaredByBundle d: SubscriptDecl.ID,
     specializedBy specialization: GenericArguments,

--- a/Sources/IR/Mangling/Demangler.swift
+++ b/Sources/IR/Mangling/Demangler.swift
@@ -3,7 +3,7 @@ import Core
 /// Hylo's demangling algorithm.
 struct Demangler {
 
-  /// The list of demangled symbols, in order of appearence (a.k.a. the symbol lookup table).
+  /// The list of demangled symbols, in order of appearance (a.k.a. the symbol lookup table).
   private var symbols: [DemangledSymbol] = []
 
   /// Creates an instance with an empty lookup table.
@@ -133,7 +133,7 @@ struct Demangler {
         continue
       }
 
-      // Otherise, we're done.
+      // Otherwise, we're done.
       return d
     }
 

--- a/Sources/IR/Operands/Instruction/Instruction.swift
+++ b/Sources/IR/Operands/Instruction/Instruction.swift
@@ -15,7 +15,7 @@ public protocol Instruction: CustomStringConvertible {
 
   /// Replaces the operand at position `i` with `o`.
   ///
-  /// Do not call this method direcly. Use `Module.replaceUses(of:with:)` instead to ensure def-use
+  /// Do not call this method directly. Use `Module.replaceUses(of:with:)` instead to ensure def-use
   /// ensure def-use chains are kept updated.
   mutating func replaceOperand(at i: Int, with new: Operand)
 

--- a/Sources/IR/Operands/Instruction/ProjectBundle.swift
+++ b/Sources/IR/Operands/Instruction/ProjectBundle.swift
@@ -15,7 +15,7 @@ public struct ProjectBundle: Instruction {
   /// The arguments of the call.
   ///
   /// Operands to non-`sink` inputs must be the result of an `access` instruction requesting a
-  /// capability for each variant in `calle` and having no use before `project`.
+  /// capability for each variant in `callee` and having no use before `project`.
   public private(set) var operands: [Operand]
 
   /// The site of the code corresponding to that instruction.

--- a/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
+++ b/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
@@ -27,7 +27,7 @@ public struct ReleaseCaptures: Instruction {
 
 extension Module {
 
-  /// Creates a `release_capture` anchored at `site` that relases the accesses previously captured
+  /// Creates a `release_capture` anchored at `site` that releases the accesses previously captured
   /// in `container`.
   func makeReleaseCapture(_ container: Operand, at site: SourceRange) -> ReleaseCaptures {
     precondition(container.instruction.map({ self[$0] is AllocStack }) ?? false)

--- a/Sources/TestUtils/TestAnnotation.swift
+++ b/Sources/TestUtils/TestAnnotation.swift
@@ -25,7 +25,7 @@ import XCTest
 ///
 /// An annotation body corresponds to a single annotation. When present, the line offset is parsed
 /// as a natural number prefixed by either `@+` or `@-`. The next sequence of non-whitespace
-/// characters is parsed as the command. Preceeding whitespaces are ignored; following whitespaces
+/// characters is parsed as the command. Preceding whitespaces are ignored; following whitespaces
 /// are ignored only if they are on the same line as the command. The remainder of the annotation
 /// body is parsed as the argument.
 ///

--- a/Sources/Utils/DoublyLinkedList.swift
+++ b/Sources/Utils/DoublyLinkedList.swift
@@ -44,7 +44,7 @@ public struct DoublyLinkedList<Element> {
   /// - Note: A bucket is said to be used if its element is not `nil`.
   fileprivate struct Bucket {
 
-    /// If the bucket is used, represents the offset of the preceeding bucket in the list, or `-1`
+    /// If the bucket is used, represents the offset of the preceding bucket in the list, or `-1`
     /// if such a bucket is not defined. Unspecified otherwise.
     var previousOffset: Int
 

--- a/Sources/Utils/StatefulCoder.swift
+++ b/Sources/Utils/StatefulCoder.swift
@@ -4,7 +4,7 @@ import Foundation
 private let stateKey = CodingUserInfoKey(rawValue: UUID().uuidString)!
 
 /// An object that flattens values into—or reconstitutes values from—a serialized `Encoding`,
-/// maintaing state across the (de)serialization of individual parts.
+/// maintaining state across the (de)serialization of individual parts.
 ///
 /// - Note: this protocol matches Foundation's `XXXEncoder`/`XXXDecoder` types,
 ///   which—confusingly—do not themselves conform to the `Encoder`/`Decoder` protocols.
@@ -27,7 +27,7 @@ extension StatefulCoder {
 
 }
 
-/// An object that flattens values into a serialized `Encoding`, maintaing state across the
+/// An object that flattens values into a serialized `Encoding`, maintaining state across the
 /// serialization of individual parts.
 ///
 /// - Note: this protocol matches Foundation's `XXXEncoder` types, which—confusingly—do not
@@ -52,7 +52,7 @@ extension StatefulEncoder {
 
 }
 
-/// An object that reconstitutes values from a serialized `Encoding`, maintaing state across the
+/// An object that reconstitutes values from a serialized `Encoding`, maintaining state across the
 /// deserialization of individual parts.
 ///
 /// - Note: this protocol matches Foundation's `XXXEncoder` types, which—confusingly—do not

--- a/Sources/Utils/String+Extensions.swift
+++ b/Sources/Utils/String+Extensions.swift
@@ -44,8 +44,8 @@ extension StringProtocol {
     return r
   }
 
-  /// Replace any sucession of whitespace characters (including newlines and tabs) with a single
-  /// white space charater.
+  /// Replace any succession of whitespace characters (including newlines and tabs) with a single
+  /// white space character.
   public func canonicalize() -> String {
     var remaining = self[..<self.endIndex]
     var result: String = ""
@@ -58,7 +58,7 @@ extension StringProtocol {
       }
 
       // Now, `remaining` starts with a non-whitespace
-      // Find the next whitespace, i.e., continous non-whitespace text
+      // Find the next whitespace, i.e., continuous non-whitespace text
       let idx = remaining.firstIndex(where: { $0.isWhitespace }) ?? self.endIndex
 
       // Copy non-whitespace text, and advance the text we need to copy

--- a/Sources/Utils/WideUInt.swift
+++ b/Sources/Utils/WideUInt.swift
@@ -1,6 +1,6 @@
 import BigInt
 
-/// An unisgned integer with an arbitrary, but fixed, bit width.
+/// An unsigned integer with an arbitrary, but fixed, bit width.
 public struct WideUInt {
 
   /// The underlying value.

--- a/Tests/DriverTests/DriverTests.swift
+++ b/Tests/DriverTests/DriverTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class DriverTests: XCTestCase {
 
-  /// The result of a compiler invokation.
+  /// The result of a compiler invocation.
   private struct CompilationResult {
 
     /// The exit status of the compiler.

--- a/Tests/HyloTests/LexerTests.swift
+++ b/Tests/HyloTests/LexerTests.swift
@@ -357,7 +357,7 @@ final class LexerTests: XCTestCase {
     file: StaticString = #filePath,
     line: UInt = #line
   ) {
-    // The list of tokens should have the same lenght as that of the specifications.
+    // The list of tokens should have the same length as that of the specifications.
     XCTAssert(
       tokens.count == specs.count,
       "expected \(specs.count) token(s), found \(tokens.count)",

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -753,21 +753,21 @@ final class ParserTests: XCTestCase {
     XCTAssertNotNil(decl.defaultValue)
   }
 
-  func testParameterIntefaceLabelAndName() throws {
+  func testParameterInterfaceLabelAndName() throws {
     let input: SourceFile = "for name"
     let interface = try XCTUnwrap(try apply(Parser.parameterInterface, on: input).element)
     XCTAssertEqual(interface.label?.value, "for")
     XCTAssertEqual(interface.name.value, "name")
   }
 
-  func testParameterIntefaceUnderscoreAndName() throws {
+  func testParameterInterfaceUnderscoreAndName() throws {
     let input: SourceFile = "_ name"
     let interface = try XCTUnwrap(try apply(Parser.parameterInterface, on: input).element)
     XCTAssertNil(interface.label)
     XCTAssertEqual(interface.name.value, "name")
   }
 
-  func testParameterIntefaceOnlyName() throws {
+  func testParameterInterfaceOnlyName() throws {
     let input: SourceFile = "name"
     let interface = try XCTUnwrap(try apply(Parser.parameterInterface, on: input).element)
     XCTAssertEqual(interface.label?.value, "name")
@@ -782,7 +782,7 @@ final class ParserTests: XCTestCase {
     XCTAssertNil(decl.precedenceGroup)
   }
 
-  func testOperatorDeclWithPredecenceGroup() throws {
+  func testOperatorDeclWithPrecedenceGroup() throws {
     let input: SourceFile = "operator infix+ : addition"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseOperatorDecl)
     let decl = try XCTUnwrap(ast[declID])

--- a/Tests/ManglingTests/ManglingTests.swift
+++ b/Tests/ManglingTests/ManglingTests.swift
@@ -132,7 +132,7 @@ private struct SymbolCollector: ASTWalkObserver {
   private(set) var symbols: [String: AnyDeclID] = [:]
 
   /// Creates an instance observing the nodes in `p` and reporting assertion failures as though
-  /// they occured at line `l` of this source file..
+  /// they occurred at line `l` of this source file..
   init(forNodesIn p: TypedProgram, reportingFailuresAtLine l: UInt = #line) {
     self.program = p
     self.failuresReportingLine = l

--- a/Tools/gyb.py
+++ b/Tools/gyb.py
@@ -50,7 +50,7 @@ linesClose = r'[\ \t]* end [\ \t]* (?: \# .* )? $'
 
 # Note: Where "# Absorb" appears below, the regexp attempts to eat up
 # through the end of ${...} and %{...}% constructs.  In reality we
-# handle this with the Python tokenizer, which avoids mis-detections
+# handle this with the Python tokenizer, which avoids misdetections
 # due to nesting, comments and strings.  This extra absorption in the
 # regexp facilitates testing the regexp on its own, by preventing the
 # interior of some of these constructs from being treated as literal


### PR DESCRIPTION
This *shouldn't* get in the way of development too much. It's [designed](https://github.com/crate-ci/typos/blob/master/docs/design.md) to work with code and have a low false-positive count. Feel free to drop the `Add github spell check workflow` commit if you recon it'll be more hassle than  worth.