### PR TITLE
Handle implicit conversions on assignments

### DIFF
--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -1103,14 +1103,14 @@ extension LLVM.Module {
     func insert(switch i: IR.InstructionID) {
       let s = m[i] as! Switch
 
-      // Pick the case 0 as the "default".
-      let cases = s.successors[1...].enumerated().map { (value, destination) in
+      let branches = s.successors.enumerated().map { (value, destination) in
         (word().constant(UInt64(value)), block[destination]!)
       }
 
+      // The last branch is the "default".
       let n = llvm(s.index)
       insertSwitch(
-        on: n, cases: cases, default: block[s.successors[0]]!,
+        on: n, cases: branches.dropLast(), default: branches.last!.1,
         at: insertionPoint)
     }
 


### PR DESCRIPTION
This PR fixes IR generation and codegen to properly handle assignments like the one below:
```swift
typealias A = Union<Int, String>

public fun main() {
  var x: A = "Bonjour"
  &x = 42
  if let y: Int = x { print(y) }
}
```
Assigning `42` to `x` requires an implicit conversion of `Int` to `Optional<Int>`. This conversion wasn't performed in the current implementation, which was causing UB.