### PR TITLE
Throw from AST construction instead of swallowing diagnostics.

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -159,7 +159,7 @@ public struct Driver: ParsableCommand {
     let productName = makeProductName(inputs)
 
     /// An instance that includes just the standard library.
-    var ast = freestanding ? Host.freestandingLibraryAST : Host.hostedLibraryAST
+    var ast = try (freestanding ? Host.freestandingLibraryAST : Host.hostedLibraryAST)[]
 
     // The module whose Hylo files were given on the command-line
     let sourceModule = try ast.makeModule(

--- a/Sources/Utils/ResultOrError.swift
+++ b/Sources/Utils/ResultOrError.swift
@@ -1,0 +1,42 @@
+/// A value of type `T` or the error produced by computing that value.
+public enum ResultOrError<T> {
+
+  /// The successful computation.
+  case result(T)
+
+  /// The error thrown by a failed computation.
+  case error(any Error)
+
+  /// The result of `constructResult()` or if it throws, the error it threw.
+  public init(_ constructResult: () throws -> T) {
+    do {
+      self = .result(try constructResult())
+    } catch let e {
+      self = .error(e)
+    }
+  }
+
+  /// The result of the succesful computation if any, or `nil` otherwise.
+  public var result: T? {
+    if case .result(let r) = self { return r }
+    return nil
+  }
+
+  /// The error thrown by the failed computation if any, or `nil` otherwise.
+  public var error: (any Error)? {
+    if case .error(let e) = self { return e }
+    return nil
+  }
+
+  /// Accesses the result of the successful computation if any, or else rethrows the error thrown by
+  /// the computation.
+  public subscript() -> T {
+    get throws {
+      switch self {
+      case .result(let r): return r
+      case .error(let e): throw e
+      }
+    }
+  }
+
+}

--- a/Sources/Utils/ResultOrError.swift
+++ b/Sources/Utils/ResultOrError.swift
@@ -16,7 +16,7 @@ public enum ResultOrError<T> {
     }
   }
 
-  /// The result of the succesful computation if any, or `nil` otherwise.
+  /// The result of the successful computation if any, or `nil` otherwise.
   public var result: T? {
     if case .result(let r) = self { return r }
     return nil

--- a/StandardLibrary/AST+Extensions.swift
+++ b/StandardLibrary/AST+Extensions.swift
@@ -6,20 +6,16 @@ import Utils
 extension AST {
 
   /// Creates an instance that includes the Hylo library whose sources are rooted at `libraryRoot`.
-  init(libraryRoot: URL, for compiler: CompilerConfiguration) {
+  init(libraryRoot: URL, for compiler: CompilerConfiguration) throws {
     self.init(for: compiler)
-    do {
-      var diagnostics = DiagnosticSet()
-      coreLibrary = try makeModule(
-        "Hylo",
-        sourceCode: sourceFiles(in: [libraryRoot]),
-        builtinModuleAccess: true,
-        diagnostics: &diagnostics)
-      assert(isCoreModuleLoaded)
-      self.coreTraits = .init(self)
-    } catch let error {
-      fatalError("Error parsing the Hylo module:\n\(error)")
-    }
+    var diagnostics = DiagnosticSet()
+    coreLibrary = try makeModule(
+      "Hylo",
+      sourceCode: sourceFiles(in: [libraryRoot]),
+      builtinModuleAccess: true,
+      diagnostics: &diagnostics)
+    assert(isCoreModuleLoaded)
+    self.coreTraits = .init(self)
   }
 
 }

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -23,11 +23,11 @@ extension Utils.Host {
   /// An AST representing the whole standard library, conditionally compiled for targeting the host
   /// platform.
   public static let hostedLibraryAST
-    = AST(libraryRoot: hostedLibrarySourceRoot, for: CompilerConfiguration([]))
+    = ResultOrError({ try AST(libraryRoot: hostedLibrarySourceRoot, for: CompilerConfiguration([])) })
 
   /// An AST representing the freestanding core of standard library, conditionally compiled for
   /// targeting the host platform.
   public static let freestandingLibraryAST
-    = AST(libraryRoot: freestandingLibrarySourceRoot, for: CompilerConfiguration(["freestanding"]))
+    = ResultOrError({ try AST(libraryRoot: freestandingLibrarySourceRoot, for: CompilerConfiguration(["freestanding"])) })
 
 }

--- a/Tests/HyloTests/LoweringTests.swift
+++ b/Tests/HyloTests/LoweringTests.swift
@@ -14,7 +14,7 @@ extension XCTestCase {
     try checkAnnotatedHyloFileDiagnostics(inFileAt: hyloFilePath, expectSuccess: expectSuccess) {
       (valSource, diagnostics) in
       // Note: built-in module is visible so that we can test built-in function calls.
-      var ast = Host.freestandingLibraryAST
+      var ast = try Host.freestandingLibraryAST[]
 
       let module = try ast.makeModule(
         valSource.baseName, sourceCode: [valSource], builtinModuleAccess: true,

--- a/Tests/HyloTests/TypeCheckerTests.swift
+++ b/Tests/HyloTests/TypeCheckerTests.swift
@@ -14,7 +14,7 @@ extension XCTestCase {
     try checkAnnotatedHyloFileDiagnostics(inFileAt: hyloFilePath, expectSuccess: expectSuccess) {
       (source, diagnostics) in
 
-      var ast = Host.freestandingLibraryAST
+      var ast = try Host.freestandingLibraryAST[]
 
       _ = try ast.makeModule(
         source.baseName, sourceCode: [source], builtinModuleAccess: true,

--- a/Tests/ManglingTests/ManglingTests.swift
+++ b/Tests/ManglingTests/ManglingTests.swift
@@ -68,7 +68,7 @@ final class ManglingTests: XCTestCase {
 
     let input = SourceFile(synthesizedText: text, named: "main")
     let (p, m) = try checkNoDiagnostic { (d) in
-      var ast = Utils.Host.hostedLibraryAST
+      var ast = try Utils.Host.hostedLibraryAST[]
       let main = try ast.makeModule("Main", sourceCode: [input], diagnostics: &d)
       let base = ScopedProgram(ast)
       return (try TypedProgram(annotating: base, reportingDiagnosticsTo: &d), main)
@@ -95,7 +95,7 @@ final class ManglingTests: XCTestCase {
 
   func testTypes() throws {
     let p = try checkNoDiagnostic { (d) in
-      let ast = Host.hostedLibraryAST
+      let ast = try Host.hostedLibraryAST[]
       let base = ScopedProgram(ast)
       return try TypedProgram(annotating: base, reportingDiagnosticsTo: &d)
     }


### PR DESCRIPTION
If the standard library fails to parse we want to know why.