### PR TITLE
Improve the construction of generic environment

### DIFF
--- a/Docs/GenericEnvironments.md
+++ b/Docs/GenericEnvironments.md
@@ -1,0 +1,171 @@
+# Generic environments
+
+A generic _signature_ is a set of generic parameter declarations and constraints thereupon.
+For example, the generic signature of the following declaration contains one parameter declaration and two constraints.
+
+```hylo
+fun f<T: Collection where T.Element == Int>(x: X) {}
+```
+
+To make sense of a generic signature, the compiler creates a corresponding generic _environment_ gathering the information that it describes.
+In essence, a generic environment is a set of axioms that can be used in conjunction with the type system to prove arbitrary formulae about type or value terms.
+For example, given the generic signature above, the corresponding environment can be used to prove that `T.Element` has a member `infix+`.
+
+> Note that trait decalrations also describe a generic environment.
+> All traits define an implicit generic parameter denoting `Self` that is bound by the trait they declare.
+> Constraints on associated type and values define additional axioms.
+
+## Why are generic environments hard to build?
+
+Building generic environments is a little tricky because generic signatures are expressed very declaratively.
+Hence, the type checker must figure out the order in which it can read the environment's constraints to make sense of them.
+Further, very little assumptions can be made about the kind of entity an expression should denote, as constraints can relate to both types and values.
+For example, consider the following program:
+
+```hylo
+trait P { fun h() -> Bool }
+fun g<x: T, T: P where x.h()>() { ... }
+```
+
+This program is perfectly valid.
+`x` is declared as a generic value parameter of type `T`, which is known to conform to `P`.
+This conformance lets us conclude that `h` is indeed a member function of `T` returning Booleans, so we're allowed to call `x.h`.
+
+### Why isn't that the same as type checking anything else?
+
+Name resolution typically relies on generic environments having been built to determine whether a generic type parameter conforms to a particular trait.
+As a result, we can't reuse the general name resolution algorithm to answer questions about an environment being constructed.
+Consider the following function:
+
+```hylo
+fun h<T: Collection, U: Collection where T.Element == U.Element>(_ x: T, _ y: U) {
+  let a: T.Position = x.first_position()
+  ...
+}
+```
+
+To evaluate `T.Position`, name resolution finds the environment declaring `T`, asks for the traits to which `T` conforms, and then proceed with quialified name lookup in those traits to find an associated type or value declaration.
+This strategy requires the environment to be built.
+Therefore, if the construction of an environment is implemented as a single logical step, we can't evaluate `T.Element` in the above function because the fact that `T` conforms to `Collection` is not known yet.
+
+This problem is compounded by the fact that we may have to deduce conformances through equality constraints.
+For example, consider this setup:
+
+```hylo
+trait Q { type X }
+type A<T: Collection, U: Q> { ... }
+extension A where T == Array<U>, T.Element.X == Int { ... }
+```
+
+Resolving `T.Element.X` requires us to first conclude that `T.Element: Q`, which only holds because `T == Array<U>` implies that `T.Element == U` and `U: Q`.
+It is a difficult problem because it requires us to perform some form of unification based not only on the shape of type terms but also on ad-hoc information about conformance.
+
+### Why can't we simply reuse our solver?
+
+One may think that a simple solution could be to assign a type variable to each generic parameter and simply reuse our constraint solver.
+After all, we already have a way to solve member constraints that depend on unification to deal with generic argument deduction and overloading.
+Sadly, name resolution isn't the only roadblock.
+
+As tempting is it may be to throw all constraints at the solver, the problem here is that it is harder to establish facts about type variables.
+To illustrate, consider the following example:
+
+```hylo
+public fun main() {
+  fun id<T where T: Movable>(_ v: sink T) -> T { v }
+  let x: Int = 1
+  let y = id(x)
+}
+```
+
+When we look at the expression `id(x)`, we can look at the declarations of all entities and use them to establish some "ground truth".
+Here, we know that `id` is a function `[](sink T) -> T` and that `x` is an `Int`.
+We can substitute `Int` for `T`, check that it is indeed `Movable`, and conclude that the expression has type `Int`.
+Crucially, `T: Movable` only served as a _constraint_ to be checked the whole time.
+We never had to infer anything from it because we could prove that `T: Movable` using some external evidence, specifically `Int: Movable`.
+Contrast that with the following declaration
+
+```hylo
+fun foo<T where T: Collection, T.Element == Int>() { ... }
+```
+
+Here, `T: Collection` must be taken for granted, as it is the only way to make sense of `T.Element`.
+Our constraint solver is not designed to do that because in general a conformance constraint must be checked, not assumed.
+Otherwise, expressions like `id<Immovable()>` would pass type checking, as the solver would simply _assume_ `Immovable: Movable`.
+
+So while it is possible that we could reuse (parts of) our solver, we would need to engineer a way to hold assumptions until we either have enough information to check them or can conclude that they must be taken for granted because they define some properties of a generic environment.
+Note that whether or not we reuse our solver, that is the strategy we must implement anyway.
+
+One minor complication to keep in mind is that there is no obvious way to assign blame in case an inconsistency is detected.
+For example:
+
+```hylo
+fun bar<T where T: Collection, T == Bool>() { ... }
+```
+
+Here, `bar` has an inconsistent environment, assuming there is no user-defined conformance in scope making `Bool` a `Collection`.
+Either of the two constraints can be blamed.
+This problem is not specific to environment checking, though, as we also need a way to assign blame when infer the type of any other expression.
+
+## Construction strategy
+
+The biggest challenge is to figure out the order in which we process the expressions of a generic signature.
+One way to tackle this issue is to assume that the order in which constraints are written is significant.
+If we process expressions from left to right, then we can incrementally add facts to the typing contexts without having to consider what we don't know yet.
+In other words, this strategy solves the problem of distinguishing between constraints that must be taken for granted and those that must be checked.
+
+To illustrate, consider the following signature:
+
+```hylo
+<T, n: Int where T: Collection, T.Element == Int[n], T.Element.Element: Collection>
+```
+
+If we read this signature from left to right, we can conclude that:
+
+1. `T` is a generic _type_ (by `T`)
+2. `n` is a generic _value_ (by `n: Int`)
+3. `T` conforms to `Collection` (by `T: Collection`)
+4. `T.Element` is an associated type (by 3)
+5. `Int[n]` is well-formed (by 2)
+6. `T.Element` is `Int[n]` (by 4 and 5)
+
+At this point we have read all declarations and constraints before `T.Element.Element: Collection` and can consider them granted.
+We have yet to evaluate `T.Element.Element: Collection`, which at this point is a constraint we must _check_ w.r.t. the information we already gather.
+If the check passed, then the implications of the constraints would be merged with our typing context.
+Here, however, it doesn't because at this point we now that `T.Element.Element` is `Int` (by 6) and `Int: Collection` does not hold (assuming there is no user-defined conformance in scope).
+
+There is one rule we must add to use this evaluation order: a generic parameters introduced without a bound are assumed type-kinded.
+With this assumption, we never have to look at uses of a generic parameter to determine whether it is a type or a value.
+For example, this signature is ill-formed: `<T, U where T == Int[U]>`.
+Further, note that generic parameters can't be instantiated as traits, so if we see `T: U` we can always conclude that `T` must be a value and that `U` must be a tyoe.
+
+The next challenge is to deduce the implications of a constraint, given a partially constructed environment.
+Before we tackle this one, let's make a few observations:
+
+- Since traits can't be declared in types, if the root of a name expression is a type we now that a constraint of the form `A: B` is an instance constraint.
+
+- The LHS and/or RHS of an equality constraint must be rooted at a generic parameter.
+  That means we do not have to infer `T == U` from `Array<T> == Array<U>`.
+  However, we must accept constraints on parameters introduced by logically enclosing environments (e.g., `Element == Int` in an extension of `Array`).
+
+### Determining the kind of generic parameters
+
+Given the above observations, we can define a strategy to determine whether a generic parameter declaration denote a value or a type:
+
+- If the parameter has no bound, it is a type.
+- If the parameter has a bound, it is a type if and only if that bound is a name expression composed exclusively of nominal components that do not refer to any generic parameter.
+
+For example, `T: A<X>` declares a value parameter, regardless of what name resolution can say about `A` or `X`.
+
+### Determining constraints on associated types
+
+When we process an equality constraint, we can look at the traits modeled by the generic parameters or associated types constrained to deduce additional information.
+Consider the following generic signature:
+
+```hylo
+<T: Collection, U where T.Element == Int, U == Bool, T == Array<U>>
+```
+
+Once we have verified that `Array<U>` is well-formed, we should look at the traits to which `T` is known to conform.
+Then, for each of these traits, we should look how `Array<U>` implements associated types and declarations to establish additional facts.
+In this case, because `Array<U>::Collection.Element == U`, we can derive an additional constraint `T.Element == U` from `T == U`, which we must check.
+Because at this point we'll have already concluded that `T.Element == Int` and `U == Bool`, we can conclude that the environment is inconsistent.

--- a/Sources/Core/AST/AST+Walk.swift
+++ b/Sources/Core/AST/AST+Walk.swift
@@ -823,7 +823,7 @@ extension AST {
     constraintExpr c: WhereClause.ConstraintExpr, notifying o: inout O
   ) {
     switch c {
-    case .conformance(let lhs, let traits):
+    case .bound(let lhs, let traits):
       walk(lhs, notifying: &o)
       for t in traits { walk(t, notifying: &o) }
     case .equality(let lhs, let rhs):

--- a/Sources/Core/AST/Decl/GenericClause.swift
+++ b/Sources/Core/AST/Decl/GenericClause.swift
@@ -7,9 +7,10 @@ public struct GenericClause: Codable {
   /// The where clause of the generic clause, if any.
   public let whereClause: SourceRepresentable<WhereClause>?
 
+  /// Creates an instance with the given properties.
   public init(
     parameters: [GenericParameterDecl.ID],
-    whereClause: SourceRepresentable<WhereClause>? = nil
+    whereClause: SourceRepresentable<WhereClause>?
   ) {
     self.parameters = parameters
     self.whereClause = whereClause

--- a/Sources/Core/AST/Decl/WhereClause.swift
+++ b/Sources/Core/AST/Decl/WhereClause.swift
@@ -10,14 +10,10 @@ public struct WhereClause: Codable {
   public enum ConstraintExpr: Codable {
 
     /// An equality constraint involving one or two skolems.
-    case equality(
-      l: NameExpr.ID,
-      r: AnyExprID)
+    case equality(l: NameExpr.ID, r: AnyExprID)
 
-    /// A conformance constraint on a skolem.
-    case conformance(
-      l: NameExpr.ID,
-      traits: TraitComposition)
+    /// A conformance or instance constraint on a skolem.
+    case bound(l: NameExpr.ID, r: [AnyExprID])
 
     /// A constraint on a value parameter.
     case value(AnyExprID)

--- a/Sources/Core/Types/GenericEnvironment.swift
+++ b/Sources/Core/Types/GenericEnvironment.swift
@@ -17,13 +17,6 @@ public struct GenericEnvironment {
   /// The declaration associated with the environment.
   public let decl: AnyDeclID
 
-  /// A number reflecting the number of times the environment has been updated.
-  ///
-  /// A generic environments is built incrementally by inserting constraints on generic parameters.
-  /// Each update increments the generation number until all constraints have been inserted, at
-  /// which point the environment must be finalized, setting its generation to `UInt.max`.
-  public private(set) var generation: UInt = 0
-
   /// The generic parameters introduced in the environment, in the order there declaration appears
   /// in Hylo sources.
   public let parameters: [GenericParameterDecl.ID]
@@ -46,11 +39,6 @@ public struct GenericEnvironment {
     self.parameters = parameters
   }
 
-  /// `true` iff `self` has been fully constructed and type checked.
-  public var isFinalized: Bool {
-    generation == .max
-  }
-
   /// Returns the set of traits to which `type` conforms in t`self`.
   public func conformedTraits(of type: AnyType) -> Set<TraitType> {
     if let i = ledger[type] {
@@ -58,14 +46,6 @@ public struct GenericEnvironment {
     } else {
       return []
     }
-  }
-
-  /// Marks that `self` has been fully constructed.
-  ///
-  /// - Requires: `self` has not been finalized yet.
-  public mutating func finalize() {
-    precondition(!isFinalized)
-    generation = .max
   }
 
   /// Inserts constraint `c` to the environment, updating equivalence classes.
@@ -80,7 +60,6 @@ public struct GenericEnvironment {
     default:
       break
     }
-    generation += 1
   }
 
   /// Registers the fact that `l` is equivalent to `r` in the context of this environment.
@@ -109,7 +88,6 @@ public struct GenericEnvironment {
       ledger[l] = entries.count
       entries.append(.init(equivalences: [l, r], conformances: []))
     }
-    generation += 1
   }
 
   /// Registers the fact that `l` conforms to `r` in the context of this environment.
@@ -122,7 +100,6 @@ public struct GenericEnvironment {
       ledger[l] = entries.count
       entries.append(.init(equivalences: [l], conformances: [r]))
     }
-    generation += 1
   }
 
 }

--- a/Sources/FrontEnd/Monotonic.swift
+++ b/Sources/FrontEnd/Monotonic.swift
@@ -68,7 +68,17 @@ extension DeclReference: Monotonic {}
 
 extension FoldedSequenceExpr: Monotonic {}
 
-extension GenericEnvironment: Monotonic {}
+extension GenericEnvironment: Monotonic {
+
+  mutating func updateMonotonically(_ other: GenericEnvironment) {
+    if (self.decl == other.decl) && (self.generation < other.generation) {
+      self = other
+    } else {
+      assert(self == other)
+    }
+  }
+
+}
 
 extension ImplicitCapture: Monotonic {}
 

--- a/Sources/FrontEnd/Monotonic.swift
+++ b/Sources/FrontEnd/Monotonic.swift
@@ -68,17 +68,7 @@ extension DeclReference: Monotonic {}
 
 extension FoldedSequenceExpr: Monotonic {}
 
-extension GenericEnvironment: Monotonic {
-
-  mutating func updateMonotonically(_ other: GenericEnvironment) {
-    if (self.decl == other.decl) && (self.generation < other.generation) {
-      self = other
-    } else {
-      assert(self == other)
-    }
-  }
-
-}
+extension GenericEnvironment: Monotonic {}
 
 extension ImplicitCapture: Monotonic {}
 

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -3286,11 +3286,11 @@ public enum Parser {
           range: state.ast[lhs].site.extended(upTo: state.currentIndex))
       }
 
-      // conformance-constraint
+      // bound-constraint
       if state.take(.colon) != nil {
-        let traits = try state.expect("trait composition", using: traitComposition)
+        let rhs = try state.expect("type expression", using: boundList)
         return SourceRepresentable(
-          value: .conformance(l: lhs, traits: traits),
+          value: .bound(l: lhs, r: rhs),
           range: state.ast[lhs].site.extended(upTo: state.currentIndex))
       }
 
@@ -3308,6 +3308,10 @@ public enum Parser {
   static let traitComposition =
     (nameTypeExpr.and(zeroOrMany(take(.ampersand).and(nameTypeExpr).second))
       .map({ (state, tree) -> TraitComposition in [tree.0] + tree.1 }))
+
+  private static let boundList =
+    (expr.and(zeroOrMany(take(.ampersand).and(expr).second))
+      .map({ (state, tree) -> [AnyExprID] in [tree.0] + tree.1 }))
 
   // MARK: Attributes
 

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -165,10 +165,10 @@ struct ConstraintSystem {
   }
 
   /// Creates a solution from the current state.
+  ///
+  /// - Requires: There is no fresh goal to solve left.
   private mutating func formSolution() -> Solution {
-    assert(fresh.isEmpty)
     assert(outcomes.enumerated().allSatisfy({ (i, o) in (o != nil) || stale.contains(i) }))
-
     for g in stale {
       setOutcome(.failure({ (_, _, _) in () }), for: g)
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -167,6 +167,12 @@ struct TypeChecker {
 
   /// Returns the traits to which `t` is declared conforming in `scopeOfUse`.
   mutating func conformedTraits(of t: AnyType, in scopeOfUse: AnyScopeID) -> Set<TraitType> {
+    // Computation is not memoized for generic type parameters because queries might come from
+    // generic arguments under construction.
+    if let u = GenericTypeParameterType(t) {
+      return conformedTraits(of: u, in: scopeOfUse)
+    }
+
     let key = Cache.TypeLookupKey(t, in: scopeOfUse)
     if let r = cache.typeToConformedTraits[key] {
       return r
@@ -179,8 +185,6 @@ struct TypeChecker {
     case let u as BoundGenericType:
       result = conformedTraits(of: u.base, in: scopeOfUse)
     case let u as BuiltinType:
-      result = conformedTraits(of: u, in: scopeOfUse)
-    case let u as GenericTypeParameterType:
       result = conformedTraits(of: u, in: scopeOfUse)
     case let u as ProductType:
       result = conformedTraits(of: u, in: scopeOfUse)
@@ -1668,23 +1672,81 @@ struct TypeChecker {
 
     // Nothing to do if the declaration has no generic clause.
     guard let clause = program[d].genericClause?.value else {
-      return commit(GenericEnvironment(introducing: []))
-    }
-
-    var result = GenericEnvironment(introducing: clause.parameters)
-    for p in clause.parameters {
-      insertAnnotatedConstraints(on: p, in: &result)
-    }
-    for c in (clause.whereClause?.value.constraints ?? []) {
-      insertConstraint(c, in: &result)
-    }
-    return commit(result)
-
-    /// Commits `e` as the environment of `d` to the cache.
-    func commit(_ e: GenericEnvironment) -> GenericEnvironment {
+      var e = GenericEnvironment(of: AnyDeclID(d), introducing: [])
+      e.finalize()
       cache.write(e, at: \.environment[d])
       return e
     }
+
+    var partialResult = GenericEnvironment(
+      of: AnyDeclID(d),
+      introducing: clause.parameters)
+    cache.write(partialResult, at: \.environment[d], ignoringSharedCache: true)
+
+    var nameToParameter: [String: GenericParameterDecl.ID] = [:]
+    for p in clause.parameters {
+      cache.declsUnderChecking.insert(AnyDeclID(p))
+      nameToParameter[program[p].baseName] = p
+    }
+
+    var hasError = false
+
+    for p in clause.parameters {
+      // If `p` is introduced without any bounds, it is assumed to be type-kinded.
+      guard let bounds = program[p].conformances.headAndTail else {
+        _ = assumeTypeKinded(p)
+        continue
+      }
+
+      // Otherwise, the first bound of `p` determines its kind.
+      let (firstBoundAsTrait, nameResolutionFailed) = resolveTrait(
+        expressedBy: bounds.head, inEnvironmentIntroducing: nameToParameter)
+
+      // Register failures so we can fail fast.
+      if nameResolutionFailed {
+        _ = assumeTypeKinded(p)
+        hasError = true
+        continue
+      }
+
+      // If the first bound is a trait, then `p` is type-kinded.
+      if let rhs = firstBoundAsTrait {
+        let lhs = assumeTypeKinded(p)
+        let c = GenericConstraint(.conformance(lhs, rhs), at: program[bounds.head].site)
+        insertConstraint(c, in: &partialResult)
+
+        for (n, t) in evalTraitComposition(bounds.tail) {
+          let c = GenericConstraint(.conformance(lhs, t), at: program[n].site)
+          insertConstraint(c, in: &partialResult)
+        }
+      }
+
+      // Otherwise, `p` is value-kinded.
+      else {
+        let rhs = evalTypeAnnotation(AnyExprID(bounds.head))
+        _ = assumeValueKinded(p, instanceOf: rhs)
+        if let n = bounds.tail.first {
+          report(.error(tooManyAnnotationsOnGenericValueParametersAt: program[n].site))
+        }
+      }
+    }
+
+    // Commit the current result and bail out if there are errors already.
+    if !hasError {
+      cache.write(partialResult, at: \.environment[d], ignoringSharedCache: true)
+    } else {
+      cache.write(partialResult, at: \.environment[d])
+      return partialResult
+    }
+
+    // Otherwise, proceed with the constraints of the where clause.
+    for c in (clause.whereClause?.value.constraints ?? []) {
+      insertConstraint(c, in: &partialResult)
+    }
+
+    partialResult.finalize()
+    cache.write(partialResult, at: \.environment[d])
+    return partialResult
   }
 
   /// Returns the generic environment introduced by `d`.
@@ -1693,42 +1755,42 @@ struct TypeChecker {
     if let e = cache.read(\.environment[d]) { return e }
 
     let receiver = program[d].receiver.id
-    var result = GenericEnvironment(introducing: [receiver])
+    var partialResult = GenericEnvironment(of: AnyDeclID(d), introducing: [receiver])
+
+    // Synthesize `Self: T`.
+    let s = assumeTypeKinded(receiver)
+    let t = TraitType(uncheckedType(of: d))!
+    let c = GenericConstraint(.conformance(^s, t), at: program[d].identifier.site)
+    insertConstraint(c, in: &partialResult)
 
     for m in program[d].members {
       switch m.kind {
       case AssociatedTypeDecl.self:
-        insertConstraints(of: AssociatedTypeDecl.ID(m)!, in: &result)
+        insertConstraints(of: AssociatedTypeDecl.ID(m)!, in: &partialResult)
       case AssociatedValueDecl.self:
-        insertConstraints(of: AssociatedValueDecl.ID(m)!, in: &result)
+        insertConstraints(of: AssociatedValueDecl.ID(m)!, in: &partialResult)
       default:
         continue
       }
     }
 
-    // Synthesize `Self: T`.
-    let s = GenericTypeParameterType(receiver, ast: program.ast)
-    let t = TraitType(uncheckedType(of: d))!
-    for c in refinements(of: t).unordered {
-      result.insertConstraint(.init(.conformance(^s, c), at: program[d].identifier.site))
-    }
-
-    cache.write(result, at: \.environment[d])
-    return result
+    partialResult.finalize()
+    cache.write(partialResult, at: \.environment[d])
+    return partialResult
   }
 
-  /// Returns the generic environment introduced by `s`.
+  /// Returns the generic environment introduced by `d`.
   private mutating func environment<T: TypeExtendingDecl>(of d: T.ID) -> GenericEnvironment {
     // Check if work has to be done.
     if let e = cache.read(\.environment[d]) { return e }
 
-    var result = GenericEnvironment(introducing: [])
+    var partialResult = GenericEnvironment(of: AnyDeclID(d), introducing: [])
     for c in (program[d].whereClause?.value.constraints ?? []) {
-      insertConstraint(c, in: &result)
+      insertConstraint(c, in: &partialResult)
     }
 
-    cache.write(result, at: \.environment[d])
-    return result
+    cache.write(partialResult, at: \.environment[d])
+    return partialResult
   }
 
   /// Returns the generic environment introduced by the declaration of `t`, if any.
@@ -1793,13 +1855,12 @@ struct TypeChecker {
 
     // Synthesize sugared conformance constraint, if any.
     for (n, t) in evalTraitComposition(program[p].conformances) {
-      for c in refinements(of: t).unordered {
-        e.insertConstraint(.init(.conformance(lhs, c), at: program[n].site))
-      }
+      let c = GenericConstraint(.conformance(lhs, t), at: program[n].site)
+      insertConstraint(c, in: &e)
     }
   }
 
-  /// Inserts `c` in `e`.
+  /// Evaluates `c` as a generic constraint and inserts it in `e`.
   private mutating func insertConstraint(
     _ c: SourceRepresentable<WhereClause.ConstraintExpr>, in e: inout GenericEnvironment
   ) {
@@ -1811,26 +1872,120 @@ struct TypeChecker {
       else { return }
 
       if lhs.isTypeParameter || rhs.isTypeParameter {
-        e.insertConstraint(.init(.equality(lhs, rhs), at: c.site))
+        insertConstraint(.init(.equality(lhs, rhs), at: c.site), in: &e)
       } else {
         report(.error(invalidEqualityConstraintBetween: lhs, and: rhs, at: c.site))
       }
 
-    case .conformance(let l, let r):
+    case .bound(let l, let r):
       guard let lhs = evalTypeAnnotation(AnyExprID(l)).errorFree else { return }
       guard lhs.isTypeParameter else {
         report(.error(invalidConformanceConstraintTo: lhs, at: c.site))
         return
       }
 
-      for (_, rhs) in evalTraitComposition(r) {
-        e.insertConstraint(.init(.conformance(lhs, rhs), at: c.site))
+      let r2 = r.map({ (e) in NameExpr.ID.init(e)! })
+      for (_, rhs) in evalTraitComposition(r2) {
+        insertConstraint(.init(.conformance(lhs, rhs), at: c.site), in: &e)
       }
 
     case .value(let p):
       // TODO: Symbolic execution
-      return e.insertConstraint(.init(.predicate(p), at: c.site))
+      insertConstraint(.init(.predicate(p), at: c.site), in: &e)
     }
+  }
+
+  /// Inserts `c` in `e` and registers the conformances and equalities that `c` implies.
+  private mutating func insertConstraint(
+    _ c: GenericConstraint, in e: inout GenericEnvironment
+  ) {
+    switch c.value {
+    case .conformance(let lhs, let rhs):
+      for c in refinements(of: rhs).unordered {
+        e.establishConformance(lhs, to: c)
+      }
+
+    case .equality(let lhs, let rhs):
+      e.establishEquivalence(lhs, rhs)
+
+    case .instance:
+      break
+
+    case .predicate:
+      UNIMPLEMENTED("generic value constraints")
+    }
+
+    e.insertConstraint(c)
+    cache.write(e, at: \.environment[e.decl], ignoringSharedCache: true)
+  }
+
+  /// Returns `(trait, hasError)` where `trait` is the trait to which `bound` resolves or `nil` if
+  /// it resolves to another entity, and `hasError` is `true` iff name resolution failed.
+  ///
+  /// This method does not run standard name resolution on `bound`, as it may require information
+  /// in which `bound` occurs. Instead, it processes the components of `bound` one by one, bailing
+  /// out as soon as it find one that denotes a type or expression since trait declarations can
+  /// only occur at global scope.
+  ///
+  /// - Parameters:
+  ///   - bound: The expression of a bound on a generic parameter declaration or the RHS of a
+  ///     conformance constraint in a where clause.
+  ///   - siblings: A map from the name of each generic parameter introduced by the environment
+  ///     in which `bound` occurs to its declarations.
+  private mutating func resolveTrait(
+    expressedBy bound: NameExpr.ID,
+    inEnvironmentIntroducing siblings: [String: GenericParameterDecl.ID]
+  ) -> (trait: TraitType?, hasError: Bool) {
+    let (n, d) = program.ast.splitNominalComponents(of: bound)
+
+    // Traits can't be declared as type members.
+    if (d != .none) || (siblings[program[n.last!].name.value.stem] != nil) {
+      return (nil, false)
+    }
+
+    // We can apply name resolution on the components of the bound as long as they don't have
+    // generic arguments. A name expression with arguments can't denote a trait.
+    var parent: NameResolutionContext? = nil
+    for component in n.reversed() {
+      if !program[component].arguments.isEmpty {
+        return (nil, false)
+      }
+
+      let candidates = resolve(component, in: parent, usedAs: .unapplied)
+      if candidates.isEmpty {
+        return (nil, true)
+      }
+
+      guard let pick = candidates.uniqueElement else {
+        return (nil, false)
+      }
+
+      switch pick.type.base {
+      case is ModuleType, is NamespaceType, is TraitType:
+        parent = .init(type: pick.type, arguments: [:], receiver: .explicit(AnyExprID(component)))
+      default:
+        return (nil, false)
+      }
+    }
+
+    return (TraitType(parent?.type), false)
+  }
+
+  private mutating func assumeTypeKinded(
+    _ p: GenericParameterDecl.ID
+  ) -> AnyType {
+    let t = ^GenericTypeParameterType(p, ast: program.ast)
+    cache.write(^MetatypeType(of: t), at: \.declType[p])
+    cache.declsUnderChecking.remove(AnyDeclID(p))
+    return t
+  }
+
+  private mutating func assumeValueKinded(
+    _ p: GenericParameterDecl.ID, instanceOf t: AnyType
+  ) -> AnyType {
+    cache.write(t, at: \.declType[p])
+    cache.declsUnderChecking.remove(AnyDeclID(p))
+    return t
   }
 
   /// Returns the type of `d`, computing it if necessary, without type checking `d`.
@@ -1981,19 +2136,8 @@ struct TypeChecker {
 
   /// Computes and returns the type of `d`.
   private mutating func _uncheckedType(of d: GenericParameterDecl.ID) -> AnyType {
-    let bounds = program[d].conformances.map({ evalTypeAnnotation(AnyExprID($0)) })
-
-    // The declaration introduces a value if it's first annotation isn't a trait. Otherwise, it
-    // introduces a type.
-    if let first = bounds.first, !(first.base is TraitType) {
-      if bounds.count > 1 {
-        let s = program[program[d].conformances[1]].site
-        report(.error(tooManyAnnotationsOnGenericValueParametersAt: s))
-      }
-      return first
-    } else {
-      return ^MetatypeType(of: GenericTypeParameterType(d, ast: program.ast))
-    }
+    _ = environment(of: program[d].scope)!
+    return cache.local.declType[d]!
   }
 
   /// Computes and returns the type of `d`.
@@ -2608,8 +2752,8 @@ struct TypeChecker {
   ///
   /// The returned sequence contains an element for each valid trait expression in `composition`.
   /// A diagnostic is reported each invalid expression.
-  private mutating func evalTraitComposition(
-    _ composition: [NameExpr.ID]
+  private mutating func evalTraitComposition<S: Sequence<NameExpr.ID>>(
+    _ composition: S
   ) -> [(name: NameExpr.ID, trait: TraitType)] {
     var result: [(name: NameExpr.ID, trait: TraitType)] = []
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1768,11 +1768,9 @@ struct TypeChecker {
   }
 
   /// Ensures `e` is consistent and writes it to the cache.
-  private mutating func commit(_ e: GenericEnvironment) -> GenericEnvironment {
-    var finalResult = e
-    finalResult.finalize()
-    cache.partiallyFormedEnvironment[e.decl] = nil
-    cache.write(finalResult, at: \.environment[e.decl])
+  private mutating func commit(_ finalResult: GenericEnvironment) -> GenericEnvironment {
+    cache.partiallyFormedEnvironment[finalResult.decl] = nil
+    cache.write(finalResult, at: \.environment[finalResult.decl])
     return finalResult
   }
 

--- a/Sources/IR/Mangling/Mangler.swift
+++ b/Sources/IR/Mangling/Mangler.swift
@@ -307,7 +307,7 @@ struct Mangler {
     case .value:
       UNIMPLEMENTED()
 
-    case .conformance(let lhs, let rhs):
+    case .bound(let lhs, let rhs):
       write(operator: .conformanceConstraint, to: &output)
       mangle(type: program[lhs].type, to: &output)
       write(integer: rhs.count, to: &output)

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1439,7 +1439,7 @@ final class ParserTests: XCTestCase {
   func testWhereClauseConformanceConstraint() throws {
     let input: SourceFile = "T : U & V"
     let constraint = try XCTUnwrap(try apply(Parser.typeConstraint, on: input).element)
-    if case .conformance(let lhs, _) = constraint.value {
+    if case .bound(let lhs, _) = constraint.value {
       XCTAssertEqual(lhs.kind, .init(NameExpr.self))
     } else {
       XCTFail()

--- a/Tests/HyloTests/TestCases/TypeChecking/GenericEnvironment.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/GenericEnvironment.hylo
@@ -1,0 +1,7 @@
+//- typeCheck expecting: success
+
+trait P {
+  type Element
+}
+
+type A0<X: P, Y where Y == X.Element> {}


### PR DESCRIPTION
This PR redesigns the construction of generic environments. A short explanation of the changes is given in the commit description of 3c142f4755601cb571f0c26110dbeb1ac8a78a82. `Docs/GenericEnvironments.md` provides more general information about generic environments and their construction.

This PR does not implement any consistency check on generic environments; that will be done as a separate patch.