### PR TITLE
Rotate robustness

### DIFF
--- a/StandardLibrary/Sources/Core/MutableCollection.hylo
+++ b/StandardLibrary/Sources/Core/MutableCollection.hylo
@@ -16,8 +16,8 @@ trait MutableCollection: Collection {
 public extension MutableCollection {
 
   /// Swaps the order in which the values `self[..<p]` and `self[p...]` occur, so that the end of
-  /// the latter sequence of element values is the start of the former sequence; returns that
-  /// position, where the sequences coincide.
+  /// the latter sequence of element values is the start of the former sequence, and returns that
+  /// position.
   ///
   /// - Complexity: O(n), where n is the number of elements in `self`.
   public fun rotate(regions_separated_by p: Position) inout -> Position {

--- a/StandardLibrary/Sources/Core/MutableCollection.hylo
+++ b/StandardLibrary/Sources/Core/MutableCollection.hylo
@@ -16,12 +16,8 @@ trait MutableCollection: Collection {
 public extension MutableCollection {
 
   /// Swaps the order in which the values `self[..<p]` and `self[p...]` occur, so that the end of
-  /// the latter sequence of element values is the start of the former sequence, and returns that
-  /// position.
-  ///
-  /// The value originally at `self[p]` (if any) ends up first.  The value originally located at
-  /// `p`'s predecessor (if any) ends up last.  The return value is the new position of the value
-  /// originally at `start_position()` (if any).
+  /// the latter sequence of element values is the start of the former sequence; returns that
+  /// position, where the sequences coincide.
   ///
   /// - Complexity: O(n), where n is the number of elements in `self`.
   public fun rotate(regions_separated_by p: Position) inout -> Position {

--- a/StandardLibrary/Sources/Core/MutableCollection.hylo
+++ b/StandardLibrary/Sources/Core/MutableCollection.hylo
@@ -15,47 +15,80 @@ trait MutableCollection: Collection {
 
 public extension MutableCollection {
 
-  /// Shifts the elements of `self` so that the element currently at `middle` becomes first.
+  /// Swaps the order in which the values `self[..<p]` and `self[p...]` occur, so that the end of
+  /// the latter sequence of element values is the start of the former sequence, and returns that
+  /// position.
   ///
-  /// The contents of `self` is reordered so that the elements in the range [`middle`, `end`) occur
-  /// before the elements in the range [`start`, `middle`) and the orders of the elements in these
-  /// ranges  are preserved.
+  /// The value originally at `self[p]` (if any) ends up first.  The value originally located at
+  /// `p`'s predecessor (if any) ends up last.  The return value is the new position of the value
+  /// originally at `start_position()` (if any).
   ///
   /// - Complexity: O(n), where n is the number of elements in `self`.
-  public fun rotate(to_start_at middle: Position) inout {
-    // Handle the trivial cases
-    if middle == start_position() { return }
-    if middle == end_position() { return }
-
+  public fun rotate(regions_separated_by p: Position) inout -> Position {
+    var m = p.copy()
     var s = start_position()
-    var m = middle.copy()
-    var i = middle.copy()
+    let e = end_position()
 
-    // Bring the back range to the front.
+    // Handle the trivial cases
+    if s == m { return e }
+    if m == e { return s }
+
+    // We have two regions of possibly-unequal length that need to be
+    // exchanged.  The return value of this method is going to be the
+    // position following that of the element that is currently last
+    // (element j).
+    //
+    //   [a b c d e f g|h i j]   or   [a b c|d e f g h i j]
+    //   ^             ^     ^        ^     ^             ^
+    //   s             m     e        s     m             e
+    //
+    var ret = e.copy() // start with a known incorrect result.
     while true {
-      swap_at(s, i)
-      &s = position(after: s)
-      &i = position(after: i)
-      if i == end_position() { break }
-      if s == m { &m = i.copy() }
-    }
+      // Exchange the leading elements of each region (up to the
+      // length of the shorter region).
+      //
+      //   [a b c d e f g|h i j]   or   [a b c|d e f g h i j]
+      //    ^^^^^         ^^^^^          ^^^^^ ^^^^^
+      //   [h i j d e f g|a b c]   or   [d e f|a b c g h i j]
+      //   ^     ^       ^     ^         ^    ^     ^       ^
+      //   s    s1       m    m1/e       s   s1/m   m1      e
+      //
 
-    // Nothing more to do; the order of the front range was maintained.
-    if s == m { return }
-
-    // Reestablish the order of the front range (now at the back).
-    &i = m.copy()
-    while true {
-      swap_at(s, i)
-      &s = position(after: s)
-      &i = position(after: i)
-      if i == end_position() {
-        if s == m { break }
-        &i = m.copy()
-      } else if s == m {
-        &m = i.copy()
+      var s1 = s.copy()
+      var m1 = m.copy()
+      while true {
+        swap_at(s1, m1)
+        &s1 = position(after: &s1)
+        &m1 = position(after: &m1)
+        if s1 == m || m1 == e { break }
       }
+
+
+      if m1 == e {
+        // Left-hand case: we have moved element j into position.  if
+        // we haven't already, we can capture the return value which
+        // is in s1.
+        //
+        // Note: the STL breaks the loop into two just to avoid this
+        // comparison once the return value is known.  I'm not sure
+        // it's a worthwhile optimization, though.
+        if ret == e { &ret = s1.copy() }
+
+        // If both regions were the same size, we're done.
+        if s1 == m { break }
+      }
+
+      // Now we have a smaller problem that is also a rotation, so we
+      // can adjust our bounds and repeat.
+      //
+      //    h i j[d e f g|a b c]   or    d e f[a b c|g h i j]
+      //         ^       ^     ^              ^     ^       ^
+      //         s       m     e              s     m       e
+      &s = s1.copy()
+      if s == m { &m = m1.copy() }
     }
+
+    return ret
   }
 
 }

--- a/StandardLibrary/Sources/Core/MutableCollection.hylo
+++ b/StandardLibrary/Sources/Core/MutableCollection.hylo
@@ -21,15 +21,15 @@ public extension MutableCollection {
   /// before the elements in the range [`start`, `middle`) and the orders of the elements in these
   /// ranges  are preserved.
   ///
-  /// - Requires: `middle != end_position()`.
   /// - Complexity: O(n), where n is the number of elements in `self`.
   public fun rotate(to_start_at middle: Position) inout {
+    // Handle the trivial cases
+    if middle == start_position() { return }
+    if middle == end_position() { return }
+
     var s = start_position()
     var m = middle.copy()
     var i = middle.copy()
-
-    // Nothing to do if `middle` is already pointing at the start of `self`.
-    if s == m { return }
 
     // Bring the back range to the front.
     while true {

--- a/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
+++ b/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
@@ -1,6 +1,7 @@
 //- compileAndRun expecting: success
 
-fun fill(_ a: inout Array<Int>, to limit: Int) {
+/// Appends `0 ..< limit` to `a`
+fun appendCount(up_to limit: Int, to a: inout Array<Int>) {
   var i = 0
   while i < limit {
     &a.append(i.copy())
@@ -8,31 +9,44 @@ fun fill(_ a: inout Array<Int>, to limit: Int) {
   }
 }
 
-fun test_rotate() -> Bool {
-
-  let N = 17
-
+/// Tests rotate on collections of length N
+fun test_rotate(length N: Int) {
   var failed = false
-  var i = 0
-  while i <= N {
 
+  // For all possible pivot points
+  var pivot = 0
+  while pivot <= N {
+
+    // A collection to work on
     var a = Array<Int>()
-    fill(&a, to: N)
+    appendCount(up_to: N, to: &a)
 
-    &a.rotate(to_start_at: i)
+    &a.rotate(to_start_at: pivot)
+
+    // Verify the results
     var j = 0
-
     while j < N {
-      if a[j] != (i + j) % N {
+      if a[j] != (pivot + j) % N {
         &failed = true
       }
       j += 1
     }
-    i += 1
+
+    pivot += 1
   }
-  return !failed
+  precondition(!failed)
+}
+
+/// Tests rotate on a variety of lengths
+fun test_rotate() {
+  var failed = false
+  var n = 0
+  while n < 17 {
+    test_rotate(length: n)
+    n += 1
+  }
 }
 
 public fun main() {
-  precondition(test_rotate())
+  test_rotate()
 }

--- a/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
+++ b/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
@@ -1,7 +1,7 @@
 //- compileAndRun expecting: success
 
 /// Appends `0 ..< limit` to `a`
-fun appendCount(up_to limit: Int, to a: inout Array<Int>) {
+fun append_count(up_to limit: Int, to a: inout Array<Int>) {
   var i = 0
   while i < limit {
     &a.append(i.copy())
@@ -19,7 +19,7 @@ fun test_rotate(length N: Int) {
 
     // A collection to work on
     var a = Array<Int>()
-    appendCount(up_to: N, to: &a)
+    append_count(up_to: N, to: &a)
 
     let newPivot = &a.rotate(regions_separated_by: pivot)
     if newPivot != N - pivot { &failed = true }

--- a/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
+++ b/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
@@ -14,7 +14,7 @@ fun test_rotate() -> Bool {
 
   var failed = false
   var i = 0
-  while i < N {
+  while i <= N {
 
     var a = Array<Int>()
     fill(&a, to: N)

--- a/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
+++ b/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
@@ -21,7 +21,8 @@ fun test_rotate(length N: Int) {
     var a = Array<Int>()
     appendCount(up_to: N, to: &a)
 
-    &a.rotate(to_start_at: pivot)
+    let newPivot = &a.rotate(regions_separated_by: pivot)
+    if newPivot != N - pivot { &failed = true }
 
     // Verify the results
     var j = 0

--- a/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
+++ b/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
@@ -1,25 +1,38 @@
 //- compileAndRun expecting: success
 
-fun test_rotate() {
-  var a = Array<Int>()
+fun fill(_ a: inout Array<Int>, to limit: Int) {
+  var i = 0
+  while i < limit {
+    &a.append(i.copy())
+    i += 1
+  }
+}
 
-  &a.append(0)
-  &a.append(1)
-  &a.append(2)
-  &a.append(3)
-  &a.append(4)
-  &a.append(5)
+fun test_rotate() -> Bool {
 
-  &a.rotate(to_start_at: 2)
+  let N = 17
 
-  precondition(a[0] == 2)
-  precondition(a[1] == 3)
-  precondition(a[2] == 4)
-  precondition(a[3] == 5)
-  precondition(a[4] == 0)
-  precondition(a[5] == 1)
+  var failed = false
+  var i = 0
+  while i < N {
+
+    var a = Array<Int>()
+    fill(&a, to: N)
+
+    &a.rotate(to_start_at: i)
+    var j = 0
+
+    while j < N {
+      if a[j] != (i + j) % N {
+        &failed = true
+      }
+      j += 1
+    }
+    i += 1
+  }
+  return !failed
 }
 
 public fun main() {
-  test_rotate()
+  precondition(test_rotate())
 }


### PR DESCRIPTION
This PR adds a much more complete test of Hylo's rotate and makes it handle one important case that used to cause an assertion.

Except for not returning the new pivot, it actually does work!  So I'm sorry I doubted it (@kyouko-taiga). Amazingly, the swift implementation it was derived from failed [this test](https://github.com/hylo-lang/hylo/blob/045f1bb3f3313b532bb67dfc4285cf2fdb6dfce6/Tests/UtilsTests/CollectionExtensionsTests.swift#L68-L89).

As a student of rotate, I was expecting to see nested loops, which I have in my implementation.  But it's been too long since I worked on that algorithm, so I had forgotten the purpose of that nesting; I should have remembered that since it's O(N)  that nesting isn't strictly necessary; it just avoids a bunch of tests/branches.  

----

**update**: this PR now replaces the implementation of rotate with a more efficient one that returns the new pivot.

The comments in the original implementation didn't make sense to me;  I couln't understand how it works and thus I couldn't quite figure out how to get it to return the new pivot.