### PR TITLE
Future-Swift compatibility.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -155,11 +155,11 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Setup swift
-      uses: compnerd/gha-setup-swift@main
+      uses: compnerd/gha-setup-swift@v0.2.1
       with:
         github-repo: thebrowsercompany/swift-build
         release-asset-name: installer-amd64.exe
-        release-tag-name: 20231010.3
+        release-tag-name: 20231130.2
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,7 +99,7 @@ jobs:
           }
         ]
         swift: [
-          { version: "5.8" }
+          { version: "5.9" }
         ]
         configuration: [ "debug", "release" ]
 

--- a/.github/workflows/doc-extraction.yml
+++ b/.github/workflows/doc-extraction.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Setup swift
       uses: swift-actions/setup-swift@v1
       with:
-        swift-version: 5.8
+        swift-version: 5.9
 
     - run: swift --version
 

--- a/.spi.yml
+++ b/.spi.yml
@@ -3,7 +3,7 @@ builder:
   configs:
   - platform: linux
     swift_version: '5.9'
-    image: registry.gitlab.com/finestructure/spi-images:val-5.9-latest
+    image: registry.gitlab.com/finestructure/spi-images:hylo-5.9-latest
     documentation_targets:
     - CLI
     - CodeGenLLVM
@@ -22,9 +22,3 @@ builder:
     --source-service-base-url, https://github.com/hylo-lang/hylo/blob/main,
     --checkout-path, .
     ]
-  - platform: linux
-    swift_version: '5.8'
-    image: registry.gitlab.com/finestructure/spi-images:val-5.8-latest
-  - platform: linux
-    swift_version: '5.7'
-    image: registry.gitlab.com/finestructure/spi-images:val-5.7-latest

--- a/Sources/Driver/SourceLine+Extensions.swift
+++ b/Sources/Driver/SourceLine+Extensions.swift
@@ -20,5 +20,5 @@ extension SourceLine {
 #if swift(>=5.10)
 extension SourceLine : @retroactive ExpressibleByArgument {}
 #else
-extension SourceLine : @retroactive ExpressibleByArgument {}
+extension SourceLine : ExpressibleByArgument {}
 #endif

--- a/Sources/Driver/SourceLine+Extensions.swift
+++ b/Sources/Driver/SourceLine+Extensions.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Core
 import Foundation
 
-extension SourceLine: @retroactive ExpressibleByArgument {
+extension SourceLine {
 
   public init?(argument: String) {
     let x = argument.split(atLastIndexOf: ":")
@@ -16,3 +16,9 @@ extension SourceLine: @retroactive ExpressibleByArgument {
   }
 
 }
+
+#if swift(>=5.10)
+extension SourceLine : @retroactive ExpressibleByArgument {}
+#else
+extension SourceLine : @retroactive ExpressibleByArgument {}
+#endif

--- a/Sources/Driver/SourceLine+Extensions.swift
+++ b/Sources/Driver/SourceLine+Extensions.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Core
 import Foundation
 
-extension SourceLine: ExpressibleByArgument {
+extension SourceLine: @retroactive ExpressibleByArgument {
 
   public init?(argument: String) {
     let x = argument.split(atLastIndexOf: ":")

--- a/Sources/Driver/SourceLine+Extensions.swift
+++ b/Sources/Driver/SourceLine+Extensions.swift
@@ -17,7 +17,7 @@ extension SourceLine {
 
 }
 
-#if swift(>=5.10)
+#if swift(>=5.11)
 extension SourceLine : @retroactive ExpressibleByArgument {}
 #else
 extension SourceLine : ExpressibleByArgument {}

--- a/Sources/IR/Operands/Constant/IntegerConstant.swift
+++ b/Sources/IR/Operands/Constant/IntegerConstant.swift
@@ -3,7 +3,7 @@ import Utils
 
 // DWA: This conformance belongs in WideUInt.swift, but is here pending
 // https://github.com/apple/swift/issues/62498.
-#if swift(>=5.10)
+#if swift(>=5.11)
 extension WideUInt: @retroactive UnsignedInteger {}
 #else
 extension WideUInt: UnsignedInteger {}

--- a/Sources/IR/Operands/Constant/IntegerConstant.swift
+++ b/Sources/IR/Operands/Constant/IntegerConstant.swift
@@ -3,7 +3,7 @@ import Utils
 
 // DWA: This conformance belongs in WideUInt.swift, but is here pending
 // https://github.com/apple/swift/issues/62498.
-extension WideUInt: UnsignedInteger {}
+extension WideUInt: @retroactive UnsignedInteger {}
 
 /// An unsigned integer Hylo IR constant.
 public struct IntegerConstant: Constant, Hashable {

--- a/Sources/IR/Operands/Constant/IntegerConstant.swift
+++ b/Sources/IR/Operands/Constant/IntegerConstant.swift
@@ -3,7 +3,11 @@ import Utils
 
 // DWA: This conformance belongs in WideUInt.swift, but is here pending
 // https://github.com/apple/swift/issues/62498.
+#if swift(>=5.10)
 extension WideUInt: @retroactive UnsignedInteger {}
+#else
+extension WideUInt: UnsignedInteger {}
+#endif
 
 /// An unsigned integer Hylo IR constant.
 public struct IntegerConstant: Constant, Hashable {


### PR DESCRIPTION
Swift 5.11 requires you to acknowledge retroactive conformances, and on Windows that's the compiler version to test.