### PR TITLE
Remove the use of github actions cache

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,13 +54,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/cache@v3
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
-
     - name: Build and Test
       uses: devcontainers/ci@v0.3
       with:


### PR DESCRIPTION
Apparently it's a net loss: https://github.com/KyleMayes/install-llvm-action/commit/878985d084d4991346a5f6f26eae447ddc16457a