### PR TITLE
Eliminate subscript access on SharedMutable.

### DIFF
--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -84,14 +84,18 @@ public struct TypedProgram {
       }
     }
 
-    var checker = TypeChecker(
-      constructing: instanceUnderConstruction[],
-      tracingInferenceIf: isTypeCheckingParallel ? nil : shouldTraceInference)
-    checker.checkAllDeclarations()
+    self = try instanceUnderConstruction.apply {
 
-    log.formUnion(checker.diagnostics)
-    try log.throwOnError()
-    self = checker.program
+      var checker = TypeChecker(
+        constructing: $0,
+        tracingInferenceIf: isTypeCheckingParallel ? nil : shouldTraceInference)
+      checker.checkAllDeclarations()
+
+      log.formUnion(checker.diagnostics)
+      try log.throwOnError()
+      return checker.program
+
+    }
   }
 
   /// The type checking of a collection of source files.

--- a/Sources/Utils/SharedMutable.swift
+++ b/Sources/Utils/SharedMutable.swift
@@ -17,17 +17,17 @@ public final class SharedMutable<SharedValue> {
     self.storage = toBeShared
   }
 
-  /// Thread-safely accesses the wrapped instance.
-  public subscript() -> SharedValue {
-    get { mutex.sync { storage } }
-    set { mutex.sync { storage = newValue } }
+  /// Returns the result of thread-safely applying `f` to the wrapped instance.
+  public func apply<R>(_ f: (SharedValue) throws -> R) rethrows -> R {
+    try mutex.sync {
+      try f(storage)
+    }
   }
 
   /// Returns the result of thread-safely applying `modification` to the wrapped instance.
   public func modify<R>(applying modification: (inout SharedValue) throws -> R) rethrows -> R {
     try mutex.sync {
-      let r = try modification(&storage)
-      return r
+      try modification(&storage)
     }
   }
 


### PR DESCRIPTION
This doesn't suppress the undefined behavior we've been seeing, but it potentially leads to fewer CoWs.