### PR TITLE
Cache llvm and clang download

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,10 +113,20 @@ jobs:
 
     - run: swift --version
 
-    - name: Setup LLVM
+    - name: Cache LLVM and Clang
+      id: cache-llvm
+      uses: actions/cache@v3
+      with:
+        path: |
+          C:/Program Files/LLVM
+          ./llvm
+        key: llvm-15.0
+
+    - name: Install LLVM and Clang
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "15.0"
+        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
     - run: llvm-config --version
 
@@ -160,9 +170,20 @@ jobs:
     - name: Swift version
       run: swift --version
 
-    - name: Set up LLVM 15.0.6
+    - name: Cache LLVM
+      id: cache-llvm-windows
+      uses: actions/cache@v3
+      with:
+        path: llvm-15.0.6-windows-x86-msvc17-msvcrt.7z
+        key: llvm-windows-15.0.6
+
+    - name: Download LLVM windows
+      if: steps.cache-llvm-windows.outputs.cache-hit != 'true'
       run: |
         curl.exe -L -O -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}"https://github.com/c3lang/win-llvm/releases/download/llvm_15_0_6/llvm-15.0.6-windows-x86-msvc17-msvcrt.7z
+
+    - name: Setup LLVM windows
+      run: |
         7z x llvm-15.0.6-windows-x86-msvc17-msvcrt.7z -oC:\
         Add-Content $env:GITHUB_PATH 'C:\llvm-15.0.6-windows-x86-msvc17-msvcrt\bin'
         

--- a/.github/workflows/doc-extraction.yml
+++ b/.github/workflows/doc-extraction.yml
@@ -43,10 +43,19 @@ jobs:
 
     - run: swift --version
 
-    - name: Setup LLVM
+    - name: Cache LLVM and Clang
+      id: cache-llvm
+      uses: actions/cache@v3
+      with:
+        path: |
+          C:/Program Files/LLVM
+          ./llvm
+        key: llvm-15.0
+    - name: Install LLVM and Clang
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "15.0"
+        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
     - run: llvm-config --version
 


### PR DESCRIPTION
Currently this looks like it's not worth it at all. [The documentation](https://github.com/KyleMayes/install-llvm-action#example-usage-with-caching) claims the cache improves the step from ~1min to 20 seconds but I'm seeing [57s without cache](https://github.com/WalterSmuts/hylo/actions/runs/6072776646/job/16473382898) and [1m48s](https://github.com/WalterSmuts/hylo/actions/runs/6072997465/job/16474045063) with cache.

This also contains DIY caching of the windows `curl` LLVM download command resulting in [3s without cache](https://github.com/WalterSmuts/hylo/actions/runs/6072776646/job/16473383242) and [11s](https://github.com/WalterSmuts/hylo/actions/runs/6072776646/job/16473383242) with the caching. Looks like the cache servers are just pretty slow.

```
commit 349c742cd9488390ee02c02e86b5a13c647324fd
Author: Walter Smuts <smuts.walter@gmail.com>
Date:   Mon Sep 4 12:58:54 2023 +0200

    Cache llvm and clang download

    Partially fixes: https://github.com/hylo-lang/hylo/issues/951
```