### PR TITLE
Parse the standard library at most twice for host == target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -136,7 +136,7 @@ let package = Package(
       name: "StandardLibrary",
       dependencies: ["FrontEnd", "Utils"],
       path: "StandardLibrary",
-      resources: [.copy("Sources")],
+      exclude: ["Sources"],
       swiftSettings: allTargetsSwiftSettings),
 
     .plugin(

--- a/Package.swift
+++ b/Package.swift
@@ -88,7 +88,6 @@ let package = Package(
       dependencies: [
         "Utils",
         "Core",
-        "StandardLibrary",
         .product(name: "Collections", package: "swift-collections"),
         .product(name: "Durian", package: "Durian"),
         .product(name: "BigInt", package: "BigInt"),
@@ -135,6 +134,7 @@ let package = Package(
 
     .target(
       name: "StandardLibrary",
+      dependencies: ["FrontEnd", "Utils"],
       path: "StandardLibrary",
       resources: [.copy("Sources")],
       swiftSettings: allTargetsSwiftSettings),

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -157,7 +157,7 @@ public struct Driver: ParsableCommand {
     let productName = makeProductName(inputs)
 
     /// An instance that includes just the standard library.
-    var ast = freestanding ? Host.freestandingLibraryAST : Host.standardLibraryAST
+    var ast = freestanding ? Host.freestandingLibraryAST : Host.hostedLibraryAST
 
     // The module whose Hylo files were given on the command-line
     let sourceModule = try ast.makeModule(

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -155,10 +155,9 @@ public struct Driver: ParsableCommand {
     }
 
     let productName = makeProductName(inputs)
+
     /// An instance that includes just the standard library.
-    var ast = AST(
-      libraryRoot: freestanding ? coreLibrarySourceRoot : standardLibrarySourceRoot,
-      for: CompilerConfiguration(freestanding ? ["freestanding"] : []))
+    var ast = freestanding ? Host.freestandingLibraryAST : Host.standardLibraryAST
 
     // The module whose Hylo files were given on the command-line
     let sourceModule = try ast.makeModule(

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -45,13 +45,8 @@ public struct Driver: ParsableCommand {
   private var importBuiltinModule: Bool = false
 
   @Flag(
-    name: [.customLong("unhosted")],
-    help: "Load only the core library, omitting any definitions that depend on OS support.")
-  private var unhosted: Bool = false
-
-  @Flag(
     name: [.customLong("freestanding")],
-    help: "Compile in freestanding mode (no libc).")
+    help: "Import only the freestanding core of the standard library, omitting any definitions that depend on having an operating system.")
   private var freestanding: Bool = false
 
   @Flag(
@@ -162,7 +157,7 @@ public struct Driver: ParsableCommand {
     let productName = makeProductName(inputs)
     /// An instance that includes just the standard library.
     var ast = AST(
-      libraryRoot: unhosted ? coreLibrarySourceRoot : standardLibrarySourceRoot,
+      libraryRoot: freestanding ? coreLibrarySourceRoot : standardLibrarySourceRoot,
       for: CompilerConfiguration(freestanding ? ["freestanding"] : []))
 
     // The module whose Hylo files were given on the command-line

--- a/StandardLibrary/AST+Extensions.swift
+++ b/StandardLibrary/AST+Extensions.swift
@@ -1,12 +1,12 @@
 import Core
 import Foundation
-import StandardLibrary
+import FrontEnd
 import Utils
 
 extension AST {
 
   /// Creates an instance that includes the Hylo library whose sources are rooted at `libraryRoot`.
-  public init(libraryRoot: URL, for compiler: CompilerConfiguration) {
+  init(libraryRoot: URL, for compiler: CompilerConfiguration) {
     self.init(for: compiler)
     do {
       var diagnostics = DiagnosticSet()

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -2,6 +2,13 @@ import Core
 import Foundation
 import Utils
 
+// This path points into the source tree rather than to some copy so that when diagnostics are
+// issued for the standard library, they point to the original source files and edits to those
+// source files actually fix the problems (see https://github.com/hylo-lang/hylo/issues/932).  If we
+// ever change that, some other mechanism is needed to ensure that diagnostics refer to the original
+// source files.
+//
+/// The parent directory of the standard library sources directory.
 private let libraryRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 
 /// The root URL of Hylo's standard library.
@@ -12,10 +19,13 @@ private let freestandingLibrarySourceRoot = standardLibrarySourceRoot.appendingP
 
 extension Utils.Host {
 
+  /// An AST representing the whole standard library, conditionally compiled for targeting the host platform.
   public static let standardLibraryAST = AST(
     libraryRoot: standardLibrarySourceRoot,
     for: CompilerConfiguration([]))
 
+  /// An AST representing the freestanding core of standard library, conditionally compiled for
+  /// targeting the host platform.
   public static let freestandingLibraryAST = AST(
     libraryRoot: freestandingLibrarySourceRoot,
     for: CompilerConfiguration(["freestanding"]))

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -1,10 +1,23 @@
+import Core
 import Foundation
+import Utils
 
 fileprivate let libraryRoot = Bundle.module.resourceURL!
 
 /// The root URL of Hylo's standard library.
-public let standardLibrarySourceRoot = libraryRoot.appendingPathComponent("Sources")
+private let standardLibrarySourceRoot = libraryRoot.appendingPathComponent("Sources")
 
 /// The root URL of Hylo's core library.
-public let coreLibrarySourceRoot = standardLibrarySourceRoot.appendingPathComponent("Core")
+private let freestandingLibrarySourceRoot = standardLibrarySourceRoot.appendingPathComponent("Core")
 
+extension Utils.Host {
+
+  public static let standardLibraryAST = AST(
+    libraryRoot: standardLibrarySourceRoot,
+    for: CompilerConfiguration([]))
+
+  public static let freestandingLibraryAST = AST(
+    libraryRoot: freestandingLibrarySourceRoot,
+    for: CompilerConfiguration(["freestanding"]))
+
+}

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -2,7 +2,7 @@ import Core
 import Foundation
 import Utils
 
-fileprivate let libraryRoot = Bundle.module.resourceURL!
+private let libraryRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 
 /// The root URL of Hylo's standard library.
 private let standardLibrarySourceRoot = libraryRoot.appendingPathComponent("Sources")

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -11,23 +11,23 @@ import Utils
 /// The parent directory of the standard library sources directory.
 private let libraryRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 
-/// The root URL of Hylo's standard library.
-private let standardLibrarySourceRoot = libraryRoot.appendingPathComponent("Sources")
+/// The root of a directory hierarchy containing all the standard library sources.
+private let hostedLibrarySourceRoot = libraryRoot.appendingPathComponent("Sources")
 
-/// The root URL of Hylo's core library.
-private let freestandingLibrarySourceRoot = standardLibrarySourceRoot.appendingPathComponent("Core")
+/// The root of a directory hierarchy containing the sources for the standard library's freestanding
+/// core.
+private let freestandingLibrarySourceRoot = hostedLibrarySourceRoot.appendingPathComponent("Core")
 
 extension Utils.Host {
 
-  /// An AST representing the whole standard library, conditionally compiled for targeting the host platform.
-  public static let standardLibraryAST = AST(
-    libraryRoot: standardLibrarySourceRoot,
-    for: CompilerConfiguration([]))
+  /// An AST representing the whole standard library, conditionally compiled for targeting the host
+  /// platform.
+  public static let hostedLibraryAST
+    = AST(libraryRoot: hostedLibrarySourceRoot, for: CompilerConfiguration([]))
 
   /// An AST representing the freestanding core of standard library, conditionally compiled for
   /// targeting the host platform.
-  public static let freestandingLibraryAST = AST(
-    libraryRoot: freestandingLibrarySourceRoot,
-    for: CompilerConfiguration(["freestanding"]))
+  public static let freestandingLibraryAST
+    = AST(libraryRoot: freestandingLibrarySourceRoot, for: CompilerConfiguration(["freestanding"]))
 
 }

--- a/Tests/HyloTests/LoweringTests.swift
+++ b/Tests/HyloTests/LoweringTests.swift
@@ -14,7 +14,8 @@ extension XCTestCase {
     try checkAnnotatedHyloFileDiagnostics(inFileAt: hyloFilePath, expectSuccess: expectSuccess) {
       (valSource, diagnostics) in
       // Note: built-in module is visible so that we can test built-in function calls.
-      var ast = AST(libraryRoot: coreLibrarySourceRoot, for: CompilerConfiguration())
+      var ast = Host.freestandingLibraryAST
+
       let module = try ast.makeModule(
         valSource.baseName, sourceCode: [valSource], builtinModuleAccess: true,
         diagnostics: &diagnostics)

--- a/Tests/HyloTests/TypeCheckerTests.swift
+++ b/Tests/HyloTests/TypeCheckerTests.swift
@@ -2,6 +2,7 @@ import Core
 import FrontEnd
 import StandardLibrary
 import TestUtils
+import Utils
 import XCTest
 
 extension XCTestCase {
@@ -13,7 +14,7 @@ extension XCTestCase {
     try checkAnnotatedHyloFileDiagnostics(inFileAt: hyloFilePath, expectSuccess: expectSuccess) {
       (source, diagnostics) in
 
-      var ast = AST(libraryRoot: coreLibrarySourceRoot, for: CompilerConfiguration())
+      var ast = Host.freestandingLibraryAST
 
       _ = try ast.makeModule(
         source.baseName, sourceCode: [source], builtinModuleAccess: true,

--- a/Tests/ManglingTests/ManglingTests.swift
+++ b/Tests/ManglingTests/ManglingTests.swift
@@ -3,6 +3,7 @@ import FrontEnd
 import IR
 import StandardLibrary
 import TestUtils
+import Utils
 import XCTest
 
 final class ManglingTests: XCTestCase {
@@ -67,7 +68,7 @@ final class ManglingTests: XCTestCase {
 
     let input = SourceFile(synthesizedText: text, named: "main")
     let (p, m) = try checkNoDiagnostic { (d) in
-      var ast = AST(libraryRoot: standardLibrarySourceRoot, for: CompilerConfiguration())
+      var ast = Utils.Host.standardLibraryAST
       let main = try ast.makeModule("Main", sourceCode: [input], diagnostics: &d)
       let base = ScopedProgram(ast)
       return (try TypedProgram(annotating: base, reportingDiagnosticsTo: &d), main)
@@ -94,7 +95,7 @@ final class ManglingTests: XCTestCase {
 
   func testTypes() throws {
     let p = try checkNoDiagnostic { (d) in
-      let ast = AST(libraryRoot: standardLibrarySourceRoot, for: CompilerConfiguration())
+      let ast = Host.standardLibraryAST
       let base = ScopedProgram(ast)
       return try TypedProgram(annotating: base, reportingDiagnosticsTo: &d)
     }

--- a/Tests/ManglingTests/ManglingTests.swift
+++ b/Tests/ManglingTests/ManglingTests.swift
@@ -68,7 +68,7 @@ final class ManglingTests: XCTestCase {
 
     let input = SourceFile(synthesizedText: text, named: "main")
     let (p, m) = try checkNoDiagnostic { (d) in
-      var ast = Utils.Host.standardLibraryAST
+      var ast = Utils.Host.hostedLibraryAST
       let main = try ast.makeModule("Main", sourceCode: [input], diagnostics: &d)
       let base = ScopedProgram(ast)
       return (try TypedProgram(annotating: base, reportingDiagnosticsTo: &d), main)
@@ -95,7 +95,7 @@ final class ManglingTests: XCTestCase {
 
   func testTypes() throws {
     let p = try checkNoDiagnostic { (d) in
-      let ast = Host.standardLibraryAST
+      let ast = Host.hostedLibraryAST
       let base = ScopedProgram(ast)
       return try TypedProgram(annotating: base, reportingDiagnosticsTo: &d)
     }


### PR DESCRIPTION
In an attempt to speed up testing, instead of parsing the library each time we need an AST for it as a starting point for testing, store hosted and/or freestanding ASTs in global constants, which are initialized once, lazily and thread-safely in Swift.

Also fixes #932.

## Results

- Debug:
   - Parallel testing (`time swift test --parallel --skip-build`):
      - Before: `440.54s user 23.45s system 834% cpu 55.578 total`
      - After:    `441.36s user 23.85s system 834% cpu 55.723 total`
   - Serial testing  (`time swift test --parallel --skip-build`):
      - Before: `325.20s user 11.28s system 96% cpu 5:49.06 total`
      - After:    `289.28s user 10.43s system 95% cpu 5:13.35 total`
- Release:
   - Parallel testing (`time swift test --parallel --skip-build`):
      - Before: `263.19s user 29.15s system 618% cpu 47.302 total`
      - After:    `264.44s user 28.92s system 624% cpu 46.998 total`
   - Serial testing  (`time swift test --parallel --skip-build`):
      - Before: `211.38s user 15.21s system 144% cpu 2:36.36 total`
      - After:   `186.19s user 14.69s system 155% cpu 2:09.02 total`

The `time` man page is unhelpful but from my experiment (`time sleep 5` yields `0.00s user 0.00s system 0% cpu 5.014 total`), the number we mostly care about is the last one, total.

This change seems to make zero difference if parallel testing is enabled, for reasons I don't understand, and the wins from parallel testing for a developer far outweigh any improvement we get from this change when testing serially.  I think it's still a change worth making.