### PR TITLE
Fix name lookup in associated types

### DIFF
--- a/Sources/Core/Types/GenericConstraint.swift
+++ b/Sources/Core/Types/GenericConstraint.swift
@@ -31,3 +31,20 @@ public struct GenericConstraint: Hashable {
   }
 
 }
+
+extension GenericConstraint: CustomStringConvertible {
+
+  public var description: String {
+    switch value {
+    case .equality(let l, let r):
+      return "\(l) == \(r)"
+    case .instance(let l, let r):
+      return "\(l): \(r)"
+    case .conformance(let l, let r):
+      return "\(l): \(r)"
+    case .predicate(let e):
+      return e.description
+    }
+  }
+
+}

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -192,7 +192,7 @@ extension Diagnostic {
   static func note(
     trait x: TraitType, requiresAssociatedType n: String, at site: SourceRange
   ) -> Diagnostic {
-    return .note("trait '\(x)' requires associaed type '\(n)'", at: site)
+    return .note("trait '\(x)' requires associated type '\(n)'", at: site)
   }
 
   static func error(undefinedOperator name: String, at site: SourceRange) -> Diagnostic {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -94,12 +94,6 @@ extension Diagnostic {
     .error("incompatible types '\(l)' and '\(r)'", at: site)
   }
 
-  static func error(invalidUseOfAssociatedType name: String, at site: SourceRange) -> Diagnostic {
-    .error(
-      "associated type '\(name)' can only be used with a concrete type or generic type parameter",
-      at: site)
-  }
-
   static func error(invalidDestructuringOfType type: AnyType, at site: SourceRange) -> Diagnostic {
     .error("invalid destructuring of type '\(type)'", at: site)
   }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -363,6 +363,16 @@ extension Diagnostic {
     }
   }
 
+  static func error(
+    invalidReferenceToAssociatedType a: AssociatedTypeDecl.ID, at site: SourceRange, in ast: AST
+  ) -> Diagnostic {
+    .error(
+      """
+      associated type '\(ast[a].baseName)' can only be referred to with a concrete type or \
+      generic parameter base
+      """, at: site)
+  }
+
   static func warning(needlessImport d: ImportDecl.ID, in ast: AST) -> Diagnostic {
     let s = ast[d].identifier
     return .warning("needless import: source file is part of '\(s.value)'", at: s.site)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1468,7 +1468,7 @@ struct TypeChecker {
     func concreteImplementation(
       of requirement: AnyDeclID, withAPI expectedAPI: API
     ) -> AnyDeclID? {
-      guard !expectedAPI.type[.hasError] else { return nil }
+      if expectedAPI.type[.hasError] { return nil }
 
       switch requirement.kind {
       case FunctionDecl.self:
@@ -2570,9 +2570,7 @@ struct TypeChecker {
     var types: [TupleType.Element] = []
     for (c, x) in captureToStemAndEffect {
       let t = resolveType(of: c, reportingDiagnosticsAt: program[d].site)
-      guard !t[.hasError] else {
-        continue
-      }
+      if t[.hasError] { continue }
 
       let u = RemoteType(x.effect, t)
       captures.append(ImplicitCapture(name: .init(stem: x.stem), type: u, decl: c))
@@ -3860,9 +3858,7 @@ struct TypeChecker {
     reportingDiagnosticsTo log: inout DiagnosticSet
   ) -> (candidateType: AnyType, specialization: GenericArguments, isConstructor: Bool)? {
     var candidateType = resolveType(of: d, lookedUpIn: context, reportingDiagnosticsAt: name.site)
-    guard !candidateType[.hasError] else {
-      return nil
-    }
+    if candidateType[.hasError] { return nil }
 
     // The specialization of the match includes that of context in which it was looked up.
     var specialization = genericArguments(inScopeIntroducing: d, resolvedIn: context)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3942,14 +3942,14 @@ struct TypeChecker {
       return uncheckedType(of: d)
     }
 
-     if isSkolem(domain) {
-       return ^MetatypeType(of: AssociatedTypeType(d, domain: domain, ast: program.ast))
-     } else if domain.base is TraitType {
-       report(.error(invalidReferenceToAssociatedType: d, at: diagnosticSite, in: program.ast))
-       return uncheckedType(of: d)
-     } else {
-       unreachable("unexpected associated type domain")
-     }
+    if isSkolem(domain) {
+      return ^MetatypeType(of: AssociatedTypeType(d, domain: domain, ast: program.ast))
+    } else if domain.base is TraitType {
+      report(.error(invalidReferenceToAssociatedType: d, at: diagnosticSite, in: program.ast))
+      return uncheckedType(of: d)
+    } else {
+      unreachable("unexpected associated type domain")
+    }
   }
 
   /// Returns the generic type of a reference to `d`, found in `context`.

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3950,7 +3950,14 @@ struct TypeChecker {
       return uncheckedType(of: d)
     }
 
-    return ^MetatypeType(of: AssociatedTypeType(d, domain: domain, ast: program.ast))
+     if isSkolem(domain) {
+       return ^MetatypeType(of: AssociatedTypeType(d, domain: domain, ast: program.ast))
+     } else if domain.base is TraitType {
+       report(.error(invalidReferenceToAssociatedType: d, at: diagnosticSite, in: program.ast))
+       return uncheckedType(of: d)
+     } else {
+       unreachable("unexpected associated type domain")
+     }
   }
 
   /// Returns the generic type of a reference to `d`, found in `context`.
@@ -5806,6 +5813,18 @@ struct TypeChecker {
   /// Returns `true` iff `t` is the receiver of a trait declaration.
   private func isTraitReceiver(_ t: GenericTypeParameterType) -> Bool {
     program[t.decl].scope.kind == TraitDecl.self
+  }
+
+  /// Returns `true` iff `t` is bound to an existential quantifier.
+  private func isSkolem(_ t: AnyType) -> Bool {
+    switch t.base {
+    case is AssociatedTypeType, is GenericTypeParameterType:
+      return true
+    case let u as ConformanceLensType:
+      return isSkolem(u.subject)
+    default:
+      return false
+    }
   }
 
   /// Returns `true` if `d` isn't a trait requirement, an FFI, or an external function.

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3702,10 +3702,6 @@ struct TypeChecker {
         continue
       }
 
-      if (context?.type.base is TraitType) && (m.kind == AssociatedTypeDecl.self) {
-        log.insert(.error(invalidUseOfAssociatedType: name.value.stem, at: name.site))
-      }
-
       let cs = collectConstraints(
         associatedWith: m, specializedBy: specialization, in: scopeOfUse, at: name.site)
       candidates.insert(

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3876,8 +3876,8 @@ struct TypeChecker {
       specialization[p] = a
     }
 
-    // If the match is a trait member looked, specialize its receiver.
-    // TODO: Remove `mayCaptureGenericParameters` when
+    // If the match is a trait member, specialize its receiver.
+    // TODO: Remove `mayCaptureGenericParameters`
     if let t = traitDeclaring(d), mayCaptureGenericParameters(d) {
       // DR: `mayCaptureGenericParameters` is used to avoid populating the specialization table
       // when `m` is an associated type declaration. Otherwise, `specialize` causes resolution

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1689,7 +1689,7 @@ struct TypeChecker {
       return commit(GenericEnvironment(of: AnyDeclID(d), introducing: []))
     }
 
-    var partialResult = partiallyConstructedEnvironment(
+    var partialResult = initialEnvironment(
       of: d, default: GenericEnvironment(of: AnyDeclID(d), introducing: clause.parameters))
 
     for p in clause.parameters {
@@ -1719,7 +1719,7 @@ struct TypeChecker {
     if let e = cache.read(\.environment[d]) { return e }
 
     let r = program[d].receiver.id
-    var partialResult = partiallyConstructedEnvironment(
+    var partialResult = initialEnvironment(
       of: d, default: GenericEnvironment(of: AnyDeclID(d), introducing: [r]))
 
     // Synthesize `Self: T`.
@@ -1748,7 +1748,7 @@ struct TypeChecker {
   private mutating func environment<T: TypeExtendingDecl>(of d: T.ID) -> GenericEnvironment {
     if let e = cache.read(\.environment[d]) { return e }
 
-    var partialResult = partiallyConstructedEnvironment(
+    var partialResult = initialEnvironment(
       of: d, default: GenericEnvironment(of: AnyDeclID(d), introducing: []))
 
     for c in (program[d].whereClause?.value.constraints ?? []) {
@@ -1772,8 +1772,9 @@ struct TypeChecker {
     }
   }
 
-  /// Returns the latest computed version of the generic environment introduced by `d`.
-  private mutating func partiallyConstructedEnvironment<T: Decl>(
+  /// Calls `initialResult` to form a generic environment for `d` that doesn't contain any
+  /// constraint on its parameters.
+  private mutating func initialEnvironment<T: Decl>(
     of d: T.ID, default initialResult: @autoclosure () -> GenericEnvironment
   ) -> GenericEnvironment {
     modify(&cache.partiallyFormedEnvironment[d]) { (e) in

--- a/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypeLookup.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypeLookup.hylo
@@ -8,7 +8,7 @@ trait U: T {
 
   property x1: Self.X { let }
 
-  //! @+1 diagnostic associated type 'X' can only be used with a concrete type or generic type parameter
+  //! @+1 diagnostic associated type 'X' can only be referred to with a concrete type or generic parameter base
   property x2: T.X { let }
 
   property x3: Self::T.X { let }

--- a/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypesWithConformances.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypesWithConformances.hylo
@@ -1,0 +1,11 @@
+//- typeCheck expecting: success
+
+trait P { type Z }
+trait Q { type Y }
+trait R { type X: Q }
+trait S { type W: R where W.X: P }
+
+type A<T: S> {
+  typealias B = T.W.X.Y
+  typealias C = T.W.X.Z
+}


### PR DESCRIPTION
This PR refactors name lookup in associated types to take conformance constraints into account. Conformances declared in all traits related to an associated types are now considered.

When performing qualified name lookup into an associated type of the form `T.X.Y`, one should not only consider the conformance constraints declared in the generic environment introducing `T`, but also those declared in the traits defining `X` and `Y` (see [AssociatedTypesWithConformances.hylo](https://github.com/hylo-lang/hylo/blob/2dff14c2380de9642ced5b717071632a3c4b138b/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypesWithConformances.hylo) for an example).