### PR TITLE
Improve the support of constraints on associated types

### DIFF
--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -427,6 +427,30 @@ public struct AST {
     self[self[self[s].binding].pattern].introducer.value.isConsuming
   }
 
+  /// Returns `true` if `e` is an expression starting with an implicit name qualification.
+  public func isImplicitlyQualified(_ e: AnyExprID) -> Bool {
+    switch e.kind {
+    case FunctionCallExpr.self:
+      return isImplicitlyQualified(self[FunctionCallExpr.ID(e)!].callee)
+    case NameExpr.self:
+      return isImplicitlyQualified(NameExpr.ID(e)!)
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` if `e` is an expression starting with an implicit name qualification.
+  public func isImplicitlyQualified(_ e: NameExpr.ID) -> Bool {
+    switch self[e].domain {
+    case .implicit:
+      return true
+    case .explicit(let e):
+      return isImplicitlyQualified(e)
+    case .none, .operand:
+      return false
+    }
+  }
+
   /// Returns the source site of `expr`.
   public func site(of expr: FoldedSequenceExpr) -> SourceRange {
     switch expr {

--- a/Sources/Core/AST/NodeIDs/NodeID.swift
+++ b/Sources/Core/AST/NodeIDs/NodeID.swift
@@ -15,6 +15,11 @@ public protocol NodeIDProtocol: Hashable, Codable, CustomStringConvertible {
 
 extension NodeIDProtocol {
 
+  /// `true` iff `self` denotes a generic scope.
+  public var isGenericScope: Bool {
+    kind.value is GenericScope.Type
+  }
+
   public var description: String { "\(kind)(\(rawValue))" }
 
 }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -337,7 +337,7 @@ struct TypeChecker {
     declaredByConstraintsOn t: AnyType, exposedTo scopeOfUse: AnyScopeID
   ) -> Set<TraitType> {
     var result = Set<TraitType>()
-    for s in program.scopes(from: scopeOfUse) where s.kind.value is GenericScope.Type {
+    for s in program.scopes(from: scopeOfUse) where s.isGenericScope {
       // Only ask the computation of the environment if we have no (possibly partial) result in
       // cache, so that lookup queries related by the environment construction can't trigger
       // infinite recursion.
@@ -4239,7 +4239,7 @@ struct TypeChecker {
   /// Returns `true` if a reference to `d` may capture generic parameters from the surrounding
   /// lookup context.
   private func mayCaptureGenericParameters(_ d: AnyDeclID) -> Bool {
-    d.kind.value is GenericScope.Type
+    d.isGenericScope
   }
 
   /// Associates `parameters`, which are introduced by `name`'s declaration, to corresponding

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -5036,7 +5036,8 @@ struct TypeChecker {
     let resolution = resolve(e, usedAs: purpose) { (me, n) in
       switch me.program[n].domain {
       case .explicit(let e):
-        return me.inferredType(of: e, updating: &obligations)
+        let h = me.program.ast.isImplicitlyQualified(e) ? implicitNominalScope : nil
+        return me.inferredType(of: e, withHint: h, updating: &obligations)
       case .implicit:
         return implicitNominalScope
       case .none, .operand:

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -80,10 +80,10 @@ struct TypeChecker {
     if t[.isCanonical] { return t }
 
     switch t.base {
-    case let u as TypeAliasType:
-      return canonical(u.aliasee.value, in: scopeOfUse)
     case let u as BoundGenericType:
       return canonical(u, in: scopeOfUse)
+    case let u as TypeAliasType:
+      return canonical(u.aliasee.value, in: scopeOfUse)
     case let u as UnionType:
       return canonical(u, in: scopeOfUse)
     default:

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3331,8 +3331,12 @@ struct TypeChecker {
   ) -> Set<AnyDeclID> {
     if let d = names(introducedIn: nominalScope.decl)[stem] {
       return d
-    } else {
+    } else if program[nominalScope.decl].genericParameters.isEmpty {
       return lookup(stem, memberOf: nominalScope.aliasee.value, exposedTo: scopeOfUse)
+    } else {
+      let t = MetatypeType(uncheckedType(of: nominalScope.decl))!
+      let a = TypeAliasType(t.instance)!.aliasee.value
+      return lookup(stem, memberOf: a, exposedTo: scopeOfUse)
     }
   }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -4131,8 +4131,8 @@ struct TypeChecker {
     exposedTo scopeOfUse: AnyScopeID,
     reportingDiagnosticsAt diagnosticSite: SourceRange
   ) -> AnyType {
-    // The domain of associated type resolved without qualification is skolem bound by the trait in
-    // which the reference to `d` occurs.
+    // The domain of associated type resolved without qualification is a skolem bound by the trait
+    // in which the reference to `d` occurs.
     guard let domain = context?.type else {
       if let s = resolveTraitReceiver(in: scopeOfUse) {
         return ^MetatypeType(of: AssociatedTypeType(d, domain: ^s, ast: program.ast))

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -6029,17 +6029,15 @@ struct TypeChecker {
     program[t.decl].scope.kind == TraitDecl.self
   }
 
-  /// Returns `true` iff `t` is a trait receiver or an associated type rooted at a trait receiver.
+  /// Returns `true` iff `t` is a generic type parameter an associated type rooted at one.
   private func isAbstractAssociatedDomain(_ t: AnyType) -> Bool {
     switch t.base {
     case let u as AssociatedTypeType:
       return isAbstractAssociatedDomain(u.domain)
     case let u as ConformanceLensType:
       return isAbstractAssociatedDomain(u.subject)
-    case let u as GenericTypeParameterType:
-      return isTraitReceiver(u)
-    default:
-      return false
+    case let u:
+      return u is GenericTypeParameterType
     }
   }
 

--- a/Sources/Utils/Collection+Extensions.swift
+++ b/Sources/Utils/Collection+Extensions.swift
@@ -42,9 +42,9 @@ extension Collection {
 
   /// Returns the minimal elements of `self` using `compare` to order them.
   ///
-  /// A minimal element of a set *S* with a strict partial order *R* is an element is not smaller
-  /// than any other element in *S*. If *S* is a finite set and *R* is a strict total order, the
-  /// notions of minimal element and minimum coincide.
+  /// A minimal element of a set *S* with a strict partial order *R* is an element not smaller than
+  /// any other element in *S*. If *S* is a finite set and *R* is a strict total order, the notions
+  /// of minimal element and minimum coincide.
   ///
   /// - Complexity: O(*n*^2) where *n* is the length of `self`.
   public func minimalElements(

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension.hylo
@@ -1,10 +1,23 @@
 //- typeCheck expecting: failure
 
-type A<X> {}
-
 trait T {
   fun foo()
 }
 
+type A<X> {}
+
+type B<X>: Deinitializable {
+  memberwise init
+}
+
 //! @+1 diagnostic undefined name 'S' in this scope
 extension A where X: S {}
+
+extension B where X: T {
+  fun foo() {}
+}
+
+public fun main() {
+  //! @+1 diagnostic type 'Bool' does not conform to trait 'T'
+  B<Bool>().foo()
+}

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension2.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension2.hylo
@@ -1,0 +1,21 @@
+//- typeCheck expecting: success
+
+trait P { type X }
+trait Q { type Y }
+
+type A<E>: Deinitializable {
+  public memberwise init
+}
+
+extension A where E: P, E.X: Q {
+  fun foo() {}
+}
+
+type B<X: Q>: P {}
+type C: Q {
+  public typealias Y = Bool
+}
+
+public fun main() {
+  A<B<C>>.foo()
+}


### PR DESCRIPTION
This PR brings various improvements to the support of constraints on associated types. In particular, it fixes a couple of issues with the specialization of type aliases (which are typically used to form conformances) involving generic types.