### PR TITLE
Implement DirectedGraph.isReachable(_:from:)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -116,7 +116,10 @@ let package = Package(
 
     .target(
       name: "Utils",
-      dependencies: [.product(name: "BigInt", package: "BigInt")],
+      dependencies: [
+        .product(name: "BigInt", package: "BigInt"),
+        .product(name: "Collections", package: "swift-collections"),
+      ],
       swiftSettings: allTargetsSwiftSettings),
 
     .target(

--- a/Sources/TestUtils/AnnotatedHyloFileTest.swift
+++ b/Sources/TestUtils/AnnotatedHyloFileTest.swift
@@ -93,11 +93,12 @@ extension XCTestCase {
   /// Applies `process` to the ".hylo" file at the given path and reports XCTest failures where the
   /// effects of processing don't match the file's annotation commands ("//! ... diagnostic ...").
   ///
-  /// - Parameter process: applies some processing to `file`, updating `diagnostics`
-  ///   with any generated diagnostics. Throws an `Error` if processing failed.
-  /// - Parameter expectSuccess: true if an error from `process` represents a test failure, false if
-  ///   the lack of an error represents a test failure; nil if that information is to be derived
-  ///   from the contents of the file.
+  /// - Parameters:
+  ///   - process: applies some processing to `file`, updating `diagnostics` with any generated
+  ///     diagnostics. Throws an `Error` if processing failed.
+  ///   - expectSuccess: true if an error from `process` represents a test failure, false if the
+  ///     lack of an error represents a test failure; nil if that information is to be derived
+  ///     from the contents of the file.
   public func checkAnnotatedHyloFileDiagnostics(
     inFileAt hyloFilePath: String,
     expectSuccess: Bool,
@@ -114,12 +115,16 @@ extension XCTestCase {
     }
 
     if (thrownError == nil) != expectSuccess {
-      record(
-        XCTIssue(
-          Diagnostic.error(
-            thrownError.map { "success was expected, but processing failed with thrown error: \($0)" }
-              ?? "processing succeeded, but failure was expected",
-            at: f.wholeRange)))
+      record(XCTIssue(unexpectedOutcomeDiagnostic(thrownError: thrownError, at: f.wholeRange)))
+    }
+  }
+
+  /// Returns the diagnostic of an unexpected outcome with given `thrownError` reported at `s`.
+  private func unexpectedOutcomeDiagnostic(thrownError: Error?, at s: SourceRange) -> Diagnostic {
+    if let e = thrownError {
+      return .error("success was expected, but processing failed with thrown error: \(e)", at: s)
+    } else {
+      return .error("processing succeeded, but failure was expected", at: s)
     }
   }
 

--- a/Tests/UtilsTests/DirectedGraphTests.swift
+++ b/Tests/UtilsTests/DirectedGraphTests.swift
@@ -75,6 +75,34 @@ final class DirectedGraphTests: XCTestCase {
     XCTAssert(g.edges.sorted().elementsEqual(edges, by: { $0 == $1 }))
   }
 
+  func testBFS() {
+    var g = DirectedGraph<Int, ()>()
+    g.insertEdge(from: 0, to: 1)
+    g.insertEdge(from: 0, to: 2)
+    g.insertEdge(from: 1, to: 3)
+    g.insertEdge(from: 2, to: 3)
+
+    let vertices = Array(g.bfs(from: 0))
+    XCTAssertEqual(Set(vertices), [0, 1, 2, 3])
+    XCTAssertEqual(vertices.first, 0)
+    XCTAssertEqual(vertices.last, 3)
+  }
+
+  func testIsReachable() {
+    var g = DirectedGraph<Int, ()>()
+    g.insertEdge(from: 0, to: 1)
+    g.insertEdge(from: 0, to: 2)
+    g.insertEdge(from: 1, to: 3)
+    g.insertEdge(from: 2, to: 3)
+
+    XCTAssert(g.isReachable(3, from: 0))
+    XCTAssert(g.isReachable(2, from: 0))
+    XCTAssert(g.isReachable(3, from: 1))
+
+    XCTAssertFalse(g.isReachable(0, from: 3))
+    XCTAssertFalse(g.isReachable(2, from: 1))
+  }
+
 }
 
 extension DirectedGraph<Int, String>.Edge {


### PR DESCRIPTION
This algorithm will be used to detect trait refinement cycles.