### PR TITLE
Implement implicit parameters

### DIFF
--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -281,20 +281,23 @@ public struct AST {
   /// Returns a table mapping each parameter of `d` to its default argument if `d` is a function,
   /// initializer, method or subscript declaration; otherwise, returns `nil`.
   public func defaultArguments(of d: AnyDeclID) -> [AnyExprID?]? {
-    let parameters: [ParameterDecl.ID]
+    runtimeParameters(of: d)?.map({ self[$0].defaultValue })
+  }
+
+  /// Returns the run-time parameters of `d` iff `d` is callable.
+  public func runtimeParameters(of d: AnyDeclID) -> [ParameterDecl.ID]? {
     switch d.kind {
     case FunctionDecl.self:
-      parameters = self[FunctionDecl.ID(d)!].parameters
+      return self[FunctionDecl.ID(d)!].parameters
     case InitializerDecl.self:
-      parameters = self[InitializerDecl.ID(d)!].parameters
+      return self[InitializerDecl.ID(d)!].parameters
     case MethodDecl.self:
-      parameters = self[MethodDecl.ID(d)!].parameters
+      return self[MethodDecl.ID(d)!].parameters
     case SubscriptDecl.self:
-      parameters = self[SubscriptDecl.ID(d)!].parameters
+      return self[SubscriptDecl.ID(d)!].parameters
     default:
       return nil
     }
-    return self[parameters].map(\.defaultValue)
   }
 
   /// Returns the generic parameters introduced by `d`.

--- a/Sources/Core/AST/Decl/BindingDecl.swift
+++ b/Sources/Core/AST/Decl/BindingDecl.swift
@@ -20,6 +20,9 @@ public struct BindingDecl: ExposableDecl {
   /// The initializer of the declaration, if any.
   public let initializer: AnyExprID?
 
+  /// `true` iff the declaration is defining an implicit.
+  public let isGiven: Bool
+
   /// Creates an instance with the given properties.
   public init(
     attributes: [SourceRepresentable<Attribute>] = [],
@@ -35,6 +38,7 @@ public struct BindingDecl: ExposableDecl {
     self.memberModifier = memberModifier
     self.pattern = pattern
     self.initializer = initializer
+    self.isGiven = attributes.contains(where: { $0.value.name.value == "@given" })
   }
 
   /// Returns whether the declaration denotes a static member.

--- a/Sources/Core/AST/Decl/ParameterDecl.swift
+++ b/Sources/Core/AST/Decl/ParameterDecl.swift
@@ -17,11 +17,15 @@ public struct ParameterDecl: SingleEntityDecl {
   /// The default value of the declaration, if any.
   public let defaultValue: AnyExprID?
 
+  /// `true` if arguments to the parameter can be passed implicitly.
+  public let isImplicit: Bool
+
   public init(
     label: SourceRepresentable<Identifier>? = nil,
     identifier: SourceRepresentable<Identifier>,
     annotation: ParameterTypeExpr.ID? = nil,
     defaultValue: AnyExprID? = nil,
+    isImplicit: Bool = false,
     site: SourceRange
   ) {
     self.site = site
@@ -29,6 +33,7 @@ public struct ParameterDecl: SingleEntityDecl {
     self.identifier = identifier
     self.annotation = annotation
     self.defaultValue = defaultValue
+    self.isImplicit = isImplicit
   }
 
   public var baseName: String { identifier.value }

--- a/Sources/Core/AST/Expr/FoldedSequenceExpr.swift
+++ b/Sources/Core/AST/Expr/FoldedSequenceExpr.swift
@@ -4,10 +4,10 @@
 /// once the precedence groups of its operators have been determined. A tree is created by calling
 /// `append(operator:right:)` to append an operator and its right operand to the sub-sequence
 /// represented by `self`.
-public indirect enum FoldedSequenceExpr: Equatable {
+public indirect enum FoldedSequenceExpr: Hashable {
 
   /// The expression of an operator in the AST together with its precedence.
-  public struct Operator: Equatable {
+  public struct Operator: Hashable {
 
     /// The expression of an operator.
     public let expr: NameExpr.ID

--- a/Sources/Core/AST/NodeIDs/CallID.swift
+++ b/Sources/Core/AST/NodeIDs/CallID.swift
@@ -1,0 +1,20 @@
+/// The identity of a call expression.
+public enum CallID: Hashable {
+
+  case ast(AnyExprID)
+
+  case infix(FoldedSequenceExpr)
+
+  public init(_ e: FunctionCallExpr.ID) {
+    self = .ast(AnyExprID(e))
+  }
+
+  public init(_ e: SubscriptCallExpr.ID) {
+    self = .ast(AnyExprID(e))
+  }
+
+  public init(_ e: FoldedSequenceExpr) {
+    self = .infix(e)
+  }
+
+}

--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -335,6 +335,17 @@ extension Program {
     }
   }
 
+  /// Returns `true` iff `d` declares a value usable as an implicit parameter.
+  public func isImplicitDefinition(_ d: AnyDeclID) -> Bool {
+    if let i = VarDecl.ID(d) {
+      return ast[varToBinding[i]]!.isGiven
+    } else if let i = ParameterDecl.ID(d) {
+      return ast[i].isImplicit
+    } else {
+      return false
+    }
+  }
+
   /// If `s` is in a member context, returns the innermost receiver declaration exposed to `s`.
   /// Otherwise, returns `nil`
   public func innermostReceiver(in useScope: AnyScopeID) -> ParameterDecl.ID? {

--- a/Sources/Core/Types/CallableType.swift
+++ b/Sources/Core/Types/CallableType.swift
@@ -35,7 +35,7 @@ private func accepts<S: Collection>(
     return rhs.isEmpty
   } else if lhs.first!.label == rhs.first {
     return accepts(lhs.dropFirst(), rhs.dropFirst())
-  } else if lhs.first!.hasDefault {
+  } else if lhs.first!.isElidible {
     return accepts(lhs.dropFirst(), rhs)
   } else {
     return false

--- a/Sources/Core/Types/CallableTypeParameter.swift
+++ b/Sources/Core/Types/CallableTypeParameter.swift
@@ -11,21 +11,21 @@ public struct CallableTypeParameter: Hashable {
   public let hasDefault: Bool
 
   /// `true` if arguments to the parameter can be passed implicitly.
-  public let isImplict: Bool
+  public let isImplicit: Bool
 
   /// Creates an instance with the given properties.
   public init(
-    label: String? = nil, type: AnyType, hasDefault: Bool = false, isImplict: Bool = false
+    label: String? = nil, type: AnyType, hasDefault: Bool = false, isImplicit: Bool = false
   ) {
     self.label = label
     self.type = type
     self.hasDefault = hasDefault
-    self.isImplict = isImplict
+    self.isImplicit = isImplicit
   }
 
   /// `true` iff the parameter is implicit or has a default argument.
   public var isElidible: Bool {
-    hasDefault || isImplict
+    hasDefault || isImplicit
   }
 
   /// Returns a copy of this instance with its type replaced by `transformer(&m, t)`.
@@ -35,7 +35,7 @@ public struct CallableTypeParameter: Hashable {
     mutating m: inout M, _ transformer: (inout M, AnyType) -> TypeTransformAction
   ) -> Self {
     let t = type.transform(mutating: &m, transformer)
-    return .init(label: label, type: t, hasDefault: hasDefault, isImplict: isImplict)
+    return .init(label: label, type: t, hasDefault: hasDefault, isImplicit: isImplicit)
   }
 
 }

--- a/Sources/Core/Types/CallableTypeParameter.swift
+++ b/Sources/Core/Types/CallableTypeParameter.swift
@@ -10,11 +10,22 @@ public struct CallableTypeParameter: Hashable {
   /// `true` iff the parameter has a default argument.
   public let hasDefault: Bool
 
+  /// `true` if arguments to the parameter can be passed implicitly.
+  public let isImplict: Bool
+
   /// Creates an instance with the given properties.
-  public init(label: String? = nil, type: AnyType, hasDefault: Bool = false) {
+  public init(
+    label: String? = nil, type: AnyType, hasDefault: Bool = false, isImplict: Bool = false
+  ) {
     self.label = label
     self.type = type
     self.hasDefault = hasDefault
+    self.isImplict = isImplict
+  }
+
+  /// `true` iff the parameter is implicit or has a default argument.
+  public var isElidible: Bool {
+    hasDefault || isImplict
   }
 
   /// Returns a copy of this instance with its type replaced by `transformer(&m, t)`.
@@ -23,7 +34,8 @@ public struct CallableTypeParameter: Hashable {
   public func transform<M>(
     mutating m: inout M, _ transformer: (inout M, AnyType) -> TypeTransformAction
   ) -> Self {
-    .init(label: label, type: type.transform(mutating: &m, transformer), hasDefault: hasDefault)
+    let t = type.transform(mutating: &m, transformer)
+    return .init(label: label, type: t, hasDefault: hasDefault, isImplict: isImplict)
   }
 
 }

--- a/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
+++ b/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
@@ -114,4 +114,10 @@ extension Diagnostic {
     .error("attribute '\(a.value.name.value)' takes no argument", at: a.site)
   }
 
+  static func error(
+    illegalAccessModifierForImplicitParameter e: SourceRepresentable<AccessEffect>
+  ) -> Diagnostic {
+    .error("'\(e.value)'-parameter cannot be implicit", at: e.site)
+  }
+
 }

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1230,13 +1230,20 @@ public enum Parser {
 
     let defaultValue = try parseDefaultValue(in: &state)
 
+    let isImplicit = interface.implicitMarker != nil
+    if isImplicit {
+      if let e = state.ast[annotation]?.convention, e.value != .let {
+        state.diagnostics.insert(.error(illegalAccessModifierForImplicitParameter: e))
+      }
+    }
+
     return state.insert(
       ParameterDecl(
         label: interface.label,
         identifier: interface.name,
         annotation: annotation,
         defaultValue: defaultValue,
-        isImplicit: interface.implicitMarker != nil,
+        isImplicit: isImplicit,
         site: state.range(
           from: interface.label?.site.start ?? interface.name.site.start)))
   }

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1236,12 +1236,22 @@ public enum Parser {
         identifier: interface.name,
         annotation: annotation,
         defaultValue: defaultValue,
+        isImplicit: interface.implicitMarker != nil,
         site: state.range(
           from: interface.label?.site.start ?? interface.name.site.start)))
   }
 
   /// Parses the (optional) label and name of a parameter declaration.
   static func parseParameterInterface(
+    in state: inout ParserState
+  ) throws -> ParameterInterface? {
+    guard let i = try parseParameterNameAndLabel(in: &state) else { return nil }
+    let q = state.takePostfixQuestionMark()
+    return ParameterInterface(label: i.label, name: i.name, implicitMarker: q)
+  }
+
+  /// Parses the (optional) label and name of a parameter declaration.
+  private static func parseParameterNameAndLabel(
     in state: inout ParserState
   ) throws -> (label: SourceRepresentable<Identifier>?, name: SourceRepresentable<Identifier>)? {
     guard let labelCandidate = state.take(if: { $0.isLabel || $0.kind == .under }) else {
@@ -3460,6 +3470,20 @@ struct NameExprComponent {
 
   /// The static arguments of the component.
   let arguments: [LabeledArgument]
+
+}
+
+/// The name and argument label of a parameter declaration.
+struct ParameterInterface {
+
+  /// The argument label of the parameter, if any.
+  let label: SourceRepresentable<Identifier>?
+
+  /// The name of the parameter.
+  let name: SourceRepresentable<Identifier>
+
+  /// The implicit marker of the parameter, if any.
+  let implicitMarker: Token?
 
 }
 

--- a/Sources/FrontEnd/Parse/ParserState.swift
+++ b/Sources/FrontEnd/Parse/ParserState.swift
@@ -207,6 +207,15 @@ struct ParserState {
     return take(kind)
   }
 
+  /// Consumes and returns the next token iff it is a single question mark nor preceded by any
+  /// whitespace.
+  mutating func takePostfixQuestionMark() -> Token? {
+    if hasLeadingWhitespace { return nil }
+    return take(if: { [source = lexer.sourceCode] in
+      ($0.kind == .oper) && (source[$0.site] == "?")
+    })
+  }
+
   /// Consumes and returns the next token if it satisfies `predicate`.
   mutating func take(if predicate: (Token) -> Bool) -> Token? {
     if let token = peek(), predicate(token) {

--- a/Sources/FrontEnd/TypeChecking/ArgumentResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/ArgumentResolutionResult.swift
@@ -1,0 +1,15 @@
+import Core
+
+/// Information identifying a run-time argument of a function or subscript call.
+public enum ArgumentResolutionResult: Hashable, Monotonic {
+
+  /// The argument is the n-th expression in the syntax of the call.
+  case explicit(Int)
+
+  /// The argument is a an implicit declaration reference.
+  case implicit(AnyDeclID)
+
+  /// The argument is elided; the callee receive the parameter's default value.
+  case defaulted
+
+}

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -42,6 +42,9 @@ struct ConstraintSystem {
   /// to derive a complete name binding map w.r.t. its unresolved name expressions.
   private var bindingAssumptions: [NameExpr.ID: DeclReference]
 
+  /// A map from call expression to its operands after desugaring and implicit resolution.
+  private var callOperands: [CallID: [ArgumentResolutionResult]] = [:]
+
   /// The penalties associated with the constraint system.
   ///
   /// This value serves to prune explorations that cannot produce a better solution than one
@@ -177,7 +180,7 @@ struct ConstraintSystem {
     }
 
     return Solution(
-      substitutions: m, bindings: bindingAssumptions,
+      substitutions: m, bindings: bindingAssumptions, callOperands: callOperands,
       penalties: penalties, diagnostics: d, stale: stale.map({ goals[$0] }))
   }
 
@@ -675,23 +678,22 @@ struct ConstraintSystem {
       return .failure(invalidCallee(goal))
     }
 
-    // Make sure `F` structurally matches the given parameter list.
-    guard let argumentsToParameter = matchArgumentsToParameter(goal.labels, by: callee) else {
+    guard let argumentMatching = match(argumentsOf: goal, parametersOf: callee) else {
       return .failure { (d, m, _) in
         d.insert(
           .error(labels: goal.labels, incompatibleWith: callee.labels, at: goal.origin.site))
       }
     }
 
-    // Break down the goal.
+    callOperands[goal.call] = argumentMatching.pairings
+
     var subordinates: [GoalIdentity] = []
-    for (a, j) in zip(goal.arguments, argumentsToParameter) {
-      let b = callee.inputs[j]
-      let o = ConstraintOrigin(.argument, at: a.valueSite)
-      subordinates.append(schedule(ParameterConstraint(a.type, b.type, origin: o)))
+    for c in argumentMatching.constraints {
+      subordinates.append(schedule(c))
     }
     subordinates.append(
       schedule(EqualityConstraint(callee.output, goal.output, origin: goal.origin.subordinate())))
+
     return delegate(to: subordinates)
   }
 
@@ -706,28 +708,52 @@ struct ConstraintSystem {
     }
   }
 
-  /// Returns a table from argument position to its corresponding parameter position iff `callee`
-  /// accepts an argument list with given `labels`; returns `nil` otherwise.
-  ///
-  /// For example, given a callee whose parameters are `(x: Int, y: Int = 0, z: Int)` and an
-  /// argument list with labels `[x, z]`, this function returns `[0, 2]`.
-  private func matchArgumentsToParameter<T: Collection>(
-    _ labels: T, by callee: CallableType
-  ) -> [Int]?
-  where T.Element == String? {
-    var result: [Int] = []
-    var i = labels.startIndex
+  /// Returns how the arguments in `goal` match the parameters of `callee`.
+  private mutating func match(
+    argumentsOf goal: CallConstraint, parametersOf callee: CallableType
+  ) -> (constraints: [ParameterConstraint], pairings: [ArgumentResolutionResult])? {
+    var constraints: [ParameterConstraint] = []
+    var pairings: [ArgumentResolutionResult] = []
 
-    for (j, p) in callee.inputs.enumerated() {
-      if (i != labels.endIndex) && (labels[i] == p.label) {
-        result.append(j)
-        i = labels.index(after: i)
-      } else if !p.hasDefault {
-        return nil
+    var i = 0
+    for j in callee.inputs.indices {
+      let p = callee.inputs[j]
+
+      // If there's an explicit argument, use it unless if has a different label.
+      if (goal.arguments.count > i) && (goal.arguments[i].label?.value == p.label) {
+        let a = goal.arguments[i]
+        let o = ConstraintOrigin(.argument, at: goal.arguments[i].valueSite)
+        constraints.append(ParameterConstraint(a.type, p.type, origin: o))
+        pairings.append(.explicit(i))
+        i += 1
+        continue
       }
+
+      // Check for an implicit definition if the parameter accepts implicit definitions.
+      if callee.inputs[i].isImplict {
+        let t = ParameterType(callee.inputs[i].type)!
+        if let d = checker.implicitArgument(to: t, exposedTo: scope) {
+          pairings.append(.implicit(d))
+          continue
+        }
+      }
+
+      // Use the parameter's default value if available.
+      if callee.inputs[i].hasDefault {
+        pairings.append(.defaulted)
+        continue
+      }
+
+      // Argument list does not match the parameter list.
+      return nil
     }
 
-    return (i == labels.endIndex) ? result : nil
+    assert(pairings.count == callee.inputs.count)
+    if i == goal.arguments.count {
+      return (constraints, pairings)
+    } else {
+      return nil
+    }
   }
 
   private mutating func solve(merging g: GoalIdentity) -> Outcome? {

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -730,7 +730,7 @@ struct ConstraintSystem {
       }
 
       // Check for an implicit definition if the parameter accepts implicit definitions.
-      if callee.inputs[i].isImplict {
+      if callee.inputs[i].isImplicit {
         let t = ParameterType(callee.inputs[i].type)!
         if let d = checker.implicitArgument(to: t, exposedTo: scope) {
           pairings.append(.implicit(d))

--- a/Sources/FrontEnd/TypeChecking/Constraints/CallConstraint.swift
+++ b/Sources/FrontEnd/TypeChecking/Constraints/CallConstraint.swift
@@ -29,6 +29,9 @@ struct CallConstraint: Constraint, Hashable {
   /// The expected output type of `callee`.
   private(set) var output: AnyType
 
+  /// The call associated with this constraint.
+  let call: CallID
+
   /// `true` if `callee` is expected to be an arrow; `false` if it's expected to be a subscript.
   let isArrow: Bool
 
@@ -40,11 +43,13 @@ struct CallConstraint: Constraint, Hashable {
     arrow callee: AnyType,
     takes arguments: [Argument],
     gives output: AnyType,
+    in call: CallID,
     origin: ConstraintOrigin
   ) {
     self.callee = callee
     self.arguments = arguments
     self.output = output
+    self.call = call
     self.isArrow = true
     self.origin = origin
   }
@@ -55,11 +60,13 @@ struct CallConstraint: Constraint, Hashable {
     subscript callee: AnyType,
     takes arguments: [Argument],
     gives output: AnyType,
+    in call: CallID,
     origin: ConstraintOrigin
   ) {
     self.callee = callee
     self.arguments = arguments
     self.output = output
+    self.call = call
     self.isArrow = false
     self.origin = origin
   }

--- a/Sources/FrontEnd/TypeChecking/Solution.swift
+++ b/Sources/FrontEnd/TypeChecking/Solution.swift
@@ -29,6 +29,9 @@ struct Solution {
   /// The name binding assumptions made by the solver.
   private(set) var bindingAssumptions: BindingMap
 
+  /// A map from call expression to its operands after desugaring and implicit resolution.
+  private(set) var callOperands: [CallID: [ArgumentResolutionResult]]
+
   /// The penalties of the solution.
   private(set) var penalties: Int
 
@@ -40,19 +43,23 @@ struct Solution {
 
   /// Creates an empty solution.
   init() {
-    self.init(substitutions: [:], bindings: [:], penalties: 0, diagnostics: [], stale: [])
+    self.init(
+      substitutions: [:], bindings: [:], callOperands: [:],
+      penalties: 0, diagnostics: [], stale: [])
   }
 
   /// Creates an instance with the given properties.
   init(
     substitutions typeAssumptions: SubstitutionMap,
     bindings bindingAssumptions: [NameExpr.ID: DeclReference],
+    callOperands: [CallID: [ArgumentResolutionResult]],
     penalties: Int,
     diagnostics: DiagnosticSet,
     stale: [Constraint]
   ) {
     self.typeAssumptions = typeAssumptions
     self.bindingAssumptions = bindingAssumptions
+    self.callOperands = callOperands
     self.penalties = penalties
     self.diagnostics = diagnostics
     self.stale = stale

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -4487,7 +4487,7 @@ struct TypeChecker {
     let output = ((callee.base as? CallableType)?.output ?? hint) ?? ^freshVariable()
     obligations.insert(
       CallConstraint(
-        arrow: callee, takes: arguments, gives: output,
+        arrow: callee, takes: arguments, gives: output, in: .ast(AnyExprID(e)),
         origin: .init(.callee, at: program[e].callee.site)))
 
     return constrain(e, to: output, in: &obligations)
@@ -4716,6 +4716,7 @@ struct TypeChecker {
           arrow: operatorType,
           takes: [.init(label: nil, type: rhsType, valueSite: program.ast.site(of: rhs))],
           gives: outputType,
+          in: .infix(e),
           origin: .init(.callee, at: program.ast.site(of: e))))
 
       return outputType
@@ -4793,7 +4794,7 @@ struct TypeChecker {
     let output = ((callee.base as? CallableType)?.output ?? hint) ?? ^freshVariable()
     obligations.insert(
       CallConstraint(
-        subscript: callee, takes: arguments, gives: output,
+        subscript: callee, takes: arguments, gives: output, in: .ast(AnyExprID(e)),
         origin: .init(.callee, at: program[e].callee.site)))
 
     return constrain(e, to: output, in: &obligations)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2195,7 +2195,8 @@ struct TypeChecker {
     .init(
       label: program[d].label?.value,
       type: uncheckedType(of: d, ignoringSharedCache: true),
-      hasDefault: program[d].defaultValue != nil)
+      hasDefault: program[d].defaultValue != nil,
+      isImplict: program[d].isImplicit)
   }
 
   /// Computes and returns the types of the inputs `ps` of `d`.
@@ -2210,7 +2211,8 @@ struct TypeChecker {
       let i = CallableTypeParameter(
         label: program[p].label?.value,
         type: uncheckedType(of: p, ignoringSharedCache: true),
-        hasDefault: program[p].defaultValue != nil)
+        hasDefault: program[p].defaultValue != nil,
+        isImplict: program[p].isImplicit)
       result.append(i)
     }
     return result

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2196,7 +2196,7 @@ struct TypeChecker {
       label: program[d].label?.value,
       type: uncheckedType(of: d, ignoringSharedCache: true),
       hasDefault: program[d].defaultValue != nil,
-      isImplict: program[d].isImplicit)
+      isImplicit: program[d].isImplicit)
   }
 
   /// Computes and returns the types of the inputs `ps` of `d`.
@@ -2212,7 +2212,7 @@ struct TypeChecker {
         label: program[p].label?.value,
         type: uncheckedType(of: p, ignoringSharedCache: true),
         hasDefault: program[p].defaultValue != nil,
-        isImplict: program[p].isImplicit)
+        isImplicit: program[p].isImplicit)
       result.append(i)
     }
     return result

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -38,6 +38,9 @@ public struct TypedProgram {
   /// A map from name expression to its referred declaration.
   public internal(set) var referredDecl: BindingMap = [:]
 
+  /// A map from call expression to its operands after desugaring and implicit resolution.
+  public internal(set) var callOperands: [CallID: [ArgumentResolutionResult]] = [:]
+
   /// A map from sequence expressions to their evaluation order.
   public internal(set) var foldedForm: [SequenceExpr.ID: FoldedSequenceExpr] = [:]
 

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1472,7 +1472,7 @@ struct Emitter {
     // Explicit arguments are evaluated first, from left to right.
     let explicitArguments = emitArguments(
       to: ast[e].callee, in: CallID(e),
-      usingExplict: ast[e].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[e].site))
+      usingExplicit: ast[e].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[e].site))
 
     // Callee and captures are evaluated next.
     let (callee, captures) = emit(functionCallee: ast[e].callee)
@@ -1788,7 +1788,7 @@ struct Emitter {
     // Arguments are evaluated first, from left to right.
     let arguments = emitArguments(
       to: ast[call].callee, in: CallID(call),
-      usingExplict: ast[call].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[call].site))
+      usingExplicit: ast[call].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[call].site))
 
     // Receiver is captured next.
     let receiver = insert(module.makeAccess(.set, from: s, at: ast[call].site))!
@@ -1840,7 +1840,7 @@ struct Emitter {
   /// `callee` is a name expression referring to a callable declaration.
   private mutating func emitArguments(
     to callee: AnyExprID, in call: CallID,
-    usingExplict arguments: [LabeledArgument],
+    usingExplicit arguments: [LabeledArgument],
     synthesizingDefaultAt syntheticSite: SourceRange
   ) -> [Operand] {
     let parameters = (canonical(program[callee].type).base as! CallableType).inputs
@@ -2467,7 +2467,7 @@ struct Emitter {
     // Explicit arguments are evaluated first, from left to right.
     let explicitArguments = emitArguments(
       to: ast[e].callee, in: CallID(e),
-      usingExplict: ast[e].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[e].site))
+      usingExplicit: ast[e].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[e].site))
 
     // Callee and captures are evaluated next.
     let (callee, captures) = emit(subscriptCallee: ast[e].callee)

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1470,9 +1470,9 @@ struct Emitter {
     }
 
     // Explicit arguments are evaluated first, from left to right.
-    let explicitArguments = emit(
-      arguments: ast[e].arguments, to: ast[e].callee,
-      synthesizingDefaultArgumentsAt: .empty(atEndOf: ast[e].site))
+    let explicitArguments = emitArguments(
+      to: ast[e].callee, in: CallID(e),
+      usingExplict: ast[e].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[e].site))
 
     // Callee and captures are evaluated next.
     let (callee, captures) = emit(functionCallee: ast[e].callee)
@@ -1786,9 +1786,9 @@ struct Emitter {
     }
 
     // Arguments are evaluated first, from left to right.
-    let arguments = emit(
-      arguments: ast[call].arguments, to: ast[call].callee,
-      synthesizingDefaultArgumentsAt: .empty(atEndOf: ast[call].site))
+    let arguments = emitArguments(
+      to: ast[call].callee, in: CallID(call),
+      usingExplict: ast[call].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[call].site))
 
     // Receiver is captured next.
     let receiver = insert(module.makeAccess(.set, from: s, at: ast[call].site))!
@@ -1832,36 +1832,48 @@ struct Emitter {
     }
   }
 
-  /// Inserts the IR for `arguments`, which is an argument passed to a function of type `callee`.
+  /// Inserts the IR preparing the run-time arguments passed to `callee` in `call`, lowering
+  /// `arguments` and synthesizing default values at `syntheticSite`.
   ///
-  /// - Parameters:
-  ///   - syntheticSite: The site at which default pragma arguments are anchored.
-  private mutating func emit(
-    arguments: [LabeledArgument], to callee: AnyExprID,
-    synthesizingDefaultArgumentsAt syntheticSite: SourceRange
+  /// Information about argument resolution is read from `program.callOperands`. Arguments passed
+  /// explicitly have a corresponding expression in `arguments`. If default arguments are used,
+  /// `callee` is a name expression referring to a callable declaration.
+  private mutating func emitArguments(
+    to callee: AnyExprID, in call: CallID,
+    usingExplict arguments: [LabeledArgument],
+    synthesizingDefaultAt syntheticSite: SourceRange
   ) -> [Operand] {
-    let calleeType = canonical(program[callee].type).base as! CallableType
-    let calleeDecl = NameExpr.ID(callee).flatMap({ program[$0].referredDecl.decl! })
-    let defaults = calleeDecl.flatMap(ast.defaultArguments(of:))
+    let parameters = (canonical(program[callee].type).base as! CallableType).inputs
+    let inputs = program.callOperands[call]!
+    assert(parameters.count == inputs.count)
 
-    var result: [Operand] = []
-    var i = 0
-    for (j, p) in calleeType.inputs.enumerated() {
-      let a: AnyExprID
-      if (i < arguments.count) && (arguments[i].label?.value == p.label) {
-        a = arguments[i].value
-        i += 1
-      } else if let e = defaults?[j] {
-        a = e
-      } else {
-        unreachable()
-      }
+    // Nothing to do if the callee has no parameter.
+    if parameters.isEmpty { return [] }
 
-      let v = emit(argument: a, to: ParameterType(p.type)!, at: syntheticSite)
-      result.append(v)
+    // Parameter declarations are accessible iff `callee` is a direct reference to a callable.
+    let parameterDecls = NameExpr.ID(callee).flatMap { (n) in
+      program.ast.runtimeParameters(of: program[n].referredDecl.decl!)
     }
 
-    assert(i == arguments.count)
+    var result: [Operand] = []
+    for i in inputs.indices {
+      let p = ParameterType(parameters[i].type)!
+
+      switch inputs[i] {
+      case .explicit(let n):
+        let a = arguments[n].value
+        result.append(emit(argument: a, to: p, at: syntheticSite))
+
+      case .defaulted:
+        let a = program[parameterDecls![i]].defaultValue!
+        result.append(emit(argument: a, to: p, at: syntheticSite))
+
+      case .implicit(let d):
+        let s = emitLValue(directReferenceTo: d, at: syntheticSite)
+        result.append(insert(module.makeAccess(p.access, from: s, at: syntheticSite))!)
+      }
+    }
+
     return result
   }
 
@@ -2453,9 +2465,9 @@ struct Emitter {
   /// Inserts the IR for lvalue `e`.
   private mutating func emitLValue(_ e: SubscriptCallExpr.ID) -> Operand {
     // Explicit arguments are evaluated first, from left to right.
-    let explicitArguments = emit(
-      arguments: ast[e].arguments, to: ast[e].callee,
-      synthesizingDefaultArgumentsAt: .empty(atEndOf: ast[e].site))
+    let explicitArguments = emitArguments(
+      to: ast[e].callee, in: CallID(e),
+      usingExplict: ast[e].arguments, synthesizingDefaultAt: .empty(atEndOf: ast[e].site))
 
     // Callee and captures are evaluated next.
     let (callee, captures) = emit(subscriptCallee: ast[e].callee)

--- a/Tests/EndToEndTests/TestCases/Implicits.hylo
+++ b/Tests/EndToEndTests/TestCases/Implicits.hylo
@@ -1,0 +1,10 @@
+//- compileAndRun expecting: success
+
+public fun foo(x?: let Int) -> Int { bar() }
+
+public fun bar(x?: let Int) -> Int { x.copy() }
+
+public fun main() {
+  @given var x = 42
+  precondition(foo() == 42)
+}

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -761,11 +761,19 @@ final class ParserTests: XCTestCase {
     XCTAssertNotNil(ast[d]?.defaultValue)
   }
 
+  func testParameterDeclImplicit() throws {
+    let input: SourceFile = "_ foo?: T"
+    let (d, ast) = try input.parse(with: Parser.parseParameterDecl(in:))
+    let tree = try XCTUnwrap(ast[d])
+    XCTAssert(tree.isImplicit)
+  }
+
   func testParameterInterfaceLabelAndName() throws {
     let input: SourceFile = "for name"
     let tree = try XCTUnwrap(input.parse(with: Parser.parseParameterInterface(in:)).element)
     XCTAssertEqual(tree.label?.value, "for")
     XCTAssertEqual(tree.name.value, "name")
+    XCTAssertNil(tree.implicitMarker)
   }
 
   func testParameterInterfaceUnderscoreAndName() throws {
@@ -773,6 +781,7 @@ final class ParserTests: XCTestCase {
     let tree = try XCTUnwrap(input.parse(with: Parser.parseParameterInterface(in:)).element)
     XCTAssertNil(tree.label)
     XCTAssertEqual(tree.name.value, "name")
+    XCTAssertNil(tree.implicitMarker)
   }
 
   func testParameterInterfaceOnlyName() throws {
@@ -780,6 +789,15 @@ final class ParserTests: XCTestCase {
     let tree = try XCTUnwrap(input.parse(with: Parser.parseParameterInterface(in:)).element)
     XCTAssertEqual(tree.label?.value, "name")
     XCTAssertEqual(tree.name.value, "name")
+    XCTAssertNil(tree.implicitMarker)
+  }
+
+  func testParameterInterfaceImplicit() throws {
+    let input: SourceFile = "in context?"
+    let tree = try XCTUnwrap(input.parse(with: Parser.parseParameterInterface(in:)).element)
+    XCTAssertEqual(tree.label?.value, "in")
+    XCTAssertEqual(tree.name.value, "context")
+    XCTAssertNotNil(tree.implicitMarker)
   }
 
   func testOperatorDecl() throws {

--- a/Tests/HyloTests/TestCases/Parsing/IllegalImplicit.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/IllegalImplicit.hylo
@@ -1,0 +1,4 @@
+//- parse expecting: failure
+
+//! @+1 diagnostic 'inout'-parameter cannot be implicit
+fun bar(x?: inout Int) -> Int { x.copy() }


### PR DESCRIPTION
This PR implements implicit parameters. The design of the feature is mostly copied from [Scala3](https://docs.scala-lang.org/tour/implicit-parameters.html). Syntactic choices are motivated by precedent in Scala and Haskell.

In summary:

- Parameters of functions, methods, initializers, and subscripts can be declared "implicit"
- The compiler passes values to implicit parameters automatically
- Bindings elligible as implicit arguments are implicit parameters and annotated local declarations
- Implicit resolution is entirely type-based

The motivation for this feature are twofold:

- Implicit parameters give us a way to alleviate the "argument piping" problem. Many functions in `hc` need "context" to compute properties of objects identified by some position in a collection. The ability to pass such a context implicitly lets us write more concise calls (see https://github.com/orgs/hylo-lang/discussions/731).
- Implicit parameters can be used as "object capabilities" to model a function's ability to perform an unsafe operation or throw an exception. Object capabilities offer an [alternative to effect polymorphism](https://dotty.epfl.ch/docs/reference/experimental/canthrow.html).

Here is an example:

```hylo
type Item: SemiRegular {
  public let cost: Int
  public memberwise init
  public fun infix== (_ other: Item) -> Bool { self.cost == other.cost }
}

/// Returns the cost of item `i`.
fun name(of i: Int, in items? : Array<Item>) -> Int {
  let x = items[i] // See #1219
  return x.cost.copy()
}

public fun main() {
  @given var all_items = Array<Item>()
  &items.append(Item(cost: 28))
  // ...
  let x = 0
  print(name(of: x))
}
```

In the above program, `items` in the function `name(of:in:)` is declared as implicit parameter by appending a question mark to its name. When `name(of:in:)` is called, because the second argument is missing, the compiler looks for a binding suitable to be passed implicitly. It finds `all_items` because it is declared, which is declared with the `@given` attribute. The use of an implicit in this program lets us write more concise calls to `name(of:in:)`.

Unlike in Scala, implicit resolution is not allowed to look further than the scope of the function containing in which the call occurs. Further, the type of the implicit value must match _exactly_ the type of the argument so that no conversion occurs (note: this restriction may be obvious if we remove all implicit conversions, see https://github.com/orgs/hylo-lang/discussions/1165).

Implicit parameters must be `let`. This restriction is meant to avoid surprising effects on the state of local bindings.
