### PR TITLE
Implement IR support for method bundles

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -152,7 +152,7 @@ struct TypeChecker {
     return [
       program.ast.movableTrait,
       program.ast.deinitializableTrait,
-      program.ast.foreignConvertibleTrait
+      program.ast.foreignConvertibleTrait,
     ]
   }
 

--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -83,7 +83,7 @@ extension Module {
     case is Load:
       return [.sink]
     case is Move:
-      return [.inout]
+      return u.index == 0 ? [.sink] : [.inout]
     case is ProjectBundle:
       return requests(projectBundle: u)
     default:

--- a/Sources/IR/Analysis/Module+CallBundleReification.swift
+++ b/Sources/IR/Analysis/Module+CallBundleReification.swift
@@ -1,0 +1,32 @@
+import Core
+
+extension Module {
+
+  /// Replace occurrences of `call_bundle` by `call` depending on the uses of their first operands,
+  /// reporting errors and warnings to `diagnostics`.
+  ///
+  /// - Requires: `f` is in `self`.
+  public mutating func reifyCallsToBundles(in f: Function.ID, diagnostics: inout DiagnosticSet) {
+    for i in blocks(in: f).map(instructions(in:)).joined() where self[i] is CallBundle {
+      reify(callBundle: i, for: .let)
+    }
+  }
+
+  private mutating func reify(callBundle i: InstructionID, for k: AccessEffect) {
+    let s = self[i] as! CallBundle
+    assert(s.capabilities.contains(k))
+
+    var arguments = Array(s.arguments)
+    let r = makeAccess(k, from: arguments[0], at: s.site)
+    arguments[0] = .register(insert(r, before: i))
+
+    let b = Block.ID(containing: i)
+    let f = FunctionReference(
+      to: s.variants[k]!, in: self, specializedBy: s.bundle.arguments, in: self[b].scope)
+
+    let reified = makeCall(
+      applying: .constant(f), to: arguments, writingResultTo: s.output, at: s.site)
+    replace(i, with: reified)
+  }
+
+}

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -320,6 +320,46 @@ struct Emitter {
   }
 
   /// Inserts the IR for `d`.
+  private mutating func lower(method d: MethodDecl.ID) {
+    for i in ast[d].impls {
+      lower(methodImpl: i)
+    }
+  }
+
+  /// Inserts the IR for `d`.
+  private mutating func lower(methodImpl d: MethodImpl.ID) {
+    let f = module.demandDeclaration(lowering: d)
+    guard let b = ast[d].body else { return }
+
+    // Create the function entry.
+    let entry = module.appendEntry(in: program.scopeContainingBody(of: d)!, to: f)
+
+    // Configure the locals.
+    var locals = DeclProperty<Operand>()
+    locals[ast[d].receiver] = .parameter(entry, 0)
+
+    let bundle = MethodDecl.ID(program[d].scope)!
+    for (i, p) in ast[bundle].parameters.enumerated() {
+      locals[p] = .parameter(entry, i + 1)
+    }
+
+    let bodyFrame = Frame(locals: locals)
+
+    // Emit the body.
+    self.insertionPoint = .end(of: entry)
+    switch b {
+    case .block(let s):
+      let returnType = LambdaType(program[d].type)!.output
+      let returnSite = pushing(bodyFrame, { $0.lowerStatements(s, expecting: returnType) })
+      insert(module.makeReturn(at: returnSite))
+
+    case .expr(let e):
+      pushing(bodyFrame, { $0.emitStore(value: e, to: $0.returnValue!) })
+      insert(module.makeReturn(at: ast[e].site))
+    }
+  }
+
+  /// Inserts the IR for `d`.
   private mutating func lower(subscript d: SubscriptDecl.ID) {
     for i in ast[d].impls {
       lower(subscriptImpl: i)
@@ -418,6 +458,8 @@ struct Emitter {
         lower(function: .init(m)!)
       case InitializerDecl.self:
         lower(initializer: .init(m)!)
+      case MethodDecl.self:
+        lower(method: .init(m)!)
       case SubscriptDecl.self:
         lower(subscript: .init(m)!)
       default:

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1468,8 +1468,9 @@ struct Emitter {
     writingResultTo storage: Operand, at site: SourceRange
   ) {
     let o = insert(module.makeAccess(.set, from: storage, at: site))!
-    insert(module.makeCallBundle(
-      applying: .init(callee, in: insertionScope!), to: arguments, writingResultTo: o, at: site))
+    insert(
+      module.makeCallBundle(
+        applying: .init(callee, in: insertionScope!), to: arguments, writingResultTo: o, at: site))
     insert(module.makeEndAccess(o, at: site))
   }
 

--- a/Sources/IR/Mangling/Demangler.swift
+++ b/Sources/IR/Mangling/Demangler.swift
@@ -113,6 +113,12 @@ struct Demangler {
         return nil
       case .monomorphizedFunctionDecl:
         return nil
+      case .methodDecl:
+        return nil
+      case .methodImpl:
+        return nil
+      case .methodType:
+        return nil
       case .synthesizedFunctionDecl:
         return nil
       case .conformanceConstraint, .equalityConstraint, .valueConstraint, .whereClause:

--- a/Sources/IR/Mangling/ManglingOperator.swift
+++ b/Sources/IR/Mangling/ManglingOperator.swift
@@ -22,6 +22,10 @@ public enum ManglingOperator: String {
 
   case existentializedFunctionDecl = "eF"
 
+  case methodDecl = "hF"
+
+  case methodImpl = "iF"
+
   case monomorphizedFunctionDecl = "mF"
 
   case staticFunctionDecl = "sF"
@@ -75,6 +79,8 @@ public enum ManglingOperator: String {
   case existentialMetatype = "emT"
 
   case genericTypeParameterType = "gT"
+
+  case methodType = "hT"
 
   case lambdaType = "lT"
 

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -202,6 +202,7 @@ public struct Module {
     }
 
     try run({ removeDeadCode(in: $0, diagnostics: &log) })
+    try run({ reifyCallsToBundles(in: $0, diagnostics: &log) })
     try run({ reifyAccesses(in: $0, diagnostics: &log) })
     try run({ closeBorrows(in: $0, diagnostics: &log) })
     try run({ normalizeObjectStates(in: $0, diagnostics: &log) })

--- a/Tests/EndToEndTests/TestCases/MethodBundle.hylo
+++ b/Tests/EndToEndTests/TestCases/MethodBundle.hylo
@@ -1,0 +1,20 @@
+//- compileAndRun expecting: success
+
+type A: Deinitializable {
+
+  public var x: Int
+
+  public memberwise init
+
+  public fun foo() -> Int {
+    let  { x.copy() }
+    sink { x }
+  }
+
+}
+
+public fun main() {
+  var a = A(x: 42)
+  precondition(a.foo() == 42)
+  precondition(a.foo() == 42)
+}


### PR DESCRIPTION
This PR lays down the foundations for compiling calls to method bundles. It only implements an embarrassingly primitive bundle reification pass that does not perform last use analysis to pick the appropriate variant in a bundle. This feature should be addressed in another PR.