### PR TITLE
Disable parallel type checking on macOS

### DIFF
--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -61,6 +61,9 @@ public struct TypedProgram {
     tracingInferenceIf shouldTraceInference: ((AnyNodeID, TypedProgram) -> Bool)? = nil
   ) throws {
     let instanceUnderConstruction = SharedMutable(TypedProgram(partiallyFormedFrom: base))
+    #if os(macOS) && DEBUG
+    let isTypeCheckingParallel = isTypeCheckingParallel && false
+    #endif
 
     if isTypeCheckingParallel {
       let sources = base.ast[base.ast.modules].map(\.sources).joined()


### PR DESCRIPTION
Parallel type checking is buggy on macOS in debug builds, seemingly because of UB. This patch disables it temporarily. It should be reverted once the bug is fixed.