### PR TITLE
Suppress the nasty unhandled source warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -171,18 +171,21 @@ let package = Package(
     .testTarget(
       name: "HyloTests",
       dependencies: ["Core", "FrontEnd", "IR", "TestUtils", "StandardLibrary"],
+      exclude: ["TestCases"],
       swiftSettings: allTargetsSwiftSettings,
       plugins: ["TestGeneratorPlugin"]),
 
     .testTarget(
       name: "EndToEndTests",
       dependencies: ["Driver", "TestUtils"],
+      exclude: ["TestCases"],
       swiftSettings: allTargetsSwiftSettings,
       plugins: ["TestGeneratorPlugin"]),
 
     .testTarget(
       name: "LibraryTests",
       dependencies: ["Driver", "TestUtils"],
+      exclude: ["TestCases"],
       swiftSettings: allTargetsSwiftSettings,
       plugins: ["TestGeneratorPlugin"]),
   ]


### PR DESCRIPTION
Don't treat the plugin inputs as source files and instead exclude them in Package.swift; then, instead of using target.sourceFiles(withSuffix: ".hylo") to find them, scrape target.directory for the .hylo files.  Whether they are treated as sources are not has no bearing on whether they get linked into the build dependency graph.