### PR TITLE
Fix the implementation of `print`

### DIFF
--- a/Library/Hylo/Print.hylo
+++ b/Library/Hylo/Print.hylo
@@ -1,8 +1,8 @@
 /// Writes the textual representation of `item` to the standard output.
 public fun print(_ item: String, terminator: String = "\n") {
-  let stream = stdout()
-  _ = fwrite(CVoidPointer(base: item.utf8.base), 1, item.size, CVoidPointer(base: stream.base))
-  _ = fwrite(CVoidPointer(base: terminator.utf8.base), 1, 1, CVoidPointer(base: stream.base))
+  let o = stdout
+  _ = fwrite(CVoidPointer(base: item.utf8.base), 1, item.size, CVoidPointer(base: o.base))
+  _ = fwrite(CVoidPointer(base: terminator.utf8.base), 1, terminator.size, CVoidPointer(base: o.base))
 }
 
 /// Writes the textual representation of `item` to the standard output.
@@ -26,13 +26,11 @@ public fun print(_ item: Int, radix: Int = 10, terminator: String = "\n") {
   if item < 0 { &a.append(45) }
   &a.reverse()
 
-  let stream = stdout()
+  let o = stdout
   let buffer = a.contiguous_storage.base
-  _ = fwrite(CVoidPointer(base: buffer), 1, a.count(), CVoidPointer(base: stream.base))
-  _ = fwrite(CVoidPointer(base: terminator.utf8.base), 1, 1, CVoidPointer(base: stream.base))
+  _ = fwrite(CVoidPointer(base: buffer), 1, a.count(), CVoidPointer(base: o.base))
+  _ = fwrite(CVoidPointer(base: terminator.utf8.base), 1, terminator.size, CVoidPointer(base: o.base))
 }
 
 /// The standard output of the current process.
-fun stdout() -> MemoryAddress {
-  .new(base: fdopen(1, CVoidPointer(base: "w".utf8.base)).base)
-}
+let stdout = MemoryAddress.new(base: fdopen(1, CVoidPointer(base: "w".utf8.base)).base)

--- a/Sources/Core/AST/Decl/SynthesizedFunctionDecl.swift
+++ b/Sources/Core/AST/Decl/SynthesizedFunctionDecl.swift
@@ -46,6 +46,18 @@ public struct SynthesizedFunctionDecl: Hashable {
     return RemoteType(r)?.bareType ?? r
   }
 
+  /// Returns the generic parameters of the declaration.
+  public var genericParameters: [GenericParameterDecl.ID] {
+    guard let t = BoundGenericType(receiver) else { return [] }
+    return t.arguments.compactMap { (k, v) -> GenericParameterDecl.ID? in
+      if let u = v as? AnyType {
+        return GenericTypeParameterType(u)?.decl == k ? k : nil
+      } else {
+        UNIMPLEMENTED("compile time values")
+      }
+    }
+  }
+
 }
 
 extension SynthesizedFunctionDecl: CustomStringConvertible {

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -402,12 +402,11 @@ public struct Module {
       d.type.captures, passed: d.type.receiverEffect, to: &inputs, canonicalizedIn: d.scope)
     appendParameters(d.type.inputs, to: &inputs, canonicalizedIn: d.scope)
 
-    let genericParameters = BoundGenericType(d.receiver).map({ Array($0.arguments.keys) }) ?? []
     let entity = Function(
       isSubscript: false,
       site: .empty(at: program.ast[id].site.first()),
       linkage: .external,
-      genericParameters: genericParameters,
+      genericParameters: d.genericParameters,
       inputs: inputs,
       output: output,
       blocks: [])


### PR DESCRIPTION
Before this patch, `Hylo.stdout` was defined as a function that would "reopen" the standard output every time it got called, causing unexpected results on successive calls to `fwrite`.