### PR TITLE
Initial support for the compilation of buffers

### DIFF
--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -608,6 +608,8 @@ extension LLVM.Module {
         insert(addressToPointer: i)
       case is IR.AdvancedByBytes:
         insert(advancedByBytes: i)
+      case is IR.AdvancedByStrides:
+        insert(advancedByStrides: i)
       case is IR.AllocStack:
         insert(allocStack: i)
       case is IR.Access:
@@ -686,6 +688,18 @@ extension LLVM.Module {
       let base = llvm(s.base)
       let v = insertGetElementPointerInBounds(
         of: base, typed: ptr, indices: [llvm(s.byteOffset)], at: insertionPoint)
+      register[.register(i)] = v
+    }
+
+    /// Inserts the transpilation of `i` at `insertionPoint`.
+    func insert(advancedByStrides i: IR.InstructionID) {
+      let s = m[i] as! AdvancedByStrides
+
+      let base = llvm(s.base)
+      let baseType = ir.llvm(m.type(of: s.base).ast, in: &self)
+      let indices = [i32.constant(0), i32.constant(s.offset)]
+      let v = insertGetElementPointerInBounds(
+        of: base, typed: baseType, indices: indices, at: insertionPoint)
       register[.register(i)] = v
     }
 

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -215,6 +215,8 @@ extension LLVM.Module {
     from ir: IR.Program
   ) -> LLVM.IRValue {
     switch c {
+    case let v as IR.WordConstant:
+      return transpiledConstant(v, usedIn: m, from: ir)
     case let v as IR.IntegerConstant:
       return transpiledConstant(v, usedIn: m, from: ir)
     case let v as IR.FloatingPointConstant:
@@ -230,6 +232,13 @@ extension LLVM.Module {
     default:
       unreachable()
     }
+  }
+
+  /// Returns the LLVM IR value corresponding to the Hylo IR constant `c` when used in `m` in `ir`.
+  private mutating func transpiledConstant(
+    _ c: IR.WordConstant, usedIn m: IR.Module, from ir: IR.Program
+  ) -> LLVM.IRValue {
+    word().constant(c.value)
   }
 
   /// Returns the LLVM IR value corresponding to the Hylo IR constant `c` when used in `m` in `ir`.

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -12,6 +12,8 @@ extension IR.Program {
     switch val {
     case let t as AnyType:
       return llvm(t.base, in: &module)
+    case let t as BufferType:
+      return llvm(bufferType: t, in: &module)
     case let t as BuiltinType:
       return llvm(builtinType: t, in: &module)
     case let t as BoundGenericType:
@@ -31,6 +33,17 @@ extension IR.Program {
     default:
       notLLVMRepresentable(val)
     }
+  }
+
+  /// Returns the LLVM form of `val` in `module`.
+  ///
+  /// - Requires: `val` is representable in LLVM.
+  func llvm(bufferType val: BufferType, in module: inout LLVM.Module) -> LLVM.IRType {
+    let e = llvm(val.element, in: &module)
+    guard let n = val.count.asCompilerKnown(Int.self) else {
+      notLLVMRepresentable(val)
+    }
+    return LLVM.ArrayType(n, e, in: &module)
   }
 
   /// Returns the LLVM form of `val` in `module`.

--- a/Sources/Core/CompileTimeValues/CompileTimeValue.swift
+++ b/Sources/Core/CompileTimeValues/CompileTimeValue.swift
@@ -21,6 +21,15 @@ public enum CompileTimeValue: Hashable {
     asType?.base is TypeVariable
   }
 
+  /// The payload of `.compilerKnown` as an instance of `T`.
+  public func asCompilerKnown<T>(_: T.Type) -> T? {
+    if case .compilerKnown(let v) = self {
+      return v as? T
+    } else {
+      return nil
+    }
+  }
+
 }
 
 extension CompileTimeValue: CustomStringConvertible {

--- a/Sources/Core/Types/AnyType.swift
+++ b/Sources/Core/Types/AnyType.swift
@@ -177,7 +177,7 @@ public struct AnyType {
   /// Indicates whether `self` has a record layout.
   public var hasRecordLayout: Bool {
     switch base {
-    case is LambdaType, is ProductType, is TupleType:
+    case is BufferType, is LambdaType, is ProductType, is TupleType:
       return true
     case let type as BoundGenericType:
       return type.base.hasRecordLayout

--- a/Sources/Core/Types/BufferType.swift
+++ b/Sources/Core/Types/BufferType.swift
@@ -1,0 +1,34 @@
+/// The type of a buffer.
+public struct BufferType: TypeProtocol {
+
+  /// The type of the buffer's elements.
+  public let element: AnyType
+
+  /// The number of elements in the buffer.
+  public let count: CompileTimeValue
+
+  /// The structural properties of the type.
+  public let flags: TypeFlags
+
+  /// Creates an instance with the given properties.
+  public init(_ element: AnyType, _ count: CompileTimeValue) {
+    self.element = element
+    self.count = count
+    self.flags = element.flags
+  }
+
+  public func transformParts<M>(
+    mutating m: inout M, _ transformer: (inout M, AnyType) -> TypeTransformAction
+  ) -> Self {
+    BufferType(element.transform(mutating: &m, transformer), count)
+  }
+
+}
+
+extension BufferType: CustomStringConvertible {
+
+  public var description: String {
+    return "\(element)[\(count)]"
+  }
+
+}

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -219,6 +219,12 @@ extension Diagnostic {
   }
 
   static func error(
+    invalidBufferTypeArgumentCount found: Int, at site: SourceRange
+  ) -> Diagnostic {
+    .error("buffer type requires exactly one generic argument (found \(found))", at: site)
+  }
+
+  static func error(
     noViableCandidateToResolve entity: SourceRepresentable<Name>, notes: [Diagnostic]
   ) -> Diagnostic {
     .error("no viable candidate to resolve '\(entity.value)'", at: entity.site, notes: notes)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -4206,6 +4206,8 @@ struct TypeChecker {
     switch e.kind {
     case BooleanLiteralExpr.self:
       return _inferredType(of: BooleanLiteralExpr.ID(e)!, withHint: hint, updating: &obligations)
+    case BufferLiteralExpr.self:
+      return _inferredType(of: BufferLiteralExpr.ID(e)!, withHint: hint, updating: &obligations)
     case CastExpr.self:
       return _inferredType(of: CastExpr.ID(e)!, withHint: hint, updating: &obligations)
     case ConditionalExpr.self:
@@ -4261,6 +4263,36 @@ struct TypeChecker {
     updating obligations: inout ProofObligations
   ) -> AnyType {
     constrain(e, to: ^program.ast.coreType("Bool")!, in: &obligations)
+  }
+
+  /// Returns the inferred type of `e`, updating `obligations` and gathering contextual information
+  /// from `hint`.
+  private mutating func _inferredType(
+    of e: BufferLiteralExpr.ID, withHint hint: AnyType? = nil,
+    updating obligations: inout ProofObligations
+  ) -> AnyType {
+    let elementHint: AnyType
+    if let h = hint, let b = BufferType(canonical(h, in: program[e].scope)) {
+      elementHint = b.element
+    } else {
+      elementHint = ^freshVariable()
+    }
+
+    // If the buffer has no element, we keep the element type open. Othewise, we use the type of
+    // the first element to constrain all others.
+    if let elements = program[e].elements.headAndTail {
+      let head = inferredType(of: elements.head, withHint: elementHint, updating: &obligations)
+      for x in elements.tail {
+        let t = inferredType(of: x, withHint: head, updating: &obligations)
+        let o = ConstraintOrigin(.structural, at: program[x].site)
+        obligations.insert(EqualityConstraint(head, t, origin: o))
+      }
+
+      let n = program[e].elements.count
+      return constrain(e, to: ^BufferType(head, .compilerKnown(n)), in: &obligations)
+    } else {
+      return constrain(e, to: ^BufferType(elementHint, .compilerKnown(0)), in: &obligations)
+    }
   }
 
   /// Returns the inferred type of `e`, updating `obligations` and gathering contextual information
@@ -4678,7 +4710,19 @@ struct TypeChecker {
     // The callee has a metatype and is a name expression bound to a nominal type declaration,
     // meaning that the call is actually a sugared buffer type expression.
     if isBoundToNominalTypeDecl(program[e].callee, in: obligations) {
-      UNIMPLEMENTED()
+      let n = program[e].arguments.count
+      if n != 1 {
+        report(.error(invalidBufferTypeArgumentCount: n, at: program[e].callee.site))
+        return constrain(e, to: .error, in: &obligations)
+      }
+
+      if let a = IntegerLiteralExpr.ID(program[e].arguments[0].value) {
+        let t = MetatypeType(callee)!.instance
+        let r = BufferType(t, .compilerKnown(Int(program[a].value)!))
+        return constrain(e, to: ^MetatypeType(of: r), in: &obligations)
+      } else {
+        UNIMPLEMENTED("arbitrary buffer type argument expression")
+      }
     }
 
     // The callee has a callable type or we need inference to determine its type. Either way,

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -232,6 +232,8 @@ public struct TypedProgram {
     switch t.base {
     case let u as BoundGenericType:
       return storage(of: u)
+    case let u as BufferType:
+      return storage(of: u)
     case let u as LambdaType:
       return storage(of: u)
     case let u as ProductType:
@@ -251,6 +253,15 @@ public struct TypedProgram {
     storage(of: t.base).map { (p) in
       let t = specialize(p.type, for: t.arguments, in: AnyScopeID(base.ast.coreLibrary!))
       return .init(label: p.label, type: t)
+    }
+  }
+
+  /// Returns the names and types of `t`'s stored properties.
+  public func storage(of t: BufferType) -> [TupleType.Element] {
+    if let w = t.count.asCompilerKnown(Int.self) {
+      return Array(repeating: .init(label: nil, type: t.element), count: w)
+    } else {
+      return []
     }
   }
 

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -214,6 +214,8 @@ public struct TypedProgram {
     if !c.implementations.uniqueElement!.value.isSynthetic { return false }
 
     switch model.base {
+    case let u as BufferType:
+      return isTriviallyDeinitializable(u.element, in: scopeOfUse)
     case let u as TupleType:
       return u.elements.allSatisfy({ isTriviallyDeinitializable($0.type, in: scopeOfUse) })
     case let u as UnionType:
@@ -405,6 +407,9 @@ public struct TypedProgram {
     assert(model[.isCanonical])
 
     switch model.base {
+    case let m as BufferType:
+      // FIXME: To remove once conditional conformance is implemented
+      guard conforms(m.element, to: concept, in: scopeOfUse) else { return nil }
     case let m as LambdaType:
       guard allConform(m.captures.map(\.type), to: concept, in: scopeOfUse) else { return nil }
     case let m as TupleType:

--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -171,7 +171,15 @@ extension Instruction {
   /// accessing them.
   fileprivate var isTransparentOffset: Bool {
     switch self {
-    case is AdvancedByBytes, is OpenCapture, is OpenUnion, is SubfieldView, is WrapExistentialAddr:
+    case is AdvancedByStrides:
+      return true
+    case is OpenCapture:
+      return true
+    case is OpenUnion:
+      return true
+    case is SubfieldView:
+      return true
+    case is WrapExistentialAddr:
       return true
     default:
       return false

--- a/Sources/IR/Analysis/Module+CloseBorrows.swift
+++ b/Sources/IR/Analysis/Module+CloseBorrows.swift
@@ -141,6 +141,8 @@ extension Access: LifetimeExtender {}
 
 extension AdvancedByBytes: LifetimeExtender {}
 
+extension AdvancedByStrides: LifetimeExtender {}
+
 extension OpenCapture: LifetimeExtender {}
 
 extension OpenUnion: LifetimeExtender {}

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -177,6 +177,8 @@ extension Module {
         rewrite(addressToPointer: i, to: b)
       case is AdvancedByBytes:
         rewrite(advancedByBytes: i, to: b)
+      case is AdvancedByStrides:
+        rewrite(advancedByStrides: i, to: b)
       case is AllocStack:
         rewrite(allocStack: i, to: b)
       case is Branch:
@@ -259,6 +261,13 @@ extension Module {
       let u = rewritten(s.base)
       let v = rewritten(s.byteOffset)
       append(makeAdvancedByBytes(source: u, offset: v, at: s.site), to: b)
+    }
+
+    /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
+    func rewrite(advancedByStrides i: InstructionID, to b: Block.ID) {
+      let s = sourceModule[i] as! AdvancedByStrides
+      let u = rewritten(s.base)
+      append(makeAdvanced(u, byStrides: s.offset, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -28,6 +28,8 @@ extension Module {
           pc = interpret(addressToPointer: user, in: &context)
         case is AdvancedByBytes:
           pc = interpret(advancedByBytes: user, in: &context)
+        case is AdvancedByStrides:
+          pc = interpret(advancedByStrides: user, in: &context)
         case is AllocStack:
           pc = interpret(allocStack: user, in: &context)
         case is Branch:
@@ -162,6 +164,23 @@ extension Module {
       consume(s.base, with: i, at: s.site, in: &context)
       consume(s.byteOffset, with: i, at: s.site, in: &context)
       initializeRegister(createdBy: i, in: &context)
+      return successor(of: i)
+    }
+
+    /// Interprets `i` in `context`, reporting violations into `diagnostics`.
+    func interpret(advancedByStrides i: InstructionID, in context: inout Context) -> PC? {
+      let s = self[i] as! AdvancedByStrides
+
+      // Operand must a location.
+      let locations: [AbstractLocation]
+      if case .constant = s.base {
+        // Operand is a constant.
+        UNIMPLEMENTED()
+      } else {
+        locations = context.locals[s.base]!.unwrapLocations()!.map({ $0.appending([s.offset]) })
+      }
+
+      context.locals[.register(i)] = .locations(Set(locations))
       return successor(of: i)
     }
 

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2743,10 +2743,10 @@ struct Emitter {
 
     if program.isTriviallyDeinitializable(t, in: insertionScope!) {
       insert(module.makeMarkState(storage, initialized: false, at: site))
-    } else if t.hasRecordLayout {
-      emitDeinitRecordParts(of: storage, at: site)
     } else if t.base is UnionType {
       emitDeinitUnionPayload(of: storage, at: site)
+    } else if t.hasRecordLayout {
+      emitDeinitRecordParts(of: storage, at: site)
     } else {
       report(.error(t, doesNotConformTo: ast.core.deinitializable.type, at: site))
     }

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2776,7 +2776,7 @@ struct Emitter {
     }
   }
 
-  /// If `storage`, which stores a union. is deinitializable in `self.insertionScope`, inserts
+  /// If `storage`, which stores a union, is deinitializable in `self.insertionScope`, inserts
   /// the IR for deinitializing it; reports a diagnostic for each part that isn't
   /// deinitializable otherwise.
   ///

--- a/Sources/IR/Mangling/DemangledType.swift
+++ b/Sources/IR/Mangling/DemangledType.swift
@@ -22,6 +22,9 @@ public indirect enum DemangledType: Hashable {
   /// A bound generic type.
   case boundGeneric(base: DemangledType, arguments: [DemangledSymbol])
 
+  /// A buffer type.
+  case buffer(element: DemangledType, count: Int)
+
   /// A built-in type.
   case builtin(BuiltinType)
 
@@ -96,6 +99,9 @@ extension DemangledType: CustomStringConvertible {
 
     case .boundGeneric(let base, let arguments):
       return "\(base)<\(list: arguments)>"
+
+    case .buffer(let element, let count):
+      return "\(element)[\(count)]"
 
     case .builtin(let t):
       return t.description

--- a/Sources/IR/Mangling/Demangler.swift
+++ b/Sources/IR/Mangling/Demangler.swift
@@ -27,6 +27,8 @@ struct Demangler {
         demangled = take(AssociatedValueDecl.self, qualifiedBy: qualification, from: &stream)
       case .boundGenericType:
         demangled = takeBoundGenericType(from: &stream)
+      case .bufferType:
+        demangled = takeBufferType(from: &stream)
       case .builtinIntegerType:
         demangled = takeBuiltinIntegerType(from: &stream)
       case .builtinFloatType:
@@ -379,6 +381,15 @@ struct Demangler {
     }
 
     return .type(.boundGeneric(base: b, arguments: parameterization))
+  }
+
+  /// Demangles a buffer type from `stream`.
+  private mutating func takeBufferType(from stream: inout Substring) -> DemangledSymbol? {
+    guard
+      let element = demangleType(from: &stream),
+      let count = takeInteger(from: &stream)  // TODO: arbitrary compile-time values
+    else { return nil }
+    return .type(.buffer(element: element, count: Int(count.rawValue)))
   }
 
   /// Demangles a built-in integer type from `stream`.

--- a/Sources/IR/Mangling/Mangler.swift
+++ b/Sources/IR/Mangling/Mangler.swift
@@ -410,9 +410,12 @@ struct Mangler {
 
   /// Writes the mangled representation of `symbol` to `output`.
   mutating func mangle(value symbol: CompileTimeValue, to output: inout Output) {
-    if case .type(let t) = symbol {
+    switch symbol {
+    case .type(let t):
       mangle(type: t, to: &output)
-    } else {
+    case .compilerKnown(let v) where v is Int:
+      write(integer: v as! Int, to: &output)
+    default:
       UNIMPLEMENTED()
     }
   }
@@ -431,6 +434,9 @@ struct Mangler {
 
     case let t as BoundGenericType:
       write(boundGenericType: t, to: &output)
+
+    case let t as BufferType:
+      write(bufferType: t, to: &output)
 
     case let t as BuiltinType:
       write(builtinType: t, to: &output)
@@ -508,6 +514,13 @@ struct Mangler {
     for u in t.arguments.values {
       mangle(value: u, to: &output)
     }
+  }
+
+  /// Writes the mangled representation of `t` to `output`.
+  private mutating func write(bufferType t: BufferType, to output: inout Output) {
+    write(operator: .bufferType, to: &output)
+    mangle(type: t.element, to: &output)
+    mangle(value: t.count, to: &output)
   }
 
   /// Writes the mangled representation of `symbol` to `output`.

--- a/Sources/IR/Mangling/ManglingOperator.swift
+++ b/Sources/IR/Mangling/ManglingOperator.swift
@@ -74,6 +74,8 @@ public enum ManglingOperator: String {
 
   case traitType = "cT"
 
+  case bufferType = "dT"
+
   case existentialTraitType = "eT"
 
   case existentialGenericType = "egT"

--- a/Sources/IR/Operands/Constant/WordConstant.swift
+++ b/Sources/IR/Operands/Constant/WordConstant.swift
@@ -1,0 +1,27 @@
+import Core
+
+// An integer constant that has the size of a machine word.
+public struct WordConstant: Constant, Hashable {
+
+  /// The value of the constant.
+  ///
+  /// The value is stored as a 64-bit integer with the assumption that no supported target use a
+  /// longer machine word.
+  public let value: Int64
+
+  /// Creates a new constant with given `value`.
+  public init(_ value: Int) {
+    self.value = .init(truncatingIfNeeded: value)
+  }
+
+  public var type: IR.`Type` { .object(BuiltinType.word) }
+
+}
+
+extension WordConstant: CustomStringConvertible {
+
+  public var description: String {
+    "\(type.ast)(\(value))"
+  }
+
+}

--- a/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
@@ -1,0 +1,77 @@
+import Core
+
+/// Computes a `source` address advanced by `count` strides of its referred type.
+///
+/// The stride of a type is the number of bytes from the start of an instance to the start of the
+/// next when stored in contiguous memory.
+public struct AdvancedByStrides: Instruction {
+
+  /// The address to be advanced.
+  public private(set) var base: Operand
+
+  /// The number of strides by which to advance the source value.
+  public let offset: Int
+
+  /// The type of the instruction's result.
+  public let result: IR.`Type`?
+
+  /// The site of the code corresponding to that instruction.
+  public let site: SourceRange
+
+  /// Creates an instance with the given properties.
+  fileprivate init(
+    source: Operand,
+    offset: Int,
+    result: IR.`Type`,
+    site: SourceRange
+  ) {
+    self.base = source
+    self.offset = offset
+    self.result = result
+    self.site = site
+  }
+
+  public var operands: [Operand] {
+    [base]
+  }
+
+  public mutating func replaceOperand(at i: Int, with new: Operand) {
+    precondition(i == 0)
+    base = new
+  }
+
+}
+
+extension AdvancedByStrides: CustomStringConvertible {
+
+  public var description: String {
+    "\(base) advanced by \(offset) strides"
+  }
+
+}
+
+extension Module {
+
+  /// Creates an `advanced by strides` instruction anchored at `site` computing the `source`
+  /// address advanced by `n` strides of its referred type.
+  func makeAdvanced(
+    _ source: Operand, byStrides n: Int, at site: SourceRange
+  ) -> AdvancedByStrides {
+    guard let b = sourceType(source) else {
+      preconditionFailure("source must be the address of a buffer")
+    }
+
+    return .init(source: source, offset: n, result: .address(b.element), site: site)
+  }
+
+  /// Returns the AST type of `source` iff it is the address of a buffer.
+  private func sourceType(_ source: Operand) -> BufferType? {
+    let s = type(of: source)
+    if s.isAddress {
+      return BufferType(s.ast)
+    } else {
+      return nil
+    }
+  }
+
+}

--- a/Sources/IR/Operands/Operand.swift
+++ b/Sources/IR/Operands/Operand.swift
@@ -20,7 +20,7 @@ public enum Operand {
 
   /// Returns a built-in integer constant with the size of a machine word.
   public static func word(_ v: Int) -> Operand {
-    .constant(IntegerConstant(v, bitWidth: 64))
+    .constant(WordConstant(v))
   }
 
   /// The ID of the function in which the operand is defined, if any.

--- a/Tests/EndToEndTests/TestCases/BufferInitialization.hylo
+++ b/Tests/EndToEndTests/TestCases/BufferInitialization.hylo
@@ -1,0 +1,8 @@
+//- compileAndRun expecting: success
+
+fun use(_ x: Bool[2]) {}
+
+public fun main() {
+  let x: Bool[2] = [true, true]
+  use(x)
+}


### PR DESCRIPTION
This PR implements some initial support for the compilation of buffer values:
- The type checker supports buffer expressions with constant sizes and can infer the type of buffer literals
- IR lowering can initialize buffer literals
- Code generation can emit pointer offset computation for buffer values
