### PR TITLE
Implement a universal hash function

### DIFF
--- a/StandardLibrary/Sources/Core/Hashable.hylo
+++ b/StandardLibrary/Sources/Core/Hashable.hylo
@@ -1,6 +1,7 @@
 /// A type that can be hashed into a `Hasher` to produce a hash value.
 public trait Hashable: Equatable {
 
+  /// Hashes the salient parts of `self` into `hasher`.
   fun hash(into hasher: inout Hasher)
 
 }

--- a/StandardLibrary/Sources/Core/Hashable.hylo
+++ b/StandardLibrary/Sources/Core/Hashable.hylo
@@ -1,0 +1,6 @@
+/// A type that can be hashed into a `Hasher` to produce a hash value.
+public trait Hashable: Equatable {
+
+  fun hash(into hasher: inout Hasher)
+
+}

--- a/StandardLibrary/Sources/Core/Hasher.hylo
+++ b/StandardLibrary/Sources/Core/Hasher.hylo
@@ -31,16 +31,18 @@ public type Hasher {
     &hash = hash &* FNV.prime
   }
 
-  /// Adds `value` to the hash value computed by `self`.
-  public fun combine<T>(_ value: T) inout {
-    var p = Pointer<Int8>(type_punning: pointer[to: value])
-    let e = MemoryLayout<T>.size()
+  /// Adds `bytes` to the hash value computed by `self`.
+  public fun unsafe_combine(bytes: PointerToBuffer<Int8>) {
     var i = 0
-    while i < e {
-      &combine(byte: p.unsafe[])
-      &p = p.advance(by: 1)
+    while i < bytes.count {
+      &combine(byte: bytes.start.advance(by: i).unsafe[])
       &i += 1
     }
+  }
+
+  /// Adds `value` to the hash value computed by `self`.
+  public fun combine<T: Hashable>(_ value: T) inout {
+    value.hash(into: &self)
   }
 
 }

--- a/StandardLibrary/Sources/Core/Hasher.hylo
+++ b/StandardLibrary/Sources/Core/Hasher.hylo
@@ -1,0 +1,46 @@
+namespace FNV {
+
+  let offset_basis = Int(bit_pattern: 0xcbf29ce484222325)
+
+  let prime = Int(bit_pattern: 0x100000001b3)
+
+}
+
+/// A universal hash function.
+///
+/// A hash function maps arbitrary data to fixed-size integers, called _hashes_. You feed data to
+/// a `Hasher` by calling its `combine` methods and then call `finalize` to compute a hash.
+public type Hasher {
+
+  /// The currently computed hash value.
+  var hash: Int
+
+  /// Creates a new instance.
+  public init() {
+    &self.hash = FNV.offset_basis.copy()
+  }
+
+  /// Returns the hash value computed by `self`.
+  public fun finalize() sink -> Int {
+    hash
+  }
+
+  /// Adds `byte` to the hash value computed by `self`.
+  public fun combine(byte: Int8) inout {
+    &hash = hash ^ Int(truncating_or_extending: UInt8(bit_pattern: byte))
+    &hash = hash &* FNV.prime
+  }
+
+  /// Adds `value` to the hash value computed by `self`.
+  public fun combine<T>(_ value: T) inout {
+    var p = Pointer<Int8>(type_punning: pointer[to: value])
+    let e = MemoryLayout<T>.size()
+    var i = 0
+    while i < e {
+      &combine(byte: p.unsafe[])
+      &p = p.advance(by: 1)
+      &i += 1
+    }
+  }
+
+}

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int.hylo
@@ -46,6 +46,11 @@ public type Int {
     self ^ -1
   }
 
+  /// Returns the product of `self` and `other, wrapping the result in case of any overflow.
+  public fun infix &* (_ other: Self) -> Self {
+    self.multiplied_reporting_overflow(by: other).0
+  }
+
 }
 
 public conformance Int: ExpressibleByIntegerLiteral {}

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int.hylo
@@ -81,6 +81,15 @@ public conformance Int: Equatable {
 
 public conformance Int: Regular {}
 
+public conformance Int: Hashable {
+
+  public fun hash(into hasher: inout Hasher) {
+    // TODO: use conditional compilation to avoid branches
+    &hasher.unsafe_combine(bytes: pointer_to_bytes[of: self])
+  }
+
+}
+
 public conformance Int: Comparable {
 
   public fun infix< (_ other: Self) -> Bool {

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int32.hylo
@@ -30,3 +30,27 @@ public conformance Int32: Copyable {
   }
 
 }
+
+public conformance Int32: Equatable {
+
+  public fun infix== (_ other: Self) -> Bool {
+    Bool(value: Builtin.icmp_eq_i32(value, other.value))
+  }
+
+  public fun infix!= (_ other: Self) -> Bool {
+    Bool(value: Builtin.icmp_ne_i32(value, other.value))
+  }
+
+}
+
+public conformance Int32: Hashable {
+
+  public fun hash(into hasher: inout Hasher) {
+    let p = Pointer<Int8>(type_punning: pointer[to: self])
+    &hasher.combine(byte: p.unsafe[])
+    &hasher.combine(byte: p.advance(by: 1).unsafe[])
+    &hasher.combine(byte: p.advance(by: 2).unsafe[])
+    &hasher.combine(byte: p.advance(by: 3).unsafe[])
+  }
+
+}

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int8.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int8.hylo
@@ -62,6 +62,14 @@ public conformance Int8: Equatable {
 
 public conformance Int8: Regular {}
 
+public conformance Int8: Hashable {
+
+  public fun hash(into hasher: inout Hasher) {
+    &hasher.combine(byte: self)
+  }
+
+}
+
 public conformance Int8: Comparable {
 
   public fun infix< (_ other: Self) -> Bool {

--- a/StandardLibrary/Sources/Core/Numbers/Integers/UInt.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/UInt.hylo
@@ -50,6 +50,15 @@ public conformance UInt: Equatable {
 
 public conformance UInt: Regular {}
 
+public conformance UInt: Hashable {
+
+  public fun hash(into hasher: inout Hasher) {
+    // TODO: use conditional compilation to avoid branches
+    &hasher.unsafe_combine(bytes: pointer_to_bytes[of: self])
+  }
+
+}
+
 public conformance UInt: Comparable {
 
   public fun infix< (_ other: Self) -> Bool {

--- a/StandardLibrary/Sources/Core/Numbers/Integers/UInt8.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/UInt8.hylo
@@ -45,6 +45,14 @@ public conformance UInt8: Equatable {
 
 public conformance UInt8: Regular {}
 
+public conformance UInt8: Hashable {
+
+  public fun hash(into hasher: inout Hasher) {
+    &hasher.combine(byte: Int8(bit_pattern: self))
+  }
+
+}
+
 public conformance UInt8: Comparable {
 
   public fun infix< (_ other: Self) -> Bool {

--- a/StandardLibrary/Sources/Core/Operators.hylo
+++ b/StandardLibrary/Sources/Core/Operators.hylo
@@ -4,14 +4,14 @@ public operator infix>>   : shift
 public operator infix&>>  : shift
 
 public operator infix*    : multiplication
-public operator infix*!   : multiplication
+public operator infix&*   : multiplication
 public operator infix/    : multiplication
 public operator infix%    : multiplication
 
 public operator infix+    : addition
-public operator infix+!   : addition
+public operator infix&+   : addition
 public operator infix-    : addition
-public operator infix-!   : addition
+public operator infix&-   : addition
 
 public operator infix..<  : range
 public operator infix...  : range

--- a/StandardLibrary/Sources/Core/Pointer.hylo
+++ b/StandardLibrary/Sources/Core/Pointer.hylo
@@ -67,3 +67,12 @@ public conformance Pointer: Equatable {
 public subscript pointer<T>(to x: T): Pointer<T> {
   let { yield Pointer(base: Builtin.address(of: x)) }
 }
+
+/// The address and size of a buffer covering the raw bytes of `x`.
+public subscript pointer_to_bytes<T>(of x: T): PointerToBuffer<Int8> {
+  let {
+    let start = Pointer<Int8>(type_punning: Pointer<T>(base: Builtin.address(of: x)))
+    let count = MemoryLayout<T>.size()
+    yield PointerToBuffer(start: start, count: count)
+  }
+}

--- a/StandardLibrary/Sources/Core/PointerToBuffer.hylo
+++ b/StandardLibrary/Sources/Core/PointerToBuffer.hylo
@@ -1,0 +1,35 @@
+/// The typed memory address of a buffer whose contents can be read.
+public type PointerToBuffer<Pointee> {
+
+  /// The address at which the buffer starts.
+  public let start: Pointer<Pointee>
+
+  /// The number of elements in the buffer.
+  public let count: Int
+
+  /// Creates an instance covering `count` contiguous instances beginning at `start`.
+  public memberwise init
+
+}
+
+public conformance PointerToBuffer: Deinitializable {}
+
+public conformance PointerToBuffer: Movable {}
+
+public conformance PointerToBuffer: Copyable {
+
+  public fun copy() -> Self {
+    PointerToBuffer(start: start.copy(), count: count.copy())
+  }
+
+}
+
+public conformance PointerToBuffer: Equatable {
+
+  public fun infix== (_ other: Self) -> Bool {
+    (self.start == other.start) && (self.count == other.count)
+  }
+
+}
+
+public conformance PointerToBuffer: Regular {}


### PR DESCRIPTION
This patch implements the 64-bit variant of FNV-1 as a universal hash function.

Note that using `Hasher` is not randomized, meaning that hashing the same value across multiple executions will produce the same value. We may want to modify this behavior, at least when `--freestanding` is not set, to reduce vulnerability to attacks based on hash collisions.