### PR TITLE
Bind trait extensions to trait receivers

### DIFF
--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -297,6 +297,15 @@ public struct AST {
     return self[parameters].map(\.defaultValue)
   }
 
+  /// Returns the generic parameters introduced by `d`.
+  public func genericParameters(introducedBy d: AnyDeclID) -> [GenericParameterDecl.ID] {
+    if let s = self[d] as? GenericScope {
+      return s.genericParameters
+    } else {
+      return []
+    }
+  }
+
   /// Returns the name of `d` unless `d` is anonymous.
   public func name(of d: FunctionDecl.ID) -> Name? {
     guard let stem = self[d].identifier?.value else { return nil }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -197,7 +197,7 @@ struct TypeChecker {
   private mutating func conformedTraits(
     of t: AssociatedTypeType, in scopeOfUse: AnyScopeID
   ) -> Set<TraitType> {
-    var result = conformedTraits(declaredInEnvironmentIntroducing: ^t, exposedTo: scopeOfUse)
+    var result = conformedTraits(declaredByConstraintsOn: ^t, exposedTo: scopeOfUse)
     result.formUnion(conformedTraits(declaredInExtensionsOf: ^t, exposedTo: scopeOfUse))
     return result
   }
@@ -227,7 +227,7 @@ struct TypeChecker {
       result = []
     }
 
-    result.formUnion(conformedTraits(declaredInEnvironmentIntroducing: ^t, exposedTo: scopeOfUse))
+    result.formUnion(conformedTraits(declaredByConstraintsOn: ^t, exposedTo: scopeOfUse))
     result.formUnion(conformedTraits(declaredInExtensionsOf: ^t, exposedTo: scopeOfUse))
     return result
   }
@@ -280,7 +280,7 @@ struct TypeChecker {
   /// logically containing `scopeOfUse`. The return value is the set of traits used as bounds of
   /// `t` in that environment.
   mutating func conformedTraits(
-    declaredInEnvironmentIntroducing t: AnyType, exposedTo scopeOfUse: AnyScopeID
+    declaredByConstraintsOn t: AnyType, exposedTo scopeOfUse: AnyScopeID
   ) -> Set<TraitType> {
     var result = Set<TraitType>()
     for s in program.scopes(from: scopeOfUse) where s.kind.value is GenericScope.Type {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2562,7 +2562,7 @@ struct TypeChecker {
       if let u = LambdaType(t) {
         if !u.inputs.isEmpty {
           report(.error(autoclosureExpectsEmptyLambdaAt: s, given: t))
-        } 
+        }
       } else {
         report(.error(autoclosureExpectsEmptyLambdaAt: s, given: t))
       }
@@ -2845,7 +2845,7 @@ struct TypeChecker {
   ) -> Set<AnyDeclID> {
     let extended = uncheckedType(of: lookupContext)
 
-    if let t = GenericTypeParameterType(extended), isTraitReceiver(t), (stem == "Self") {
+    if let t = GenericTypeParameterType(extended), isTraitReceiver(t), stem == "Self" {
       // "Self" in the context of a trait extension denotes that trait's receiver.
       return [AnyDeclID(t.decl)]
     } else {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3073,16 +3073,6 @@ struct TypeChecker {
     return table
   }
 
-  /// Returns the generic parameters introduced by `d`.
-  private func genericParameters(introducedBy d: AnyDeclID) -> [GenericParameterDecl.ID] {
-    switch d.kind {
-    case TraitDecl.self:
-      return []
-    default:
-      return (program.ast[d] as? GenericScope)?.genericParameters ?? []
-    }
-  }
-
   /// Returns declarations extending `subject` exposed to `scopeOfUse`.
   ///
   /// - Requires: The imports of the module containing `scopeOfUse` have been configured.
@@ -3704,7 +3694,7 @@ struct TypeChecker {
       assert(arguments.isEmpty, "generic declaration bound twice")
       return g.arguments
     } else {
-      let p = genericParameters(introducedBy: d)
+      let p = program.ast.genericParameters(introducedBy: d)
       return associateGenericParameters(p, of: name, to: arguments, reportingDiagnosticsTo: &log)
     }
   }

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -374,7 +374,7 @@ public struct TypedProgram {
   ) -> Conformance? {
     var checker = TypeChecker(asContextFor: self)
     let bounds = checker.conformedTraits(
-      declaredInEnvironmentIntroducing: model,
+      declaredByConstraintsOn: model,
       exposedTo: scopeOfUse)
     guard bounds.contains(concept) else { return nil }
 

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -456,12 +456,6 @@ public struct TypedProgram {
     return result
   }
 
-  /// Returns the scope of the declaration extended by `d`, if any.
-  public func scopeExtended<T: TypeExtendingDecl>(by d: T.ID) -> AnyScopeID? {
-    var checker = TypeChecker(asContextFor: self)
-    return checker.scopeExtended(by: d)
-  }
-
   /// Returns the modules visible to `s`:
   public func modules(exposedTo s: AnyScopeID) -> Set<ModuleDecl.ID> {
     if let m = ModuleDecl.ID(s) {

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -62,7 +62,7 @@ public struct TypedProgram {
   ) throws {
     let instanceUnderConstruction = SharedMutable(TypedProgram(partiallyFormedFrom: base))
     #if os(macOS) && DEBUG
-    let isTypeCheckingParallel = isTypeCheckingParallel && false
+      let isTypeCheckingParallel = isTypeCheckingParallel && false
     #endif
 
     if isTypeCheckingParallel {

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -319,7 +319,6 @@ public struct Module {
     let parameters = program.accumulatedGenericParameters(in: d)
     let output = program.canonical(
       (program[d].type.base as! CallableType).output, in: program[d].scope)
-
     let inputs = loweredParameters(of: d)
 
     let entity = Function(

--- a/Tests/HyloTests/TestCases/TypeChecking/DuplicateCapture.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/DuplicateCapture.hylo
@@ -6,6 +6,7 @@ public fun main() {
 
   //! @+1 diagnostic duplicate capture name 'z'
   fun f[let z = x, let z = y]() -> Int {
+    //! @+1 diagnostic ambiguous use of 'z'
     z.copy()
   }
 }


### PR DESCRIPTION
This PR modifies name binding so that trait extensions are assumed to extend the implicit receiver parameter of the extended trait rather than the trait itself. In other words, given a trait extension `d`, `TypedProgram.declType[d]` is now the receiver parameter of a trait rather than a trait.

This change is a first step toward fixing #1111. The next one is to fix the creation of generic environments so that we can lift the restriction mentioned in 4734af6.