### PR TITLE
Restore needed plugin dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
     .package(
       url: "https://github.com/apple/swift-format",
       from: "508.0.1"),
+    .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.1.0"),
     .package(
       url: "https://github.com/SwiftPackageIndex/SPIManifest.git",
       from: "0.12.0"),


### PR DESCRIPTION
Reverts hylo-lang/hylo#1027

I'm not sure what I was thinking.  It would have been a good idea to write that in the commit message.