### PR TITLE
Make sure synthesized conformances are sound

### DIFF
--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -241,41 +241,22 @@ public struct AST {
     })
   }
 
-  /// Returns the kind identifying synthesized declarations of `requirement`, which is defined by
-  /// `concept`, or `nil` if `requirement` is not synthesizable.
-  ///
-  /// - Requires: `requirement` must be a requirement of `concept`.
-  public func synthesizedKind<T: DeclID>(
-    of requirement: T, definedBy concept: TraitType
-  ) -> SynthesizedFunctionDecl.Kind? {
+  /// Returns the kind identifying synthesized declarations of `requirement`, or `nil` if
+  /// `requirement` is not synthesizable.
+  public func synthesizedKind<T: DeclID>(of requirement: T) -> SynthesizedFunctionDecl.Kind? {
     // If the requirement is defined in `Deinitializable`, it must be the deinitialization method.
-    if concept == core.deinitializable.type {
-      assert(requirement.kind == FunctionDecl.self)
+    switch requirement.rawValue {
+    case core.deinitializable.deinitialize.rawValue:
       return .deinitialize
-    }
-
-    // If the requirement is defined in `Movable`, it must be either the move-initialization or
-    // move-assignment method.
-    if concept == core.movable.type {
-      let d = MethodImpl.ID(requirement)!
-      switch self[d].introducer.value {
-      case .set:
-        return .moveInitialization
-      case .inout:
-        return .moveAssignment
-      default:
-        unreachable()
-      }
-    }
-
-    // If the requirement is defined in `Copyable`, it must be the copy method.
-    if concept == core.copyable.type {
-      assert(requirement.kind == FunctionDecl.self)
+    case core.movable.moveInitialize.rawValue:
+      return .moveInitialization
+    case core.movable.moveAssign.rawValue:
+      return .moveAssignment
+    case core.copyable.copy.rawValue:
       return .copy
+    default:
+      return nil
     }
-
-    // Requirement is not synthesizable.
-    return nil
   }
 
   /// Returns a table mapping each parameter of `d` to its default argument if `d` is a function,

--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -428,6 +428,17 @@ extension Program {
     unreachable()
   }
 
+  /// Returns the declarations of the stored part of `p`.
+  public func storedParts(of p: ProductTypeDecl.ID) -> [VarDecl.ID] {
+    var result: [VarDecl.ID] = []
+    for m in ast[p].members.filter(BindingDecl.self) {
+      for (_, n) in ast.names(in: ast[m].pattern) {
+        result.append(self[n].decl)
+      }
+    }
+    return result
+  }
+
   /// Returns a textual description of `n` suitable for debugging.
   public func debugDescription<T: NodeIDProtocol>(_ n: T) -> String {
     switch n.kind {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1506,12 +1506,19 @@ struct TypeChecker {
     func resolveFunctionalImplementation(of requirement: AnyDeclID) {
       let expectedAPI = canonicaAPI(of: requirement)
 
+      // Look for a user-defined implementation.
       if let d = concreteImplementation(of: requirement, withAPI: expectedAPI) {
         implementations[requirement] = .concrete(d)
-      } else if let d = syntheticImplementation(of: requirement, withAPI: expectedAPI) {
+      }
+
+      // Build a synthethic implementation if possible.
+      else if let d = syntheticImplementation(of: requirement, withAPI: expectedAPI) {
         implementations[requirement] = .synthetic(d)
         registerSynthesizedDecl(d, in: program.module(containing: program[origin.source].scope))
-      } else {
+      }
+
+      // No implementation matches the requirement.
+      else {
         let t = expectedType(of: requirement)
         let n = Diagnostic.note(
           trait: trait, requires: requirement.kind,

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1455,9 +1455,9 @@ struct TypeChecker {
     func syntheticImplementation(
       of requirement: AnyDeclID, withAPI expectedAPI: API
     ) -> SynthesizedFunctionDecl? {
-      guard let k = program.ast.synthesizedKind(of: requirement, definedBy: trait) else {
-        return nil
-      }
+      guard
+        let k = program.ast.synthesizedKind(of: requirement),
+      else { return nil }
 
       // Note: compiler-known requirement is assumed to be well-typed.
       return .init(k, typed: LambdaType(expectedAPI.type)!, in: AnyScopeID(origin.source)!)

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -453,7 +453,7 @@ public struct TypedProgram {
 
     var implementations = Conformance.ImplementationMap()
     for requirement in ast.requirements(of: concept.decl) {
-      guard let k = ast.synthesizedKind(of: requirement, definedBy: concept) else { return nil }
+      guard let k = ast.synthesizedKind(of: requirement) else { return nil }
 
       let a: GenericArguments = [ast[concept.decl].receiver: .type(model)]
       let t = LambdaType(specialize(declType[requirement]!, for: a, in: scopeOfUse))!

--- a/StandardLibrary/Sources/Core/Void.hylo
+++ b/StandardLibrary/Sources/Core/Void.hylo
@@ -1,4 +1,2 @@
 /// The type whose instance denote the absence of any specific value.
 public typealias Void = {}
-
-public conformance Void: Deinitializable {}

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceStructural.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceStructural.hylo
@@ -1,0 +1,7 @@
+//- typeCheck expecting: failure
+
+//! @+1 diagnostic type 'A<T>' does not conform to trait 'Deinitializable'
+type A<T>: Deinitializable {
+  var x: T
+  public memberwise init
+}

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric.hylo
@@ -4,7 +4,7 @@ type A<X>: Movable, Deinitializable {
   public memberwise init
 }
 
-type B<X>: Movable, Deinitializable {
+type B<X: Deinitializable & Movable>: Movable, Deinitializable {
   var foo: X
   public memberwise init
 

--- a/Tests/HyloTests/TestCases/TypeChecking/NestedGenerics.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NestedGenerics.hylo
@@ -1,6 +1,6 @@
 //- typeCheck expecting: success
 
-type M<T> {
+type M<T: Deinitializable> {
   public var x: T
   public memberwise init
 


### PR DESCRIPTION
This PR makes the checker verifies that synthesized conformances for generic types are sounds. Previously the following declaration would type check, causing the compiler to crash during code generation if `A` was specialized for an indestructible type.

```hylo
type A<T>: Deinitializable {
  var x: T
  public memberwise init
}
```