### PR TITLE
Diagnose invalid return statements in non-sink subscripts

### DIFF
--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1227,7 +1227,13 @@ struct Emitter {
     return (startIndex: start, endIndex: end)
   }
 
+  /// Inserts the IR for `s`, returning its effect on control flow.
   private mutating func emit(returnStmt s: ReturnStmt.ID) -> ControlFlow {
+    if module[insertionFunction!].isSubscript {
+      report(.error(returnInSubscript: s, in: ast))
+      return .next
+    }
+
     if let e = ast[s].value {
       emitStore(value: e, to: returnValue!)
     } else {
@@ -3068,6 +3074,10 @@ extension Diagnostic {
     at site: SourceRange
   ) -> Diagnostic {
     .error("integer literal '\(s)' overflows when stored into '\(t)'", at: site)
+  }
+
+  fileprivate static func error(returnInSubscript s: ReturnStmt.ID, in ast: AST) -> Diagnostic {
+    .error("return statement in subscript", at: ast[s].introducerSite)
   }
 
   fileprivate static func warning(unreachableStatement s: AnyStmtID, in ast: AST) -> Diagnostic {

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -67,12 +67,11 @@ struct Emitter {
 
   /// The address of the return value in the current function, if any.
   private var returnValue: Operand? {
-    guard
-      let f = insertionFunction,
-      let b = module.entry(of: f),
-      !module[f].isSubscript
-    else { return nil }
-    return .parameter(b, module[f].inputs.count)
+    if let f = insertionFunction, let b = module.entry(of: f), !module[f].isSubscript {
+      return .parameter(b, module[f].inputs.count)
+    } else {
+      return nil
+    }
   }
 
   /// Reports the given diagnostic.

--- a/Tests/HyloTests/TestCases/Lowering/ReturnInSubscript.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/ReturnInSubscript.hylo
@@ -1,0 +1,6 @@
+//- lowerToFinishedIR expecting: failure
+
+public subscript s(x: Int): Int {
+  //! @+1 diagnostic return statement in subscript
+  return x
+}


### PR DESCRIPTION
Fixes the compiler trap observed in #1239