### PR TITLE
Make sure failing subprocesses cause thrown errors.

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -12,11 +12,13 @@ extension Process {
 
   /// Information about a process that exited with an error.
   struct Failure: Error {
+
     /// The process' exit code.
     let terminationStatus: Int32
 
     /// Any output captured from the process' output pipe.
     let rawOutput: String
+
   }
 
 }
@@ -399,7 +401,8 @@ public struct Driver: ParsableCommand {
     throw EnvironmentError("executable not found: \(executable)")
   }
 
-  /// Executes the program at `path` with the specified arguments in a subprocess, returning
+  /// Runs the executable at `path`, passing `arguments` on the command line, and returns
+  /// its standard output sans any leading or trailing whitespace.
   @discardableResult
   private func runCommandLine(
     _ programPath: String,

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -8,21 +8,6 @@ import IR
 import LLVM
 import Utils
 
-extension Process {
-
-  /// Information about a process that exited with an error.
-  struct Failure: Error {
-
-    /// The process' exit code.
-    let terminationStatus: Int32
-
-    /// Any output captured from the process' output pipe.
-    let rawOutput: String
-
-  }
-
-}
-
 public struct Driver: ParsableCommand {
 
   /// The type of the output files to generate.

--- a/Sources/Driver/Process+Extensions.swift
+++ b/Sources/Driver/Process+Extensions.swift
@@ -41,11 +41,7 @@ extension Process {
 
   /// Runs `executable` with the given command line `arguments` and returns its exit status along
   /// with the text written to its standard output and standard error streams.
-  public static func run(
-    _ executable: URL,
-    arguments: [String] = []
-  ) throws -> OutputStreams {
-
+  public static func run( _ executable: URL, arguments: [String] = []) throws -> OutputStreams {
     let output: OutputStreams = (standardOutput: Pipe(), standardError: Pipe())
     let p = Process()
     p.executableURL = executable

--- a/Sources/Driver/Process+Extensions.swift
+++ b/Sources/Driver/Process+Extensions.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+extension Pipe {
+
+  /// Returns the contents decoded as UTF-8, while consuming `self`.
+  public func readUTF8() -> String {
+    String(decoding: fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+  }
+
+}
+
+extension Process {
+
+  /// The textual output of a process run.
+  public typealias OutputStreams = (standardOutput: Pipe, standardError: Pipe)
+
+  /// The results of a process run that exited with a nonzero code.
+  public class NonZeroExit: Error {
+
+    /// The nonzero exit code of the process run.
+    public let terminationStatus: Int32
+
+    /// The textual output of the process run.
+    public let output: OutputStreams
+
+    /// The command-line that triggered the process run.
+    public let commandLine: [String]
+
+    /// A cache that captures the output streams the first time they are read, so that their
+    /// contents can be used repeatedly.
+    private var outputMemo: (standardOutput: String, standardError: String)? = nil
+
+    /// Creates an instance with the given properties.
+    init(terminationStatus: Int32, output: OutputStreams, commandLine: [String]) {
+      self.terminationStatus = terminationStatus
+      self.output = output
+      self.commandLine = commandLine
+    }
+
+  }
+
+  /// Runs `executable` with the given command line `arguments` and returns its exit status along
+  /// with the text written to its standard output and standard error streams.
+  public static func run(
+    _ executable: URL,
+    arguments: [String] = []
+  ) throws -> OutputStreams {
+
+    let output: OutputStreams = (standardOutput: Pipe(), standardError: Pipe())
+    let p = Process()
+    p.executableURL = executable
+    p.arguments = arguments
+    p.standardOutput = output.standardOutput
+    p.standardError = output.standardError
+    try p.run()
+    p.waitUntilExit()
+
+    if p.terminationStatus != 0 {
+      throw NonZeroExit(
+        terminationStatus: p.terminationStatus,
+        output: output,
+        commandLine: [executable.fileSystemPath] + arguments)
+    }
+
+    return output
+  }
+
+}
+
+extension Process.NonZeroExit: CustomStringConvertible {
+
+  public var description: String {
+    if outputMemo == nil {
+      outputMemo = (output.standardOutput.readUTF8(), output.standardError.readUTF8())
+    }
+
+    return """
+      NonZeroExit(
+        terminationStatus: \(terminationStatus),
+        standardOutput: \(String(reflecting: outputMemo!.standardOutput)),
+        standardError: \(String(reflecting: outputMemo!.standardError)),
+        commandLine: \(commandLine))
+      """
+  }
+
+}
+
+extension URL {
+
+  /// The representation used by the native filesystem.
+  public var fileSystemPath: String {
+    self.withUnsafeFileSystemRepresentation { String(cString: $0!) }
+  }
+
+}

--- a/Sources/Driver/Process+Extensions.swift
+++ b/Sources/Driver/Process+Extensions.swift
@@ -15,7 +15,7 @@ extension Process {
   public typealias OutputStreams = (standardOutput: Pipe, standardError: Pipe)
 
   /// The results of a process run that exited with a nonzero code.
-  public class NonZeroExit: Error {
+  public class NonzeroExit: Error {
 
     /// The nonzero exit code of the process run.
     public let terminationStatus: Int32
@@ -52,7 +52,7 @@ extension Process {
     p.waitUntilExit()
 
     if p.terminationStatus != 0 {
-      throw NonZeroExit(
+      throw NonzeroExit(
         terminationStatus: p.terminationStatus,
         output: output,
         commandLine: [executable.fileSystemPath] + arguments)
@@ -63,7 +63,7 @@ extension Process {
 
 }
 
-extension Process.NonZeroExit: CustomStringConvertible {
+extension Process.NonzeroExit: CustomStringConvertible {
 
   public var description: String {
     if outputMemo == nil {
@@ -71,7 +71,7 @@ extension Process.NonZeroExit: CustomStringConvertible {
     }
 
     return """
-      NonZeroExit(
+      NonzeroExit(
         terminationStatus: \(terminationStatus),
         standardOutput: \(String(reflecting: outputMemo!.standardOutput)),
         standardError: \(String(reflecting: outputMemo!.standardError)),

--- a/Sources/TestUtils/AnnotatedHyloFileTest.swift
+++ b/Sources/TestUtils/AnnotatedHyloFileTest.swift
@@ -165,10 +165,8 @@ extension XCTestCase {
         throw d
       }
 
-      let (status, _) = try run(executable)
-      if status != 0 {
-        throw NonzeroExitCode(value: status)
-      }
+      // discard any outputs.
+      _ = try Process.run(executable, arguments: [])
     }
   }
 
@@ -197,21 +195,6 @@ extension XCTestCase {
       "Compilation output file not found: \(output.relativePath)")
 
     return output
-  }
-
-  /// Runs `executable` and returns its exit status along with the text written to its standard
-  /// output.
-  public func run(_ executable: URL) throws -> (status: Int32, standardOutput: String) {
-    let pipe = Pipe()
-    let task = Process()
-    task.executableURL = executable
-    task.standardOutput = pipe
-    try task.run()
-    task.waitUntilExit()
-
-    let standardOutput = String(
-      data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-    return (task.terminationStatus, standardOutput ?? "")
   }
 
 }

--- a/Tests/EndToEndTests/ExecutionTests.swift
+++ b/Tests/EndToEndTests/ExecutionTests.swift
@@ -8,11 +8,18 @@ final class ExecutionTests: XCTestCase {
     let s = #"public fun main() { print("Hello, World!") }"#
     try s.write(to: f, atomically: true, encoding: .utf8)
 
-    let output = try compile(f, with: ["--emit", "binary", "-o", "hello"])
-    let result = try run(output)
-    XCTAssertEqual(result.status, 0, "Exit code is \(result.status)")
-    XCTAssert(result.standardOutput.last?.isNewline ?? false)  // Allow for windows newline.
-    XCTAssertEqual(result.standardOutput.dropLast(), "Hello, World!")
+    let executable = try compile(f, with: ["--emit", "binary", "-o", "hello"])
+
+    func runAndCheckOutput() throws {
+      let (standardOutput, _) = try Process.run(executable)
+      let outputText = standardOutput.readUTF8()
+
+      // Remember, Windows has a different newline character
+      XCTAssert(outputText.last?.isNewline ?? false, "Expected a final newline")
+      XCTAssertEqual(outputText.dropLast(), "Hello, World!")
+    }
+
+    XCTAssertNoThrow(try runAndCheckOutput())
   }
 
 }


### PR DESCRIPTION
- improve the diagnostic output when there are failures
- factor out synchronous subprocess launching.