### PR TITLE
Remove github action cache

### DIFF
--- a/.github/workflows/doc-extraction.yml
+++ b/.github/workflows/doc-extraction.yml
@@ -30,13 +30,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/cache@v3
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
-
     - name: Setup swift
       uses: swift-actions/setup-swift@v1
       with:


### PR DESCRIPTION
Apparently it's a net loss: https://github.com/KyleMayes/install-llvm-action/commit/878985d084d4991346a5f6f26eae447ddc16457a