### PR TITLE
Fix Builtin.advanced_by_bytes and add PointerToMutable.advance

### DIFF
--- a/Library/Hylo/Core/PointerToMutable.hylo
+++ b/Library/Hylo/Core/PointerToMutable.hylo
@@ -33,6 +33,14 @@ public type PointerToMutable<Pointee>: Regular {
     &base = p.base
   }
 
+// TODO: Uncomment when overload resolution works. See https://github.com/hylo-lang/hylo/issues/989
+//  /// Returns a pointer advanced by `offset_in_elements`.
+//  public fun advance( by offset_in_elements: Int ) -> Self {
+//    let offset_in_bytes = MemoryLayout<Pointee>.stride() * offset_in_elements
+//    return PointerToMutable<Pointee>.new(
+//      base: Builtin.advanced_by_bytes_word( base, offset_in_bytes.foreign_value() ) )
+//  }
+
   /// Creates an instance that does not address any usable storage.
   public static fun null() -> Self {
     .new(base: Builtin.zeroinitializer_ptr())

--- a/Library/Hylo/Pointers+DynamicAllocation.hylo
+++ b/Library/Hylo/Pointers+DynamicAllocation.hylo
@@ -7,6 +7,17 @@ public extension PointerToMutable where Pointee == Never {
 
 }
 
+public extension PointerToMutable where Pointee == Never {
+
+  /// Returns a pointer advanced by `offset_in_elements`, which is 1 for `Never`.
+  public fun advance( by offset_in_elements: Int ) -> Self {
+    let offset_in_bytes = 1 * offset_in_elements
+    return PointerToMutable<Pointee>.new(
+      base: Builtin.advanced_by_bytes_word( base, offset_in_bytes.foreign_value() ) )
+  }
+
+}
+
 public extension PointerToMutable {
 
   /// Allocates memory for `count` instances of `Pointee`.

--- a/Library/Hylo/Pointers+DynamicAllocation.hylo
+++ b/Library/Hylo/Pointers+DynamicAllocation.hylo
@@ -13,7 +13,7 @@ public extension PointerToMutable where Pointee == Never {
   public fun advance(by offset_in_elements: Int) -> Self {
     let offset_in_bytes = 1 * offset_in_elements
     return PointerToMutable<Pointee>.new(
-      base: Builtin.advanced_by_bytes_word(base, offset_in_bytes.foreign_value()))
+      base: Builtin.advanced_by_bytes_word(base, offset_in_bytes.value))
   }
 
 }

--- a/Library/Hylo/Pointers+DynamicAllocation.hylo
+++ b/Library/Hylo/Pointers+DynamicAllocation.hylo
@@ -13,7 +13,7 @@ public extension PointerToMutable where Pointee == Never {
   public fun advance(by offset_in_elements: Int) -> Self {
     let offset_in_bytes = 1 * offset_in_elements
     return PointerToMutable<Pointee>.new(
-      base: Builtin.advanced_by_bytes_word( base, offset_in_bytes.foreign_value() ) )
+      base: Builtin.advanced_by_bytes_word(base, offset_in_bytes.foreign_value()))
   }
 
 }

--- a/Library/Hylo/Pointers+DynamicAllocation.hylo
+++ b/Library/Hylo/Pointers+DynamicAllocation.hylo
@@ -10,7 +10,7 @@ public extension PointerToMutable where Pointee == Never {
 public extension PointerToMutable where Pointee == Never {
 
   /// Returns a pointer advanced by `offset_in_elements`, which is 1 for `Never`.
-  public fun advance( by offset_in_elements: Int ) -> Self {
+  public fun advance(by offset_in_elements: Int) -> Self {
     let offset_in_bytes = 1 * offset_in_elements
     return PointerToMutable<Pointee>.new(
       base: Builtin.advanced_by_bytes_word( base, offset_in_bytes.foreign_value() ) )

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -899,6 +899,15 @@ extension LLVM.Module {
       case .zeroinitializer(let t):
         register[.register(i)] = ir.llvm(builtinType: t, in: &self).null
 
+      case .advancedByBytes(_):
+        let base = llvm(s.operands[0])
+        let byteOffset = llvm(s.operands[1])
+        register[.register(i)] = insertGetElementPointerInBounds(
+          of: base,
+          typed: ptr,
+          indices: [byteOffset],
+          at: insertionPoint)
+
       default:
         unreachable("unexpected LLVM instruction '\(s.instruction)'")
       }

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -899,7 +899,7 @@ extension LLVM.Module {
       case .zeroinitializer(let t):
         register[.register(i)] = ir.llvm(builtinType: t, in: &self).null
 
-      case .advancedByBytes(_):
+      case .advancedByBytes:
         let base = llvm(s.operands[0])
         let byteOffset = llvm(s.operands[1])
         register[.register(i)] = insertGetElementPointerInBounds(

--- a/Tests/LibraryTests/TestCases/PointerToMutableTests.hylo
+++ b/Tests/LibraryTests/TestCases/PointerToMutableTests.hylo
@@ -3,9 +3,9 @@
 fun test_advance() {
   var d = PointerToMutable<Never>.allocate_bytes(
     count: 2,
-    aligned_at: 1 )
+    aligned_at: 1)
   var e = d.advance(by: 1)
-  var f = e.advance(by:-1)
+  var f = e.advance(by: -1)
   precondition(d == f)
   precondition(!(d == e))
   precondition(!(f == e))

--- a/Tests/LibraryTests/TestCases/PointerToMutableTests.hylo
+++ b/Tests/LibraryTests/TestCases/PointerToMutableTests.hylo
@@ -1,0 +1,16 @@
+//- compileAndRun expecting: success
+
+fun test_advance() {
+  var d = PointerToMutable<Never>.allocate_bytes(
+    count: 2,
+    aligned_at: 1 )
+  var e = d.advance(by: 1)
+  var f = e.advance(by:-1)
+  precondition(d == f)
+  precondition(!(d == e))
+  precondition(!(f == e))
+}
+
+public fun main() {
+  test_advance()
+}


### PR DESCRIPTION
- Added missing case for .advancedByBytes in transpilation. This code
  was based on similar code in this file.
- Added PointerToMutable<Never>.advance specialized function. This
  needed to be specialized because of issue #985. The general version
  wasn't added because of issue #989.

This code is required to enable `DynamicBuffer` to provide a pointer
to the beginning of its elements. We need this to ultimately implement
`Array`.
