### PR TITLE
Use memoization to speedup type checking

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2726,6 +2726,11 @@ struct TypeChecker {
   private mutating func extensions(
     of subject: AnyType, exposedTo scopeOfUse: AnyScopeID
   ) -> [AnyDeclID] {
+    let key = Cache.TypeLookupKey(subject, in: scopeOfUse)
+    if let r = cache.typeToExtensions[key] {
+      return r
+    }
+
     let subject = canonical(subject, in: scopeOfUse)
     var matches: [AnyDeclID] = []
     var root: ModuleDecl.ID? = nil
@@ -2756,6 +2761,7 @@ struct TypeChecker {
       reduce(decls: symbols, extending: subject, in: scopeOfUse, into: &matches)
     }
 
+    cache.typeToExtensions[key] = matches
     return matches
   }
 
@@ -4818,6 +4824,11 @@ struct TypeChecker {
     ///
     /// This map serves as cache for `conformedTraits(of:in:)`.
     var typeToConformedTraits: [TypeLookupKey: Set<TraitType>] = [:]
+
+    /// A map from type to its extensions in a given scope.
+    ///
+    /// This map serves as cache for `extensions(of:exposedTo:)`.
+    var typeToExtensions: [TypeLookupKey: [AnyDeclID]] = [:]
 
     /// Creates an instance for memoizing type checking results in `local` and comminicating them
     /// to concurrent type checkers using `shared`.

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2488,7 +2488,7 @@ struct TypeChecker {
       break
     }
 
-    let key = Cache.MemberLookupKey(nominalScope, in: scopeOfUse)
+    let key = Cache.TypeLookupKey(nominalScope, in: scopeOfUse)
     if let m = cache.scopeToMembers[key]?[stem] {
       return m
     }
@@ -4770,8 +4770,8 @@ struct TypeChecker {
     /// A lookup table.
     typealias LookupTable = [String: Set<AnyDeclID>]
 
-    /// A key in a member lookup table.
-    typealias MemberLookupKey = ScopedValue<AnyType>
+    /// A key in a type lookup table.
+    typealias TypeLookupKey = ScopedValue<AnyType>
 
     /// The local instance being type checked.
     private(set) var local: TypedProgram
@@ -4798,7 +4798,7 @@ struct TypeChecker {
     ///
     /// This map serves as cache for `lookup(_:memberOf:exposedTo)`. At no point is it guaranteed
     /// to be complete.
-    var scopeToMembers: [MemberLookupKey: LookupTable] = [:]
+    var scopeToMembers: [TypeLookupKey: LookupTable] = [:]
 
     /// A map from lexical scope to the names introduced in it.
     ///

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2123,6 +2123,10 @@ struct TypeChecker {
 
   /// Evaluates and returns the value of `e`, which is a type annotation.
   private mutating func evalTypeAnnotation(_ e: NameExpr.ID) -> AnyType {
+    if let t = cache.local.exprType[e] {
+      return t
+    }
+
     let resolution = resolve(e, withNonNominalPrefix: { (me, p) in me.evalQualification(of: p) })
     switch resolution {
     case .done(let prefix, let suffix):


### PR DESCRIPTION
This PR adds a couple of memo cache to speed up hot methods in the type checker.