### PR TITLE
Build the standard library from the sources in the repo working copy

### DIFF
--- a/Library/Library.swift
+++ b/Library/Library.swift
@@ -1,7 +1,9 @@
-import class Foundation.Bundle
+import Foundation
+
+fileprivate let libraryRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 
 /// The root URL of Hylo's core library.
-public let core = Bundle.module.url(forResource: "Hylo/Core", withExtension: nil)
+public let core = libraryRoot.appendingPathComponent("Hylo/Core")
 
 /// The root URL of Hylo's standard library.
-public let standardLibrary = Bundle.module.url(forResource: "Hylo", withExtension: nil)
+public let standardLibrary = libraryRoot.appendingPathComponent("Hylo")

--- a/Sources/FrontEnd/AST+Extensions.swift
+++ b/Sources/FrontEnd/AST+Extensions.swift
@@ -6,10 +6,10 @@ import Utils
 extension AST {
 
   /// An instance that includes just the core module.
-  public static var coreModule = AST(libraryRoot: HyloModule.core!)
+  public static var coreModule = AST(libraryRoot: HyloModule.core)
 
   /// An instance that includes just the standard library.
-  public static var standardLibrary = AST(libraryRoot: HyloModule.standardLibrary!)
+  public static var standardLibrary = AST(libraryRoot: HyloModule.standardLibrary)
 
   /// Creates an instance that includes the Hylo library rooted at `libraryRoot`.
   private init(libraryRoot: URL) {


### PR DESCRIPTION
...instead of copying them to a resources directory and building from there.

Fixes #932