### PR TITLE
Add a linking exception to the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,10 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+    As an exception, if you use this Software to compile your source code and
+    portions of this Software are embedded into the binary product as a result,
+    you may redistribute such product without providing attribution as would
+    otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.


### PR DESCRIPTION
Add the linking exception discussed in #890, which is the same as the one used in Swift.