### PR TITLE
Mixed-width hashing and comparison of WideUInt

### DIFF
--- a/Sources/Utils/WideUInt.swift
+++ b/Sources/Utils/WideUInt.swift
@@ -25,7 +25,17 @@ public struct WideUInt {
 
 }
 
-extension WideUInt: Hashable {}
+extension WideUInt: Hashable {
+
+  public func hash(into hasher: inout Hasher) {
+    value.hash(into: &hasher)
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.value == rhs.value
+  }
+
+}
 
 extension WideUInt: Comparable {
 


### PR DESCRIPTION
Fixes #1179.  

But I'm not sure this is the right fix.

@kyouko-taiga: do you want the bit width of these things to be salient or not?  Because if it is supposed to be salient, you might need to change how you're comparing and hashing them (and the types in which they are embedded).  And if it's not supposed to be salient, well, what's our excuse for having them behave differently based on their bit widths?