### PR TITLE
Fix the lowering of for loops in generic contexts

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -650,6 +650,8 @@ struct TypeChecker {
         return ^AssociatedTypeType(t.decl, domain: d, ast: me.program.ast)
       }
 
+      // DR: Maybe we could use `d`'s conformance if it has already been established.
+
       // Otherwise, look for the member of the domain that implements the associated type.
       var candidates = me.lookup(me.program[t.decl].baseName, memberOf: d, exposedTo: scopeOfUse)
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -663,11 +663,15 @@ struct TypeChecker {
         }
       }
 
-      if let selected = candidates.uniqueElement {
-        return MetatypeType(me.uncheckedType(of: selected))?.instance ?? .error
-      } else {
-        return .error
+      if let s = candidates.uniqueElement, let u = MetatypeType(me.uncheckedType(of: s)) {
+        if let b = BoundGenericType(me.canonical(d, in: scopeOfUse)) {
+          return me.specialize(u.instance, for: b.arguments, in: scopeOfUse)
+        } else {
+          return u.instance
+        }
       }
+
+      return .error
     }
 
     func transform(mutating me: inout Self, _ t: BoundGenericType) -> AnyType {

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -217,11 +217,6 @@ public struct TypedProgram {
     isTrivialModel(t, of: ast.core.deinitializable.type, in: scopeOfUse)
   }
 
-  /// Returns `true` iff instances of `t` can be moved with a byte-wise copy.
-  public func isTriviallyMovable(_ t: AnyType, in scopeOfUse: AnyScopeID) -> Bool {
-    isTrivialModel(t, of: ast.core.movable.type, in: scopeOfUse)
-  }
-
   /// Returns `true` iff `t` models `coreConcept` without any user-defined semantics.
   private func isTrivialModel(
     _ t: AnyType, of coreConcept: TraitType, in scopeOfUse: AnyScopeID

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -421,9 +421,7 @@ public struct TypedProgram {
     }
 
     var checker = TypeChecker(asContextFor: self)
-    let bounds = checker.conformedTraits(
-      declaredByConstraintsOn: model,
-      exposedTo: scopeOfUse)
+    let bounds = checker.conformedTraits(declaredByConstraintsOn: model, exposedTo: scopeOfUse)
     if !bounds.contains(concept) { return nil }
 
     var implementations = Conformance.ImplementationMap()

--- a/Sources/IR/CollectionWitness.swift
+++ b/Sources/IR/CollectionWitness.swift
@@ -19,7 +19,7 @@ struct CollectionWitness {
   let positionAfter: Operand
 
   /// The implementation of `Collection.[].let`.
-  let access: Function.ID
+  let access: FunctionReference
 
   /// Creates the lowered witness of the conformance `c` for use in `module`.
   init(_ c: Core.Conformance, in module: inout Module) {
@@ -27,13 +27,15 @@ struct CollectionWitness {
 
     self.position = module.program.associatedType(collection.position, for: c)
     self.element = module.program.associatedType(collection.element, for: c)
+
     self.startPosition = .constant(
       module.reference(toImplementationOf: collection.startPosition, for: c))
     self.endPosition = .constant(
       module.reference(toImplementationOf: collection.endPosition, for: c))
     self.positionAfter = .constant(
       module.reference(toImplementationOf: collection.positionAfter, for: c))
-    self.access = module.demandImplementation(of: collection.access, for: c)
+
+    self.access = module.reference(toImplementationOf: collection.access, for: c)
   }
 
 }

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1268,10 +1268,10 @@ struct Emitter {
     insertionPoint = .end(of: enter)
     let x6 = insert(module.makeAccess(.let, from: domain, at: introducer))!
     let x7 = insert(module.makeAccess(.let, from: currentPosition, at: introducer))!
+
+    let t = RemoteType(.let, collectionWitness.element)
     let x8 = insert(
-      module.makeProject(
-        .init(.let, collectionWitness.element), applying: collectionWitness.access,
-        specializedBy: collectionConformance.arguments, to: [x6, x7], at: introducer))!
+      module.makeProject(t, applying: collectionWitness.access, to: [x6, x7], at: introducer))!
 
     if module.type(of: x8).ast != collectionWitness.element {
       UNIMPLEMENTED("narrowing projections #1099")

--- a/Sources/IR/Operands/Instruction/Project.swift
+++ b/Sources/IR/Operands/Instruction/Project.swift
@@ -63,15 +63,23 @@ extension Project: CustomStringConvertible {
 
 extension Module {
 
-  /// Creates a `project` anchored at `site` that projects a value of type `t` by applying
-  /// `callee`, which is parameterized by `specialization`, on `arguments`.
+  /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
+  /// which is a reference to a lowered subscript, on `arguments`.
   func makeProject(
-    _ t: RemoteType, applying callee: Function.ID, specializedBy specialization: GenericArguments,
-    to arguments: [Operand], at site: SourceRange
+    _ t: RemoteType, applying s: FunctionReference, to arguments: [Operand], at site: SourceRange
   ) -> Project {
     .init(
-      projection: t, callee: callee, specialization: specialization,
+      projection: t, callee: s.function, specialization: s.specialization,
       operands: arguments, site: site)
+  }
+
+  /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
+  /// which is a lowered subscript, specialized by `z`, on `arguments`.
+  func makeProject(
+    _ t: RemoteType, applying s: Function.ID, specializedBy z: GenericArguments,
+    to arguments: [Operand], at site: SourceRange
+  ) -> Project {
+    .init(projection: t, callee: s, specialization: z, operands: arguments, site: site)
   }
 
 }


### PR DESCRIPTION
Lowering a for loop in a trait extension caused the emitter to create unspecialized references to the subscript requirement in `Collection`, making the produced IR impossible to compile to LLVM.