### PR TITLE
Type check generic requirements

### DIFF
--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -832,105 +832,32 @@ struct ConstraintSystem {
     stale.append(g)
   }
 
-  /// Unifies `lhs` with `rhs` using `relations` to check for equivalence, returning `true` if
-  /// unification succeeded.
+  /// Returns `true` iff `lhs` and `rhs` can be unified, updating the type substitution table.
   ///
-  /// Type unification consists of finding substitutions that makes `lhs` and `rhs` equal. The
-  /// algorithm recursively visits both types in lockstep, updating `self.typeAssumptions` every
-  /// time either side is a type variable for which no substitution has been made yet.
+  /// Type unification consists of finding substitutions that makes `lhs` and `rhs` equal. Both
+  /// types are visited in lockstep, updating `self.typeAssumptions` every time either side is a
+  /// type variable for which no substitution has been made yet.
   private mutating func unify(_ lhs: AnyType, _ rhs: AnyType) -> Bool {
-    let (a, b) = (typeAssumptions[lhs], typeAssumptions[rhs])
-    if checker.areEquivalent(a, b, in: scope) { return true }
+    lhs.matches(rhs, mutating: &self) { (this, a, b) in
+      this.unifySyntacticallyInequal(a, b)
+    }
+  }
 
-    switch (a.base, b.base) {
+  /// Returns `true` iff `lhs` and `rhs`, which have different constructors, can be unified.
+  private mutating func unifySyntacticallyInequal(_ lhs: AnyType, _ rhs: AnyType) -> Bool {
+    switch (typeAssumptions[lhs].base, typeAssumptions[rhs].base) {
     case (let v as TypeVariable, _):
       assume(v, equals: rhs)
       return true
-
     case (_, let v as TypeVariable):
       assume(v, equals: lhs)
       return true
-
-    case (let l as BoundGenericType, let r as BoundGenericType):
-      guard unify(l.base, r.base), l.arguments.count == r.arguments.count else {
-        return false
-      }
-
-      var result = true
-      for (a, b) in zip(l.arguments, r.arguments) {
-        result = (a.key == b.key) && result
-        switch (a.value, b.value) {
-        case (let vl as AnyType, let vr as AnyType):
-          result = unify(vl, vr) && result
-        default:
-          result = a.value.equals(b.value) && result
-        }
-      }
-      return result
-
-    case (let l as MetatypeType, let r as MetatypeType):
-      return unify(l.instance, r.instance)
-
-    case (let l as TupleType, let r as TupleType):
-      if !l.labels.elementsEqual(r.labels) {
-        return false
-      }
-
-      var result = true
-      for (a, b) in zip(l.elements, r.elements) {
-        result = unify(a.type, b.type) && result
-      }
-      return result
-
-    case (let l as LambdaType, let r as LambdaType):
-      if !l.labels.elementsEqual(r.labels) {
-        return false
-      }
-
-      var result = true
-      for (a, b) in zip(l.inputs, r.inputs) {
-        result = unify(a.type, b.type) && result
-      }
-      result = unify(l.output, r.output) && result
-      result = unify(l.environment, r.environment) && result
-      return result
-
-    case (let l as MethodType, let r as MethodType):
-      if !l.labels.elementsEqual(r.labels) {
-        return false
-      }
-      if l.capabilities != r.capabilities {
-        return false
-      }
-
-      var result = true
-      for (a, b) in zip(l.inputs, r.inputs) {
-        result = unify(a.type, b.type) && result
-      }
-      result = unify(l.output, r.output) && result
-      result = unify(l.receiver, r.receiver) && result
-      return result
-
-    case (let l as ParameterType, let r as ParameterType):
-      if l.access != r.access {
-        return false
-      }
-      return unify(l.bareType, r.bareType)
-
-    case (let l as RemoteType, let r as RemoteType):
-      if l.access != r.access {
-        return false
-      }
-      return unify(l.bareType, r.bareType)
-
+    case (_, _) where !lhs[.isCanonical]:
+      return unify(checker.canonical(lhs, in: scope), rhs)
+    case (_, _) where !rhs[.isCanonical]:
+      return unify(lhs, checker.canonical(rhs, in: scope))
     default:
-      if !lhs[.isCanonical] {
-        return unify(checker.canonical(lhs, in: scope), rhs)
-      }
-      if !rhs[.isCanonical] {
-        return unify(lhs, checker.canonical(rhs, in: scope))
-      }
-      return false
+      return checker.areEquivalent(lhs, rhs, in: scope)
     }
   }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithGenericRequirement.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithGenericRequirement.hylo
@@ -1,0 +1,9 @@
+//- typeCheck expecting: success
+
+trait P {
+  fun red<T>(_ x: T) -> Int
+}
+
+type A: P {
+  public fun red<U>(_ x: U) -> Int { 42 }
+}


### PR DESCRIPTION
This PR adds supports for traits requiring generic members.

The solution implemented is too naive and won't cover requirements with non-empty where clauses. Handling this case will require a more powerful inference engine to conclude that a particular set of symbolic constraints is implied by another.