### PR TITLE
Avoid the overspecializing function references

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -107,13 +107,18 @@ struct TypeChecker {
     return elements.uniqueElement ?? ^UnionType(elements)
   }
 
+  /// Returns the canonical form of `v` in `scopeOfUse`.
+  mutating func canonical(
+    _ v: any CompileTimeValue, in scopeOfUse: AnyScopeID
+  ) -> any CompileTimeValue {
+    (v as? AnyType).map({ canonical($0, in: scopeOfUse) }) ?? v
+  }
+
   /// Returns `arguments` with all types replaced by their canonical form in `scopeOfUse`.
   mutating func canonical(
     _ arguments: GenericArguments, in scopeOfUse: AnyScopeID
   ) -> GenericArguments {
-    arguments.mapValues { (v) in
-      (v as? AnyType).map({ canonical($0, in: scopeOfUse) }) ?? v
-    }
+    arguments.mapValues({ canonical($0, in: scopeOfUse) })
   }
 
   /// Returns `true` iff `t` and `u` are equivalent types in `scopeOfUse`.

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -139,6 +139,14 @@ public struct TypedProgram {
     return checker.canonical(t, in: scopeOfUse)
   }
 
+  /// Returns the canonical form of `v` in `scopeOfUse`.
+  public func canonical(
+    _ v: any CompileTimeValue, in scopeOfUse: AnyScopeID
+  ) -> any CompileTimeValue {
+    var checker = TypeChecker(asContextFor: self)
+    return checker.canonical(v, in: scopeOfUse)
+  }
+
   /// Returns `arguments` with all types replaced by their canonical form in `scopeOfUse`.
   public func canonical(
     _ arguments: GenericArguments, in scopeOfUse: AnyScopeID

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -1,4 +1,5 @@
 import Core
+import Utils
 
 /// A Hylo IR reference to a user function.
 public struct FunctionReference: Constant, Hashable {
@@ -35,13 +36,14 @@ public struct FunctionReference: Constant, Hashable {
     to f: Function.ID, in module: Module,
     specializedBy specialization: GenericArguments, in scopeOfUse: AnyScopeID
   ) {
-    precondition(
-      module[f].genericParameters.count <= specialization.count,
-      "underspecialized function reference")
+    var a = GenericArguments()
+    for p in module[f].genericParameters {
+      let v = specialization[p] ?? preconditionFailure("underspecialized function reference")
+      a[p] = module.program.canonical(v, in: scopeOfUse)
+    }
 
     let v = module[f]
     let t = LambdaType(inputs: v.inputs.map({ .init(type: ^$0.type) }), output: v.output)
-    let a = module.program.canonical(specialization, in: scopeOfUse)
     let u = module.program.canonical(
       module.program.specialize(^t, for: a, in: scopeOfUse), in: scopeOfUse)
 


### PR DESCRIPTION
It can happen that a function reference gets created with too many generic arguments when the emitter lowers a call in a generic context, unnecessary increasing the complexity of depolymorphization.