### PR TITLE
Extern functions

### DIFF
--- a/Sources/Core/AST/Decl/FunctionDecl.swift
+++ b/Sources/Core/AST/Decl/FunctionDecl.swift
@@ -95,16 +95,16 @@ public struct FunctionDecl: CapturingDecl, ExposableDecl, GenericDecl, GenericSc
   /// `true` iff `self` is a definition of the entity that it declares.
   public var isDefinition: Bool { body != nil }
 
-  /// Returns whether the declaration denotes a static member function.
+  /// `true` iff `self` denotes a static member function.
   public var isStatic: Bool { memberModifier?.value == .static }
 
-  /// Returns whether the declaration denotes an `inout` member function.
+  /// `true` iff `self` denotes an `inout` member function.
   public var isInout: Bool { receiverEffect?.value == .inout }
 
-  /// Returns whether the declaration denotes a `sink` member function.
+  /// `true` iff `self` denotes a `sink` member function.
   public var isSink: Bool { receiverEffect?.value == .sink }
 
-  /// Returns whether `self` is a foreign function interface.
+  /// `true` iff `self` is a foreign function interface.
   public var isForeignInterface: Bool {
     api.contains(.isForeignInterface)
   }

--- a/Sources/Core/AST/Decl/FunctionDecl.swift
+++ b/Sources/Core/AST/Decl/FunctionDecl.swift
@@ -115,16 +115,6 @@ public struct FunctionDecl: CapturingDecl, ExposableDecl, GenericDecl, GenericSc
     }
   }
 
-  /// The LLVM name of this function if this instance has the `@_llvm` attribute.
-  public var llvmName: String? {
-    if let a = attributes.first(where: { $0.value.name.value == "@_llvm" }) {
-      guard case .string(let n) = a.value.arguments[0] else { unreachable() }
-      return n.value
-    } else {
-      return nil
-    }
-  }
-
   public func validateForm(in ast: AST, reportingDiagnosticsTo log: inout DiagnosticSet) {
     if !isInExprContext {
       // Parameter declarations must have a type annotation.

--- a/Sources/Core/AST/Decl/FunctionDecl.swift
+++ b/Sources/Core/AST/Decl/FunctionDecl.swift
@@ -38,7 +38,7 @@ public struct FunctionDecl: CapturingDecl, ExposableDecl, GenericDecl, GenericSc
 
   /// The parameters of the function.
   ///
-  /// These declarations must have a type annotation unless `self.isInExprContext` is `true`.
+  /// All parameters must have a type annotation unless `isInExprContext` is `true`.
   public let parameters: [ParameterDecl.ID]
 
   /// The declaration of the implicit receiver parameter, if any.

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -729,8 +729,8 @@ struct TypeChecker {
       check(b, asBodyOfCallableProducing: r)
 
     case nil:
-      // Only requirements and FFIs can be without a body.
-      if !program.isRequirement(d) && !program[d].isForeignInterface {
+      // Only requirements, FFIs, and external functions can be without a body.
+      if requiresBody(d) {
         report(.error(declarationRequiresBodyAt: program[d].introducerSite))
       }
     }
@@ -5691,6 +5691,11 @@ struct TypeChecker {
   /// Returns `true` iff `t` is the receiver of a trait declaration.
   private func isTraitReceiver(_ t: GenericTypeParameterType) -> Bool {
     program[t.decl].scope.kind == TraitDecl.self
+  }
+
+  /// Returns `true` if `d` isn't a trait requirement, an FFI, or an external function.
+  private func requiresBody(_ d: FunctionDecl.ID) -> Bool {
+    !(program.isRequirement(d) || program[d].isForeignInterface || program[d].isExternal)
   }
 
   /// If `t` is the type of a mutating bundle in `scopeOfUse`, returns the output of a mutating


### PR DESCRIPTION
This PR implement supports for functions declared in Hylo and having an implementation defined externally.

## Usage example:

Define the two following files:

- `main.hylo`:
```hylo
@external("initialize_in_cc")
fun initialize_externally(_ n: set Int)

public fun main() {
  var x: Int
  initialize_externally(&x)
  print(x)
}
```

- `hyloinit.cc`
```c++
#include <cstdint>

struct HyloInt {
  int64_t value;
};

extern "C" {
  // Note: 2nd parameter is the "Void" returned by `initialize_externally `.
  // It will be passed as a null pointer from Hylo.
  void initialize_in_cc(void* n, void*) {
    auto* p = static_cast<HyloInt*>(n);
    p->value = 42;
  }
}
```

Build and run as follows:
```bash
c++ -c -std=c++20 -o hyloinit.o hyloinit.cc
llvm-ar r libhyloinit.a hyloinit.o
hc -L $(pwd) -l hyloinit -l c++ main.hylo
./main
```

The program prints 42.