### PR TITLE
Initial support for monomorphization of generic value parameters

### DIFF
--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -31,6 +31,11 @@ extension Program {
     return (s.kind == TranslationUnit.self) && isPublic(d) && (n == "main")
   }
 
+  /// `true` iff the `Builtin` module is visible in `s`.
+  public func builtinIsVisible(in s: AnyScopeID) -> Bool {
+    ast[module(containing: s)].canAccessBuiltins
+  }
+
   /// Returns whether `child` is contained in `ancestor`.
   ///
   /// Lexical scope containment is transitive and reflexive; this method returns `true` if:

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2490,16 +2490,12 @@ struct TypeChecker {
     case let u as MetatypeType:
       return u.instance
 
-    case is NamespaceType, is TraitType:
+    case is ErrorType, is NamespaceType, is TraitType:
       return t
 
     case let u as RemoteType where u.bareType.base is MetatypeType:
       // FIXME: Workaround to deal with the fact that `remote let T` is ambiguous.
       return ^RemoteType(u.access, MetatypeType(u.bareType)!.instance)
-
-    case is ErrorType:
-      // Diagnostic already reported.
-      return nil
 
     default:
       return nil

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -4054,10 +4054,15 @@ struct TypeChecker {
     var cs = candidate.constraints.union(t.constraints)
 
     let r = candidate.reference.modifyingArguments(mutating: &substitutions) { (s, v) in
-      let w = v.asType ?? UNIMPLEMENTED()
-      let x = instantiate(w, in: ctx, cause: cause, updating: &s)
-      cs.formUnion(x.constraints)
-      return .type(x.shape)
+      switch v {
+      case .type(let w):
+        let x = instantiate(w, in: ctx, cause: cause, updating: &s)
+        cs.formUnion(x.constraints)
+        return .type(x.shape)
+
+      case .compilerKnown:
+        return v
+      }
     }
 
     instantiate(

--- a/Sources/IR/Analysis/AbstractContext.swift
+++ b/Sources/IR/Analysis/AbstractContext.swift
@@ -68,6 +68,17 @@ struct AbstractContext<Domain: AbstractDomain>: Equatable {
     }
   }
 
+  /// Adds a new memory cell in `context` and binds its address to `i`, which is in `m`.
+  mutating func declareStorage(
+    assignedTo i: InstructionID, in m: Module, initially initialState: Domain
+  ) {
+    let t = m.type(of: .register(i)).ast
+    let l = AbstractTypeLayout(of: t, definedIn: m.program)
+    let a = AbstractLocation.root(.register(i))
+    memory[a] = .init(layout: l, value: .full(initialState))
+    locals[.register(i)] = .locations([a])
+  }
+
 }
 
 extension AbstractContext: CustomStringConvertible {

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -211,8 +211,8 @@ extension Module {
         rewrittenInstructions[i] = rewrite(endBorrow: i, to: b)
       case is EndProject:
         rewrittenInstructions[i] = rewrite(endProject: i, to: b)
-      case is GenericArgument:
-        rewrittenInstructions[i] = rewrite(genericArgument: i, to: b)
+      case is GenericParameter:
+        rewrittenInstructions[i] = rewrite(genericParameter: i, to: b)
       case is GlobalAddr:
         rewrittenInstructions[i] = rewrite(globalAddr: i, to: b)
       case is LLVMInstruction:
@@ -365,8 +365,8 @@ extension Module {
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(genericArgument i: InstructionID, to b: Block.ID) -> InstructionID {
-      let s = sourceModule[i] as! GenericArgument
+    func rewrite(genericParameter i: InstructionID, to b: Block.ID) -> InstructionID {
+      let s = sourceModule[i] as! GenericParameter
       return rewrittenGenericValues[s.parameter]!
     }
 

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -172,243 +172,242 @@ extension Module {
     func rewrite(_ i: InstructionID, to b: Block.ID) {
       switch sourceModule[i] {
       case is Access:
-        rewrite(access: i, to: b)
+        rewrittenInstructions[i] = rewrite(access: i, to: b)
       case is AddressToPointer:
-        rewrite(addressToPointer: i, to: b)
+        rewrittenInstructions[i] = rewrite(addressToPointer: i, to: b)
       case is AdvancedByBytes:
-        rewrite(advancedByBytes: i, to: b)
+        rewrittenInstructions[i] = rewrite(advancedByBytes: i, to: b)
       case is AdvancedByStrides:
-        rewrite(advancedByStrides: i, to: b)
+        rewrittenInstructions[i] = rewrite(advancedByStrides: i, to: b)
       case is AllocStack:
-        rewrite(allocStack: i, to: b)
+        rewrittenInstructions[i] = rewrite(allocStack: i, to: b)
       case is Branch:
-        rewrite(branch: i, to: b)
+        rewrittenInstructions[i] = rewrite(branch: i, to: b)
       case is Call:
-        rewrite(call: i, to: b)
+        rewrittenInstructions[i] = rewrite(call: i, to: b)
       case is CallFFI:
-        rewrite(callFFI: i, to: b)
+        rewrittenInstructions[i] = rewrite(callFFI: i, to: b)
       case is CaptureIn:
-        rewrite(captureIn: i, to: b)
+        rewrittenInstructions[i] = rewrite(captureIn: i, to: b)
       case is CloseCapture:
-        rewrite(closeUnion: i, to: b)
+        rewrittenInstructions[i] = rewrite(closeUnion: i, to: b)
       case is CloseUnion:
-        rewrite(closeUnion: i, to: b)
+        rewrittenInstructions[i] = rewrite(closeUnion: i, to: b)
       case is CondBranch:
-        rewrite(condBranch: i, to: b)
+        rewrittenInstructions[i] = rewrite(condBranch: i, to: b)
       case is ConstantString:
-        rewrite(constantString: i, to: b)
+        rewrittenInstructions[i] = rewrite(constantString: i, to: b)
       case is DeallocStack:
-        rewrite(deallocStack: i, to: b)
+        rewrittenInstructions[i] = rewrite(deallocStack: i, to: b)
       case is EndAccess:
-        rewrite(endBorrow: i, to: b)
+        rewrittenInstructions[i] = rewrite(endBorrow: i, to: b)
       case is EndProject:
-        rewrite(endProject: i, to: b)
+        rewrittenInstructions[i] = rewrite(endProject: i, to: b)
       case is GlobalAddr:
-        rewrite(globalAddr: i, to: b)
+        rewrittenInstructions[i] = rewrite(globalAddr: i, to: b)
       case is LLVMInstruction:
-        rewrite(llvm: i, to: b)
+        rewrittenInstructions[i] = rewrite(llvm: i, to: b)
       case is Load:
-        rewrite(load: i, to: b)
+        rewrittenInstructions[i] = rewrite(load: i, to: b)
       case is MarkState:
-        rewrite(markState: i, to: b)
+        rewrittenInstructions[i] = rewrite(markState: i, to: b)
       case is OpenCapture:
-        rewrite(openCapture: i, to: b)
+        rewrittenInstructions[i] = rewrite(openCapture: i, to: b)
       case is OpenUnion:
-        rewrite(openUnion: i, to: b)
+        rewrittenInstructions[i] = rewrite(openUnion: i, to: b)
       case is PointerToAddress:
-        rewrite(pointerToAddress: i, to: b)
+        rewrittenInstructions[i] = rewrite(pointerToAddress: i, to: b)
       case is Project:
-        rewrite(project: i, to: b)
+        rewrittenInstructions[i] = rewrite(project: i, to: b)
       case is ReleaseCaptures:
-        rewrite(releaseCaptures: i, to: b)
+        rewrittenInstructions[i] = rewrite(releaseCaptures: i, to: b)
       case is Return:
-        rewrite(return: i, to: b)
+        rewrittenInstructions[i] = rewrite(return: i, to: b)
       case is Store:
-        rewrite(store: i, to: b)
+        rewrittenInstructions[i] = rewrite(store: i, to: b)
       case is SubfieldView:
-        rewrite(subfieldView: i, to: b)
+        rewrittenInstructions[i] = rewrite(subfieldView: i, to: b)
       case is Switch:
-        rewrite(switch: i, to: b)
+        rewrittenInstructions[i] = rewrite(switch: i, to: b)
       case is UnionDiscriminator:
-        rewrite(unionDiscriminator: i, to: b)
+        rewrittenInstructions[i] = rewrite(unionDiscriminator: i, to: b)
       case is Unreachable:
-        rewrite(unreachable: i, to: b)
+        rewrittenInstructions[i] = rewrite(unreachable: i, to: b)
       case is Yield:
-        rewrite(yield: i, to: b)
+        rewrittenInstructions[i] = rewrite(yield: i, to: b)
       default:
         UNIMPLEMENTED()
       }
-      rewrittenInstructions[i] = InstructionID(b, self[b].instructions.lastAddress!)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(access i: InstructionID, to b: Block.ID) {
+    func rewrite(access i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Access
       let newInstruction = makeAccess(s.capabilities, from: rewritten(s.source), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(addressToPointer i: InstructionID, to b: Block.ID) {
+    func rewrite(addressToPointer i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! AddressToPointer
       let newInstruction = makeAddressToPointer(rewritten(s.source), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(advancedByBytes i: InstructionID, to b: Block.ID) {
+    func rewrite(advancedByBytes i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! AdvancedByBytes
       let u = rewritten(s.base)
       let v = rewritten(s.byteOffset)
-      append(makeAdvancedByBytes(source: u, offset: v, at: s.site), to: b)
+      return append(makeAdvancedByBytes(source: u, offset: v, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(advancedByStrides i: InstructionID, to b: Block.ID) {
+    func rewrite(advancedByStrides i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! AdvancedByStrides
       let u = rewritten(s.base)
-      append(makeAdvanced(u, byStrides: s.offset, at: s.site), to: b)
+      return append(makeAdvanced(u, byStrides: s.offset, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(allocStack i: InstructionID, to b: Block.ID) {
+    func rewrite(allocStack i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! AllocStack
       let t = monomorphize(s.allocatedType, for: specialization, in: scopeOfUse)
-      append(makeAllocStack(t, at: s.site), to: b)
+      return append(makeAllocStack(t, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(branch i: InstructionID, to b: Block.ID) {
+    func rewrite(branch i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Branch
-      append(makeBranch(to: rewrittenBlocks[s.target]!, at: s.site), to: b)
+      return append(makeBranch(to: rewrittenBlocks[s.target]!, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(call i: InstructionID, to b: Block.ID) {
+    func rewrite(call i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Call
       let f = rewritten(s.callee)
       let a = s.arguments.map(rewritten(_:))
       let o = rewritten(s.output)
-      append(makeCall(applying: f, to: a, writingResultTo: o, at: s.site), to: b)
+      return append(makeCall(applying: f, to: a, writingResultTo: o, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(callFFI i: InstructionID, to b: Block.ID) {
+    func rewrite(callFFI i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! CallFFI
       let t = monomorphize(s.returnType, for: specialization, in: scopeOfUse)
       let o = s.operands.map(rewritten(_:))
-      append(makeCallFFI(returning: t, applying: s.callee, to: o, at: s.site), to: b)
+      return append(makeCallFFI(returning: t, applying: s.callee, to: o, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(captureIn i: InstructionID, to b: Block.ID) {
+    func rewrite(captureIn i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! CaptureIn
       let newInstruction = makeCapture(rewritten(s.source), in: rewritten(s.target), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(closeCapture i: InstructionID, to b: Block.ID) {
+    func rewrite(closeCapture i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! CloseCapture
-      append(makeCloseCapture(rewritten(s.start), at: s.site), to: b)
+      return append(makeCloseCapture(rewritten(s.start), at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(closeUnion i: InstructionID, to b: Block.ID) {
+    func rewrite(closeUnion i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! CloseUnion
-      append(makeCloseUnion(rewritten(s.start), at: s.site), to: b)
+      return append(makeCloseUnion(rewritten(s.start), at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(condBranch i: InstructionID, to b: Block.ID) {
+    func rewrite(condBranch i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! CondBranch
       let c = rewritten(s.condition)
 
       let newInstruction = makeCondBranch(
         if: c, then: rewrittenBlocks[s.targetIfTrue]!, else: rewrittenBlocks[s.targetIfFalse]!,
         at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(constantString i: InstructionID, to b: Block.ID) {
+    func rewrite(constantString i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! ConstantString
-      append(makeConstantString(utf8: s.value, at: s.site), to: b)
+      return append(makeConstantString(utf8: s.value, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(deallocStack i: InstructionID, to b: Block.ID) {
+    func rewrite(deallocStack i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! DeallocStack
       let newInstruction = makeDeallocStack(for: rewritten(s.location), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(endBorrow i: InstructionID, to b: Block.ID) {
+    func rewrite(endBorrow i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! EndAccess
-      append(makeEndAccess(rewritten(s.start), at: s.site), to: b)
+      return append(makeEndAccess(rewritten(s.start), at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(endProject i: InstructionID, to b: Block.ID) {
+    func rewrite(endProject i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! EndProject
-      append(makeEndProject(rewritten(s.start), at: s.site), to: b)
+      return append(makeEndProject(rewritten(s.start), at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(globalAddr i: InstructionID, to b: Block.ID) {
+    func rewrite(globalAddr i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! GlobalAddr
-      append(makeGlobalAddr(of: s.binding, at: s.site), to: b)
+      return append(makeGlobalAddr(of: s.binding, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(llvm i: InstructionID, to b: Block.ID) {
+    func rewrite(llvm i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! LLVMInstruction
       let o = s.operands.map(rewritten(_:))
-      append(makeLLVM(applying: s.instruction, to: o, at: s.site), to: b)
+      return append(makeLLVM(applying: s.instruction, to: o, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(markState i: InstructionID, to b: Block.ID) {
+    func rewrite(markState i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! MarkState
       let o = rewritten(s.storage)
-      append(makeMarkState(o, initialized: s.initialized, at: s.site), to: b)
+      return append(makeMarkState(o, initialized: s.initialized, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(load i: InstructionID, to b: Block.ID) {
+    func rewrite(load i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Load
-      append(makeLoad(rewritten(s.source), at: s.site), to: b)
+      return append(makeLoad(rewritten(s.source), at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(openCapture i: InstructionID, to b: Block.ID) {
+    func rewrite(openCapture i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! OpenCapture
       let newInstruction = makeOpenCapture(rewritten(s.source), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(openUnion i: InstructionID, to b: Block.ID) {
+    func rewrite(openUnion i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! OpenUnion
       let t = monomorphize(s.payloadType, for: specialization, in: scopeOfUse)
       let c = rewritten(s.container)
       let newInstruction = makeOpenUnion(
         c, as: t, forInitialization: s.isUsedForInitialization, at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(pointerToAddress i: InstructionID, to b: Block.ID) {
+    func rewrite(pointerToAddress i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! PointerToAddress
       let t = monomorphize(^s.target, for: specialization, in: scopeOfUse)
       let newInstruction = makePointerToAddress(
         rewritten(s.source), to: RemoteType(t)!, at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(project i: InstructionID, to b: Block.ID) {
+    func rewrite(project i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Project
 
       let newCallee: Function.ID
@@ -423,65 +422,65 @@ extension Module {
       let a = s.operands.map(rewritten(_:))
       let newInstruction = makeProject(
         projection, applying: newCallee, specializedBy: [:], to: a, at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(releaseCaptures i: InstructionID, to b: Block.ID) {
+    func rewrite(releaseCaptures i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! ReleaseCaptures
       let newInstruction = makeReleaseCapture(rewritten(s.container), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(return i: InstructionID, to b: Block.ID) {
+    func rewrite(return i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Return
-      append(makeReturn(at: s.site), to: b)
+      return append(makeReturn(at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(store i: InstructionID, to b: Block.ID) {
+    func rewrite(store i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Store
       let v = rewritten(s.object)
       let u = rewritten(s.target)
-      append(makeStore(v, at: u, at: s.site), to: b)
+      return append(makeStore(v, at: u, at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(subfieldView i: InstructionID, to b: Block.ID) {
+    func rewrite(subfieldView i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! SubfieldView
       let a = rewritten(s.recordAddress)
       let newInstruction = makeSubfieldView(of: a, subfield: s.subfield, at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(switch i: InstructionID, to b: Block.ID) {
+    func rewrite(switch i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Switch
       let n = rewritten(s.index)
       let newInstruction = makeSwitch(
         on: n, toOneOf: s.successors.map({ rewrittenBlocks[$0]! }), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(unionDiscriminator i: InstructionID, to b: Block.ID) {
+    func rewrite(unionDiscriminator i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! UnionDiscriminator
       let newInstruction = makeUnionDiscriminator(rewritten(s.container), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(unreachable i: InstructionID, to b: Block.ID) {
+    func rewrite(unreachable i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Unreachable
-      append(makeUnreachable(at: s.site), to: b)
+      return append(makeUnreachable(at: s.site), to: b)
     }
 
     /// Rewrites `i`, which is in `r.function`, into `result`, at the end of `b`.
-    func rewrite(yield i: InstructionID, to b: Block.ID) {
+    func rewrite(yield i: InstructionID, to b: Block.ID) -> InstructionID {
       let s = sourceModule[i] as! Yield
       let newInstruction = makeYield(s.capability, rewritten(s.projection), at: s.site)
-      append(newInstruction, to: b)
+      return append(newInstruction, to: b)
     }
 
     /// Returns a monomorphized copy of `c` monomorphized for use in `scopeOfuse`.

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -148,13 +148,7 @@ extension Module {
       // Create an abstract location denoting the newly allocated memory.
       let l = AbstractLocation.root(.register(i))
       precondition(context.memory[l] == nil, "stack leak")
-
-      // Update the context.
-      let s = self[i] as! AllocStack
-      let t = AbstractTypeLayout(of: s.allocatedType, definedIn: program)
-
-      context.memory[l] = .init(layout: t, value: .full(.uninitialized))
-      context.locals[.register(i)] = .locations([l])
+      context.declareStorage(assignedTo: i, in: self, initially: .uninitialized)
       return successor(of: i)
     }
 
@@ -339,12 +333,7 @@ extension Module {
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.
     func interpret(globalAddr i: InstructionID, in context: inout Context) -> PC? {
-      let l = AbstractLocation.root(.register(i))
-      context.memory[l] = .init(
-        layout: AbstractTypeLayout(
-          of: (self[i] as! GlobalAddr).valueType, definedIn: program),
-        value: .full(.initialized))
-      context.locals[.register(i)] = .locations([l])
+      context.declareStorage(assignedTo: i, in: self, initially: .initialized)
       return successor(of: i)
     }
 

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -56,6 +56,8 @@ extension Module {
           pc = interpret(endProject: user, in: &context)
         case is EndProjectWitness:
           pc = interpret(endProjectWitness: user, in: &context)
+        case is GenericArgument:
+          pc = interpret(genericArgument: user, in: &context)
         case is GlobalAddr:
           pc = interpret(globalAddr: user, in: &context)
         case is LLVMInstruction:
@@ -328,6 +330,12 @@ extension Module {
       finalize(
         region: s.start, projecting: r.projection.access, from: sources,
         exitedWith: i, in: &context)
+      return successor(of: i)
+    }
+
+    /// Interprets `i` in `context`, reporting violations into `diagnostics`.
+    func interpret(genericArgument i: InstructionID, in context: inout Context) -> PC? {
+      context.declareStorage(assignedTo: i, in: self, initially: .initialized)
       return successor(of: i)
     }
 

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -56,8 +56,8 @@ extension Module {
           pc = interpret(endProject: user, in: &context)
         case is EndProjectWitness:
           pc = interpret(endProjectWitness: user, in: &context)
-        case is GenericArgument:
-          pc = interpret(genericArgument: user, in: &context)
+        case is GenericParameter:
+          pc = interpret(genericParameter: user, in: &context)
         case is GlobalAddr:
           pc = interpret(globalAddr: user, in: &context)
         case is LLVMInstruction:
@@ -334,7 +334,7 @@ extension Module {
     }
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.
-    func interpret(genericArgument i: InstructionID, in context: inout Context) -> PC? {
+    func interpret(genericParameter i: InstructionID, in context: inout Context) -> PC? {
       context.declareStorage(assignedTo: i, in: self, initially: .initialized)
       return successor(of: i)
     }

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -145,7 +145,7 @@ extension Module {
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.
     func interpret(allocStack i: InstructionID, in context: inout Context) -> PC? {
-      // Create an abstract location denoting the newly allocated memory.
+      // A stack leak may occur if this instruction is in a loop.
       let l = AbstractLocation.root(.register(i))
       precondition(context.memory[l] == nil, "stack leak")
       context.declareStorage(assignedTo: i, in: self, initially: .uninitialized)

--- a/Sources/IR/Analysis/Module+Ownership.swift
+++ b/Sources/IR/Analysis/Module+Ownership.swift
@@ -35,8 +35,8 @@ extension Module {
           interpret(endProject: user, in: &context)
         case is EndProject:
           interpret(endProjectWitness: user, in: &context)
-        case is GenericArgument:
-          interpret(genericArgument: user, in: &context)
+        case is GenericParameter:
+          interpret(genericParameter: user, in: &context)
         case is GlobalAddr:
           interpret(globalAddr: user, in: &context)
         case is OpenCapture:
@@ -213,7 +213,7 @@ extension Module {
     }
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.
-    func interpret(genericArgument i: InstructionID, in context: inout Context) {
+    func interpret(genericParameter i: InstructionID, in context: inout Context) {
       context.declareStorage(assignedTo: i, in: self, initially: .unique)
     }
 

--- a/Sources/IR/Analysis/Module+Ownership.swift
+++ b/Sources/IR/Analysis/Module+Ownership.swift
@@ -136,14 +136,9 @@ extension Module {
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.
     func interpret(allocStack i: InstructionID, in context: inout Context) {
-      let s = self[i] as! AllocStack
       let l = AbstractLocation.root(.register(i))
       precondition(context.memory[l] == nil, "stack leak")
-
-      context.memory[l] = .init(
-        layout: AbstractTypeLayout(of: s.allocatedType, definedIn: program),
-        value: .full(.unique))
-      context.locals[.register(i)] = .locations([l])
+      context.declareStorage(assignedTo: i, in: self, initially: .unique)
     }
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.
@@ -219,13 +214,7 @@ extension Module {
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.
     func interpret(globalAddr i: InstructionID, in context: inout Context) {
-      let s = self[i] as! GlobalAddr
-      let l = AbstractLocation.root(.register(i))
-
-      context.memory[l] = .init(
-        layout: AbstractTypeLayout(of: s.valueType, definedIn: program),
-        value: .full(.unique))
-      context.locals[.register(i)] = .locations([l])
+      context.declareStorage(assignedTo: i, in: self, initially: .unique)
     }
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.

--- a/Sources/IR/Analysis/Module+Ownership.swift
+++ b/Sources/IR/Analysis/Module+Ownership.swift
@@ -136,8 +136,6 @@ extension Module {
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.
     func interpret(allocStack i: InstructionID, in context: inout Context) {
-      let l = AbstractLocation.root(.register(i))
-      precondition(context.memory[l] == nil, "stack leak")
       context.declareStorage(assignedTo: i, in: self, initially: .unique)
     }
 

--- a/Sources/IR/Analysis/Module+Ownership.swift
+++ b/Sources/IR/Analysis/Module+Ownership.swift
@@ -35,6 +35,8 @@ extension Module {
           interpret(endProject: user, in: &context)
         case is EndProject:
           interpret(endProjectWitness: user, in: &context)
+        case is GenericArgument:
+          interpret(genericArgument: user, in: &context)
         case is GlobalAddr:
           interpret(globalAddr: user, in: &context)
         case is OpenCapture:
@@ -208,6 +210,11 @@ extension Module {
       let s = self[i] as! EndProjectWitness
       let r = self[s.start.instruction!] as! Project
       finalize(region: s.start, projecting: r.projection.access, exitedWith: i, in: &context)
+    }
+
+    /// Interprets `i` in `context`, reporting violations into `diagnostics`.
+    func interpret(genericArgument i: InstructionID, in context: inout Context) {
+      context.declareStorage(assignedTo: i, in: self, initially: .unique)
     }
 
     /// Interprets `i` in `context`, reporting violations into `diagnostics`.

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2525,7 +2525,7 @@ struct Emitter {
 
     switch d.kind {
     case GenericParameterDecl.self:
-      return insert(module.makeGenericArgument(passedTo: .init(d)!, at: site))!
+      return insert(module.makeGenericParameter(passedTo: .init(d)!, at: site))!
 
     case VarDecl.self:
       let (root, subfied) = program.subfieldRelativeToRoot(of: .init(d)!)

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1705,10 +1705,11 @@ struct Emitter {
   /// Writes an instance of `Hylo.Int` with value `v` to `storage`.
   ///
   /// - Requires: `storage` is the address of uninitialized memory of type `Hylo.Int`.
-  private mutating func emitStore(int v: Int, to storage: Operand, at site: SourceRange) {
+  mutating func emitStore(int v: Int, to storage: Operand, at site: SourceRange) {
     let x0 = emitSubfieldView(storage, at: [0], at: site)
     let x1 = insert(module.makeAccess(.set, from: x0, at: site))!
     insert(module.makeStore(.word(v), at: x1, at: site))
+    insert(module.makeEndAccess(x1, at: site))
   }
 
   /// Writes an instance of `Hylo.String` with value `v` to `storage`.

--- a/Sources/IR/Operands/Instruction/GenericArgument.swift
+++ b/Sources/IR/Operands/Instruction/GenericArgument.swift
@@ -1,0 +1,49 @@
+import Core
+
+/// Accesses the value passed to a generic parameter.
+public struct GenericArgument: Instruction {
+
+  /// The parameter whose value is accessed.
+  public let parameter: GenericParameterDecl.ID
+
+  /// The type of the instruction's result.
+  public let result: IR.`Type`?
+
+  /// The site of the code corresponding to that instruction.
+  public let site: SourceRange
+
+  /// Creates an instance with the given properties.
+  fileprivate init(
+    parameter: GenericParameterDecl.ID,
+    result: IR.`Type`,
+    site: SourceRange
+  ) {
+    self.parameter = parameter
+    self.result = result
+    self.site = site
+  }
+
+  public mutating func replaceOperand(at i: Int, with new: Operand) {
+    preconditionFailure()
+  }
+
+}
+
+extension GenericArgument: CustomStringConvertible {
+
+  public var description: String {
+    "generic_argument @\(parameter)"
+  }
+
+}
+
+extension Module {
+
+  /// Creates an `global_addr` anchored at `site` that returns the address of `binding`.
+  func makeGenericArgument(
+    passedTo p: GenericParameterDecl.ID, at site: SourceRange
+  ) -> GenericArgument {
+    .init(parameter: p, result: .address(program[p].type), site: site)
+  }
+
+}

--- a/Sources/IR/Operands/Instruction/GenericParameter.swift
+++ b/Sources/IR/Operands/Instruction/GenericParameter.swift
@@ -1,7 +1,7 @@
 import Core
 
 /// Accesses the value passed to a generic parameter.
-public struct GenericArgument: Instruction {
+public struct GenericParameter: Instruction {
 
   /// The parameter whose value is accessed.
   public let parameter: GenericParameterDecl.ID
@@ -29,20 +29,21 @@ public struct GenericArgument: Instruction {
 
 }
 
-extension GenericArgument: CustomStringConvertible {
+extension GenericParameter: CustomStringConvertible {
 
   public var description: String {
-    "generic_argument @\(parameter)"
+    "generic_parameter @\(parameter)"
   }
 
 }
 
 extension Module {
 
-  /// Creates an `global_addr` anchored at `site` that returns the address of `binding`.
-  func makeGenericArgument(
+  /// Creates an `generic_parameter` anchored at `site` that returns the address of the generic
+  /// argument passed to `p`.
+  func makeGenericParameter(
     passedTo p: GenericParameterDecl.ID, at site: SourceRange
-  ) -> GenericArgument {
+  ) -> GenericParameter {
     .init(parameter: p, result: .address(program[p].type), site: site)
   }
 

--- a/Tests/EndToEndTests/TestCases/GenericValueParameter.hylo
+++ b/Tests/EndToEndTests/TestCases/GenericValueParameter.hylo
@@ -1,0 +1,9 @@
+//- compileAndRun expecting: success
+
+public fun foo<n: Int>() -> Int {
+  n.copy()
+}
+
+public fun main() {
+  precondition(foo<42>() == 42)
+}


### PR DESCRIPTION
This PR stands up support for monomorphizing code involving generic value parameters.

Before depolymorphization, references generic value parameters are represented with a new IR instruction, `generic_argument`, which introduces initialized storage. In monomorphized form, generic value parameters are rewritten as local variables allocated and initialized before the first instruction of the generic function and uses of `generic_argument` are replaced by uses of the corresponding stack allocations.

