### PR TITLE
Use Bundle.module.resourceURL to point to Hylo standard library

### DIFF
--- a/Library/Library.swift
+++ b/Library/Library.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-fileprivate let libraryRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+fileprivate let libraryRoot = Bundle.module.resourceURL!
 
 /// The root URL of Hylo's core library.
 public let core = libraryRoot.appendingPathComponent("Hylo/Core")


### PR DESCRIPTION
This change removes a hard-coded path to the standard library, which pointed to the pre-build source directory; i.e. directly to `//repo-root/Library/`. Instead, we use `Bundle.module.resourceURL` to point to the _post-build_ location of the standard library resource files. 