### PR TITLE
Rename LambdaType to ArrowType

### DIFF
--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -196,7 +196,7 @@ extension LLVM.Module {
   ///
   /// - Note: the type of a function in Hylo IR typically doesn't match the type of its transpiled
   ///   form 1-to-1, as return values are often passed by references.
-  private mutating func transpiledType(_ t: LambdaType) -> LLVM.FunctionType {
+  private mutating func transpiledType(_ t: ArrowType) -> LLVM.FunctionType {
     // Return value is passed by reference.
     var parameters: Int = t.inputs.count + 1
 
@@ -447,7 +447,7 @@ extension LLVM.Module {
   private mutating func declare(
     _ ref: IR.FunctionReference, from ir: IR.Program
   ) -> LLVM.Function {
-    let t = transpiledType(LambdaType(ref.type.ast)!)
+    let t = transpiledType(ArrowType(ref.type.ast)!)
     return declareFunction(ir.llvmName(of: ref.function), t)
   }
 
@@ -1204,28 +1204,28 @@ extension LLVM.Module {
     }
 
     /// Returns the callee of `s`.
-    func unpackCallee(of s: Operand) -> LambdaContents {
+    func unpackCallee(of s: Operand) -> ArrowContents {
       if case .constant(let f) = s {
         let f = transpiledConstant(f, usedIn: m, from: ir)
         let t = LLVM.Function(f)!.valueType
         return .init(function: f, type: t, environment: [])
       }
 
-      // `s` is a lambda.
-      let hyloType = LambdaType(m.type(of: s).ast)!
+      // `s` is an arrow.
+      let hyloType = ArrowType(m.type(of: s).ast)!
       let llvmType = StructType(ir.llvm(hyloType, in: &self))!
-      let lambda = llvm(s)
+      let arrow = llvm(s)
 
       // The first element of the representation is the function pointer.
       var f = insertGetStructElementPointer(
-        of: lambda, typed: llvmType, index: 0, at: insertionPoint)
+        of: arrow, typed: llvmType, index: 0, at: insertionPoint)
       f = insertLoad(ptr, from: f, at: insertionPoint)
 
       // Following elements constitute the environment.
       var environment: [LLVM.IRValue] = []
       for (i, c) in hyloType.captures.enumerated() {
         var x = insertGetStructElementPointer(
-          of: lambda, typed: llvmType, index: i + 1, at: insertionPoint)
+          of: arrow, typed: llvmType, index: i + 1, at: insertionPoint)
 
         // Remote captures are passed deferenced.
         if c.type.base is RemoteType {
@@ -1276,8 +1276,8 @@ extension LLVMProgram: CustomStringConvertible {
 
 }
 
-/// The contents of a lambda.
-private struct LambdaContents {
+/// The contents of an arrow.
+private struct ArrowContents {
 
   /// A pointer to the underlying thin function.
   let function: LLVM.IRValue
@@ -1285,7 +1285,7 @@ private struct LambdaContents {
   /// The type `function`.
   let type: LLVM.IRType
 
-  /// The lambda's environment.
+  /// The arrow's environment.
   let environment: [LLVM.IRValue]
 
 }

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -18,8 +18,8 @@ extension IR.Program {
       return llvm(builtinType: t, in: &module)
     case let t as BoundGenericType:
       return llvm(boundGenericType: t, in: &module)
-    case let t as LambdaType:
-      return llvm(lambdaType: t, in: &module)
+    case let t as ArrowType:
+      return llvm(arrowType: t, in: &module)
     case is MetatypeType:
       return module.ptr
     case let t as ProductType:
@@ -94,7 +94,7 @@ extension IR.Program {
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(lambdaType val: LambdaType, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm(arrowType val: ArrowType, in module: inout LLVM.Module) -> LLVM.IRType {
     precondition(val[.isCanonical])
 
     let fields = Array(repeating: module.ptr, count: base.storage(of: val).count)

--- a/Sources/Core/AST/AST+Walk.swift
+++ b/Sources/Core/AST/AST+Walk.swift
@@ -97,6 +97,8 @@ extension AST {
     case VarDecl.self:
       traverse(self[n] as! VarDecl, notifying: &o)
 
+    case ArrowTypeExpr.self:
+      traverse(self[n] as! ArrowTypeExpr, notifying: &o)
     case BooleanLiteralExpr.self:
       traverse(self[n] as! BooleanLiteralExpr, notifying: &o)
     case BufferLiteralExpr.self:
@@ -121,8 +123,6 @@ extension AST {
       traverse(self[n] as! IntegerLiteralExpr, notifying: &o)
     case LambdaExpr.self:
       traverse(self[n] as! LambdaExpr, notifying: &o)
-    case LambdaTypeExpr.self:
-      traverse(self[n] as! LambdaTypeExpr, notifying: &o)
     case MapLiteralExpr.self:
       traverse(self[n] as! MapLiteralExpr, notifying: &o)
     case MatchExpr.self:
@@ -507,7 +507,7 @@ extension AST {
 
   /// Visits the children of `n` in pre-order, notifying `o` when a node is entered or left.
   public func traverse<O: ASTWalkObserver>(
-    _ n: LambdaTypeExpr, notifying o: inout O
+    _ n: ArrowTypeExpr, notifying o: inout O
   ) {
     walk(n.environment, notifying: &o)
     walk(roots: n.parameters.map(\.type), notifying: &o)

--- a/Sources/Core/AST/Decl/SynthesizedFunctionDecl.swift
+++ b/Sources/Core/AST/Decl/SynthesizedFunctionDecl.swift
@@ -27,7 +27,7 @@ public struct SynthesizedFunctionDecl: Hashable {
   }
 
   /// The type of this declaration.
-  public let type: LambdaType
+  public let type: ArrowType
 
   /// The scope in which the declaration is defined.
   public let scope: AnyScopeID
@@ -36,7 +36,7 @@ public struct SynthesizedFunctionDecl: Hashable {
   public let kind: Kind
 
   /// Creates an instance with the given properties.
-  public init(_ kind: Kind, typed type: LambdaType, in scope: AnyScopeID) {
+  public init(_ kind: Kind, typed type: ArrowType, in scope: AnyScopeID) {
     self.kind = kind
     self.type = type
     self.scope = scope

--- a/Sources/Core/AST/Expr/ArrowTypeExpr.swift
+++ b/Sources/Core/AST/Expr/ArrowTypeExpr.swift
@@ -1,7 +1,7 @@
-/// A lambda type expression.
-public struct LambdaTypeExpr: Expr {
+/// An arrow type expression.
+public struct ArrowTypeExpr: Expr {
 
-  /// A parameter in a lambda type expression.
+  /// A parameter in an arrow type expression.
   public struct Parameter: Codable {
 
     /// The label of the parameter.
@@ -19,16 +19,16 @@ public struct LambdaTypeExpr: Expr {
 
   public private(set) var site: SourceRange
 
-  /// The effect of the lambda's call operator.
+  /// The effect of the arrow's call operator.
   public let receiverEffect: SourceRepresentable<AccessEffect>?
 
-  /// The environment of the lambda, or `nil` if it is thin.
+  /// The environment of the arrow, or `nil` if it is thin.
   public private(set) var environment: AnyExprID?
 
-  /// The parameters of the lambda.
+  /// The parameters of the arrow.
   public let parameters: [Parameter]
 
-  /// The output type of the lambda.
+  /// The output type of the arrow.
   public let output: AnyExprID
 
   public init(

--- a/Sources/Core/AST/Expr/ParameterTypeExpr.swift
+++ b/Sources/Core/AST/Expr/ParameterTypeExpr.swift
@@ -1,4 +1,4 @@
-/// A parameter in a lambda type expression.
+/// A parameter in an arrow type expression.
 public struct ParameterTypeExpr: Expr {
 
   public let site: SourceRange

--- a/Sources/Core/AST/NodeIDs/NodeKind.swift
+++ b/Sources/Core/AST/NodeIDs/NodeKind.swift
@@ -100,6 +100,7 @@ extension NodeKind {
     TypeAliasDecl.self,
     VarDecl.self,
 
+    ArrowTypeExpr.self,
     BooleanLiteralExpr.self,
     BufferLiteralExpr.self,
     CastExpr.self,
@@ -112,7 +113,6 @@ extension NodeKind {
     InoutExpr.self,
     IntegerLiteralExpr.self,
     LambdaExpr.self,
-    LambdaTypeExpr.self,
     MapLiteralExpr.self,
     MatchExpr.self,
     NameExpr.self,

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -8,7 +8,7 @@ public struct BuiltinFunction: Hashable {
   public let name: Name
 
   /// Returns the type of the function, calling `freshVariable` to create fresh type variables.
-  public func type(makingFreshVariableWith freshVariable: () -> TypeVariable) -> LambdaType {
+  public func type(makingFreshVariableWith freshVariable: () -> TypeVariable) -> ArrowType {
     switch self.name {
     case .addressOf:
       let p = ParameterType(.let, ^freshVariable())

--- a/Sources/Core/NativeInstruction.swift
+++ b/Sources/Core/NativeInstruction.swift
@@ -152,7 +152,7 @@ public enum NativeInstruction: Hashable {
 extension NativeInstruction {
 
   /// The type of this instruction when used as a function.
-  public var type: LambdaType {
+  public var type: ArrowType {
     switch self {
     case .add(_, let t):
       return .init(^t, ^t, to: ^t)

--- a/Sources/Core/Types/AnyType.swift
+++ b/Sources/Core/Types/AnyType.swift
@@ -102,7 +102,7 @@ public struct AnyType {
 
   /// `self` transformed as the type of a member of `receiver`, which is existential.
   public func asMember(of receiver: ExistentialType) -> AnyType {
-    let m = LambdaType(self) ?? UNIMPLEMENTED()
+    let m = ArrowType(self) ?? UNIMPLEMENTED()
     return ^m.asMember(of: receiver)
   }
 
@@ -125,7 +125,7 @@ public struct AnyType {
     switch base {
     case let t as BoundGenericType:
       return t.base.isLeaf
-    case is ExistentialType, is LambdaType, is TypeVariable:
+    case is ExistentialType, is ArrowType, is TypeVariable:
       return false
     case let t as TypeAliasType:
       return t.resolved.isLeaf
@@ -189,7 +189,7 @@ public struct AnyType {
   /// Indicates whether `self` has a record layout.
   public var hasRecordLayout: Bool {
     switch base {
-    case is BufferType, is LambdaType, is ProductType, is TupleType:
+    case is BufferType, is ArrowType, is ProductType, is TupleType:
       return true
     case let type as BoundGenericType:
       return type.base.hasRecordLayout
@@ -262,7 +262,7 @@ public struct AnyType {
       }
       return result
 
-    case (let lhs as LambdaType, let rhs as LambdaType):
+    case (let lhs as ArrowType, let rhs as ArrowType):
       if !lhs.labels.elementsEqual(rhs.labels) { return false }
 
       var result = true

--- a/Sources/Core/Types/ArrowType.swift
+++ b/Sources/Core/Types/ArrowType.swift
@@ -1,18 +1,18 @@
 import Utils
 
-/// The type of a lambda.
-public struct LambdaType: TypeProtocol {
+/// A type denoting arrow-like objects.
+public struct ArrowType: TypeProtocol {
 
-  /// The effect of the lambda's call operator.
+  /// The effect of the arrow's call operator.
   public let receiverEffect: AccessEffect
 
-  /// The environment of the lambda.
+  /// The environment of the arrow.
   public let environment: AnyType
 
-  /// The input labels and types of the lambda.
+  /// The input labels and types of the arrow.
   public let inputs: [CallableTypeParameter]
 
-  /// The output type of the lambda.
+  /// The output type of the arrow.
   public let output: AnyType
 
   public let flags: TypeFlags
@@ -45,7 +45,7 @@ public struct LambdaType: TypeProtocol {
   /// Given an initializer type `t`, creates the corresponding constructor type.
   ///
   /// - Requires: `t` is an initializer type of the form `[](self: set A, B...) -> Void`.
-  public init(constructorFormOf t: LambdaType) {
+  public init(constructorFormOf t: ArrowType) {
     let r = ParameterType(t.inputs.first!.type)!
     precondition(r.access == .set)
     self.init(inputs: Array(t.inputs[1...]), output: r.bareType)
@@ -54,13 +54,13 @@ public struct LambdaType: TypeProtocol {
   /// Given an constructor type `t`, creates the corresponding initializer type.
   ///
   /// - Requires: `t` is a constructor type of the form `[](A...) -> B`.
-  public init(initializerFormOf t: LambdaType) {
+  public init(initializerFormOf t: ArrowType) {
     let r = CallableTypeParameter(label: "self", type: ^ParameterType(.set, t.output))
     self.init(receiverEffect: .let, inputs: [r] + t.inputs, output: .void)
   }
 
   /// Returns a thin type accepting `self`'s environment as parameters.
-  public var lifted: LambdaType {
+  public var lifted: ArrowType {
     let elements = TupleType(environment).map(\.elements) ?? [.init(label: nil, type: environment)]
     let p = elements.map { (e) -> CallableTypeParameter in
       if let t = RemoteType(e.type) {
@@ -73,8 +73,8 @@ public struct LambdaType: TypeProtocol {
   }
 
   /// `self` sans environment.
-  public var strippingEnvironment: LambdaType {
-    LambdaType(receiverEffect: receiverEffect, environment: .void, inputs: inputs, output: output)
+  public var strippingEnvironment: ArrowType {
+    ArrowType(receiverEffect: receiverEffect, environment: .void, inputs: inputs, output: output)
   }
 
   /// `self` transformed as the type of a member of `receiver`, which is existential.
@@ -86,19 +86,19 @@ public struct LambdaType: TypeProtocol {
       r = ^receiver
     }
 
-    return ^LambdaType(
+    return ^ArrowType(
       receiverEffect: receiverEffect,
       environment: ^TupleType(labelsAndTypes: [("self", r)]),
       inputs: inputs, output: output)
   }
 
-  /// Accesses the individual elements of the lambda's environment.
+  /// Accesses the individual elements of the arrow's environment.
   public var captures: [TupleType.Element] { TupleType(environment)?.elements ?? [] }
 
   public func transformParts<M>(
     mutating m: inout M, _ transformer: (inout M, AnyType) -> TypeTransformAction
   ) -> Self {
-    LambdaType(
+    ArrowType(
       receiverEffect: receiverEffect,
       environment: environment.transform(mutating: &m, transformer),
       inputs: inputs.map({ $0.transform(mutating: &m, transformer) }),
@@ -106,13 +106,13 @@ public struct LambdaType: TypeProtocol {
   }
 }
 
-extension LambdaType: CallableType {
+extension ArrowType: CallableType {
 
   public var isArrow: Bool { true }
 
 }
 
-extension LambdaType: CustomStringConvertible {
+extension ArrowType: CustomStringConvertible {
 
   public var description: String {
     "[\(environment)] (\(list: inputs)) \(receiverEffect) -> \(output)"

--- a/Sources/Core/Types/ArrowType.swift
+++ b/Sources/Core/Types/ArrowType.swift
@@ -1,6 +1,6 @@
 import Utils
 
-/// A type denoting arrow-like objects.
+/// A type expressed with an arrow.
 public struct ArrowType: TypeProtocol {
 
   /// The effect of the arrow's call operator.

--- a/Sources/Core/Types/ParameterType.swift
+++ b/Sources/Core/Types/ParameterType.swift
@@ -1,6 +1,6 @@
 import Utils
 
-/// The type of a parameter in a lambda, method, or subscript type.
+/// The type of a parameter in an arrow, method, or subscript type.
 public struct ParameterType: TypeProtocol {
 
   /// The passing convention of the parameter.

--- a/Sources/Core/Types/SubscriptImplType.swift
+++ b/Sources/Core/Types/SubscriptImplType.swift
@@ -41,7 +41,7 @@ public struct SubscriptImplType: TypeProtocol {
   /// Indicates whether `self` has an empty environment.
   public var isThin: Bool { environment == .void }
 
-  /// Accesses the individual elements of the lambda's environment.
+  /// Accesses the individual elements of the arrow's environment.
   public var captures: [TupleType.Element] { TupleType(environment)?.elements ?? [] }
 
   public func transformParts<M>(

--- a/Sources/Core/Types/SubscriptType.swift
+++ b/Sources/Core/Types/SubscriptType.swift
@@ -44,7 +44,7 @@ public struct SubscriptType: TypeProtocol {
   public var captures: [TupleType.Element] { TupleType(environment)?.elements ?? [] }
 
   /// Returns the type of the thin function corresponding to `self`.
-  public var pure: LambdaType {
+  public var pure: ArrowType {
     let captures = TupleType(environment).map(\.elements) ?? [.init(label: nil, type: environment)]
     let p = captures.map { (e) -> CallableTypeParameter in
       if let t = RemoteType(e.type) {

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -231,7 +231,7 @@ struct ConstraintSystem {
     assert(!(model.base is TypeVariable))
 
     switch model.base {
-    case let t as LambdaType:
+    case let t as ArrowType:
       return delegate(structuralConformance: goal, for: t.captures.lazy.map(\.type))
     case let t as TupleType:
       return delegate(structuralConformance: goal, for: t.elements.lazy.map(\.type))
@@ -318,7 +318,7 @@ struct ConstraintSystem {
     case (_, let r as TypeAliasType):
       return simplify(goal, as: goal.left, isSubtypeOf: r.resolved)
 
-    case (let l as LambdaType, let r as LambdaType):
+    case (let l as ArrowType, let r as ArrowType):
       return solve(subtyping: g, between: l, and: r)
 
     case (let l as UnionType, let r as UnionType):
@@ -454,9 +454,9 @@ struct ConstraintSystem {
     }
   }
 
-  /// Implements of `solve(subtyping:)` for two `LambdaType`s.
+  /// Implements of `solve(subtyping:)` for two `ArrowType`s.
   private mutating func solve(
-    subtyping g: GoalIdentity, between l: LambdaType, and r: LambdaType
+    subtyping g: GoalIdentity, between l: ArrowType, and r: ArrowType
   ) -> Outcome? {
     let goal = goals[g] as! SubtypingConstraint
 
@@ -559,7 +559,7 @@ struct ConstraintSystem {
   private mutating func solve(
     autoclosureParameter goal: ParameterConstraint, ofType p: ParameterType
   ) -> Outcome? {
-    let t = LambdaType(p.bareType)!
+    let t = ArrowType(p.bareType)!
     let s = schedule(
       ParameterConstraint(
         goal.left, AnyType(ParameterType(.`let`, t.output)), origin: goal.origin.subordinate()))

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -6,7 +6,7 @@ extension Diagnostic {
     .error("ambiguous disjunction", at: site)
   }
 
-  static func error(autoclosureExpectsEmptyArrowAt site: SourceRange, given: AnyType) -> Diagnostic
+  static func error(autoclosureExpectsEmptyEnvironment site: SourceRange, given: AnyType) -> Diagnostic
   {
     .error(
       "autoclosure parameter expects arrow type with no parameters (given type: \(given))",

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -6,10 +6,10 @@ extension Diagnostic {
     .error("ambiguous disjunction", at: site)
   }
 
-  static func error(autoclosureExpectsEmptyLambdaAt site: SourceRange, given: AnyType) -> Diagnostic
+  static func error(autoclosureExpectsEmptyArrowAt site: SourceRange, given: AnyType) -> Diagnostic
   {
     .error(
-      "autoclosure parameter expects lambda type with no parameters (given type: \(given))",
+      "autoclosure parameter expects arrow type with no parameters (given type: \(given))",
       at: site)
   }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2888,7 +2888,7 @@ struct TypeChecker {
     if program[e].isAutoclosure {
       let s = program[program[e].bareType].site
       guard let u = ArrowType(t), u.inputs.isEmpty else {
-        report(.error(autoclosureExpectsEmptyArrowAt: s, given: t))
+        report(.error(autoclosureExpectsEmptyEnvironment: s, given: t))
         return .error
       }
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2545,7 +2545,7 @@ struct TypeChecker {
   /// Computes and returns the types of the inputs of `e`'s underlying declaration, using `hint`
   /// to guess the passing conventions of unanotated parameters.
   ///
-  /// `hint` is used as contextual information to refine guesses if it is a lambda type with the
+  /// `hint` is used as contextual information to refine guesses iff it is a lambda type with the
   /// same number of parameters as `e`. Parameter annotations take precedence in case of conflict.
   ///
   /// After the call, `cache.uncheckedType[p]` may be assigned to a type variable if `p` has no

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -263,7 +263,7 @@ public struct TypedProgram {
       return storage(of: u)
     case let u as BufferType:
       return storage(of: u)
-    case let u as LambdaType:
+    case let u as ArrowType:
       return storage(of: u)
     case let u as ProductType:
       return storage(of: u)
@@ -295,7 +295,7 @@ public struct TypedProgram {
   }
 
   /// Returns the names and types of `t`'s stored properties.
-  public func storage(of t: LambdaType) -> [TupleType.Element] {
+  public func storage(of t: ArrowType) -> [TupleType.Element] {
     let callee = TupleType.Element(label: "__f", type: .builtin(.ptr))
     return [callee] + t.captures
   }
@@ -440,7 +440,7 @@ public struct TypedProgram {
     case let m as BufferType:
       // FIXME: To remove once conditional conformance is implemented
       guard conforms(m.element, to: concept, in: scopeOfUse) else { return nil }
-    case let m as LambdaType:
+    case let m as ArrowType:
       guard allConform(m.captures.map(\.type), to: concept, in: scopeOfUse) else { return nil }
     case let m as TupleType:
       guard allConform(m.elements.map(\.type), to: concept, in: scopeOfUse) else { return nil }
@@ -459,7 +459,7 @@ public struct TypedProgram {
       guard let k = ast.synthesizedKind(of: requirement) else { return nil }
 
       let a: GenericArguments = [ast[concept.decl].receiver: .type(model)]
-      let t = LambdaType(specialize(declType[requirement]!, for: a, in: scopeOfUse))!
+      let t = ArrowType(specialize(declType[requirement]!, for: a, in: scopeOfUse))!
       let d = SynthesizedFunctionDecl(k, typed: t, in: scopeOfUse)
       implementations[requirement] = .synthetic(d)
     }

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -186,7 +186,7 @@ extension Module {
     func interpret(call i: InstructionID, in context: inout Context) -> PC? {
       let s = self[i] as! Call
       let f = s.callee
-      let callee = LambdaType(type(of: f).ast)!
+      let callee = ArrowType(type(of: f).ast)!
 
       // Evaluate the callee.
 

--- a/Sources/IR/Callee.swift
+++ b/Sources/IR/Callee.swift
@@ -9,8 +9,8 @@ enum Callee {
   /// A reference to a variant in a method bundle.
   case bundle(BundleReference<MethodDecl>)
 
-  /// An arrow.
-  case arrow(Operand)
+  /// A lambda.
+  case lambda(Operand)
 
   /// Creates an instance representing a reference to the lowered form of `d` in `module`,
   /// specialized by`a` in `scopeOfUse`.

--- a/Sources/IR/Callee.swift
+++ b/Sources/IR/Callee.swift
@@ -9,8 +9,8 @@ enum Callee {
   /// A reference to a variant in a method bundle.
   case bundle(BundleReference<MethodDecl>)
 
-  /// A lambda.
-  case lambda(Operand)
+  /// An arrow.
+  case arrow(Operand)
 
   /// Creates an instance representing a reference to the lowered form of `d` in `module`,
   /// specialized by`a` in `scopeOfUse`.

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -210,7 +210,7 @@ struct Emitter {
     // Emit the body.
     switch b {
     case .block(let s):
-      let returnType = LambdaType(program[d].type)!.output
+      let returnType = ArrowType(program[d].type)!.output
       let returnSite = pushing(bodyFrame, { $0.lowerStatements(s, expecting: returnType) })
       insert(module.makeReturn(at: returnSite))
 
@@ -372,7 +372,7 @@ struct Emitter {
     self.insertionPoint = .end(of: entry)
     switch b {
     case .block(let s):
-      let returnType = LambdaType(program[d].type)!.output
+      let returnType = ArrowType(program[d].type)!.output
       let returnSite = pushing(bodyFrame, { $0.lowerStatements(s, expecting: returnType) })
       insert(module.makeReturn(at: returnSite))
 
@@ -501,7 +501,7 @@ struct Emitter {
     precondition(read(program[d].pattern.introducer.value, { ($0 == .let) || ($0 == .sinklet) }))
 
     let r = RemoteType(.set, program[d].type)
-    let l = LambdaType(
+    let l = ArrowType(
       receiverEffect: .set, environment: ^TupleType(types: [^r]), inputs: [], output: .void)
     let f = SynthesizedFunctionDecl(.globalInitialization(d), typed: l, in: program[d].scope)
     let i = lower(globalBindingInitializer: f)
@@ -1581,7 +1581,7 @@ struct Emitter {
     switch callee {
     case .direct(let r):
       emitApply(.constant(r), to: arguments, writingResultTo: storage, at: ast[e].site)
-    case .lambda(let r):
+    case .arrow(let r):
       emitApply(r, to: arguments, writingResultTo: storage, at: ast[e].site)
     case .bundle(let r):
       emitApply(r, to: arguments, writingResultTo: storage, at: ast[e].site)
@@ -1605,8 +1605,8 @@ struct Emitter {
     let x1 = emitSubfieldView(storage, at: [0], at: site)
     emitInitialize(storage: x1, to: x0, at: ast[e].site)
 
-    let lambda = LambdaType(program.canonical(program[e].type, in: insertionScope!))!
-    if lambda.environment == .void { return }
+    let arrow = ArrowType(program.canonical(program[e].type, in: insertionScope!))!
+    if arrow.environment == .void { return }
 
     var i = 1
     for b in program[e].decl.explicitCaptures {
@@ -1669,7 +1669,7 @@ struct Emitter {
     switch e {
     case .infix(let callee, let lhs, let rhs):
       let t = program[callee.expr].type
-      let calleeType = LambdaType(canonical(t))!.lifted
+      let calleeType = ArrowType(canonical(t))!.lifted
 
       // Emit the operands, starting with RHS.
       let r = emit(infixOperand: rhs, passed: ParameterType(calleeType.inputs[1].type)!.access)
@@ -1925,7 +1925,7 @@ struct Emitter {
   private mutating func emit(
     memberwiseInitializerCall call: FunctionCallExpr.ID, initializing receiver: Operand
   ) {
-    let callee = LambdaType(canonical(program[ast[call].callee].type))!
+    let callee = ArrowType(canonical(program[ast[call].callee].type))!
 
     if callee.inputs.isEmpty {
       insert(module.makeMarkState(receiver, initialized: true, at: ast[call].site))
@@ -2038,7 +2038,7 @@ struct Emitter {
   ) -> Operand {
     // Emit synthesized function declaration.
     let f = SynthesizedFunctionDecl(
-      .autoclosure(argument), typed: parameter.bareType.base as! LambdaType,
+      .autoclosure(argument), typed: parameter.bareType.base as! ArrowType,
       in: program[argument].scope)
     let callee = withClearContext({ $0.lower(syntheticAutoclosure: f) })
 
@@ -2062,7 +2062,7 @@ struct Emitter {
 
     switch e {
     case .infix(let callee, _, _):
-      let t = LambdaType(canonical(program[callee.expr].type))!.lifted
+      let t = ArrowType(canonical(program[callee.expr].type))!.lifted
       storage = emitAllocStack(for: t.output, at: ast.site(of: e))
       emitStore(e, to: storage)
 
@@ -2101,7 +2101,7 @@ struct Emitter {
   /// Lifted arguments are produced if `callee` is a reference to a function with captures, such as
   /// a bound member function or a local function declaration with a non-empty environment.
   ///
-  /// - Requires: `callee` has a lambda type.
+  /// - Requires: `callee` has an arrow type.
   private mutating func emit(
     functionCallee callee: AnyExprID
   ) -> (callee: Callee, captures: [Operand]) {
@@ -2114,8 +2114,8 @@ struct Emitter {
       return emit(functionCallee: ast[InoutExpr.ID(callee)!].subject)
 
     default:
-      let f = emit(lambdaCallee: callee)
-      return (.lambda(f), [])
+      let f = emit(arrowCallee: callee)
+      return (.arrow(f), [])
     }
   }
 
@@ -2127,7 +2127,7 @@ struct Emitter {
     switch program[callee].referredDecl {
     case .direct(let d, let a) where d.isCallable:
       // Callee is a direct reference to an arrow declaration.
-      guard LambdaType(canonical(program[callee].type))!.environment == .void else {
+      guard ArrowType(canonical(program[callee].type))!.environment == .void else {
         UNIMPLEMENTED("Generate IR for calls to local functions with captures #1088")
       }
       let f = FunctionReference(to: d, in: &module, specializedBy: a, in: insertionScope!)
@@ -2141,9 +2141,9 @@ struct Emitter {
       unreachable()
 
     default:
-      // Callee is a lambda.
-      let f = emit(lambdaCallee: .init(callee))
-      return (.lambda(f), [])
+      // Callee is an arrow.
+      let f = emit(arrowCallee: .init(callee))
+      return (.arrow(f), [])
     }
   }
 
@@ -2180,9 +2180,9 @@ struct Emitter {
 
   /// Inserts the IR for given `callee` and returns its value.
   ///
-  /// - Requires: `callee` has a lambda type.
-  private mutating func emit(lambdaCallee callee: AnyExprID) -> Operand {
-    switch LambdaType(program[callee].type)!.receiverEffect {
+  /// - Requires: `callee` has an arrow type.
+  private mutating func emit(arrowCallee callee: AnyExprID) -> Operand {
+    switch ArrowType(program[callee].type)!.receiverEffect {
     case .yielded:
       unreachable()
     case .set, .sink:
@@ -2390,7 +2390,7 @@ struct Emitter {
     switch rhs.base {
     case let t as ExistentialType:
       return _emitCoerce(source, to: t, at: site)
-    case let t as LambdaType:
+    case let t as ArrowType:
       return _emitCoerce(source, to: t, at: site)
     case let t as UnionType:
       return _emitCoerce(source, to: t, at: site)
@@ -2417,15 +2417,15 @@ struct Emitter {
   ///
   /// - Requires: `target` is canonical.
   private mutating func _emitCoerce(
-    _ source: Operand, to target: LambdaType, at site: SourceRange
+    _ source: Operand, to target: ArrowType, at site: SourceRange
   ) -> Operand {
     let t = module.type(of: source).ast
-    guard let lhs = LambdaType(t) else {
+    guard let lhs = ArrowType(t) else {
       unexpectedCoercion(from: t, to: ^target)
     }
 
     // TODO: Handle variance
-    let rhs = LambdaType(
+    let rhs = ArrowType(
       receiverEffect: lhs.receiverEffect,
       environment: target.environment,
       inputs: target.inputs,
@@ -2486,7 +2486,7 @@ struct Emitter {
 
       let x0 = emitAllocStack(for: ir, at: site)
       let x1 = insert(module.makeAccess(.set, from: x0, at: site))!
-      let x2 = emitAllocStack(for: LambdaType(f.type.ast)!.output, at: site)
+      let x2 = emitAllocStack(for: ArrowType(f.type.ast)!.output, at: site)
       let x3 = insert(module.makeAccess(.set, from: x2, at: site))!
       let x4 = insert(module.makeAccess(.sink, from: source, at: site))!
 
@@ -2523,7 +2523,7 @@ struct Emitter {
       let f = module.reference(to: convert, implementedFor: foreignConvertibleConformance)
 
       let x0 = insert(module.makeAccess(.let, from: o, at: site))!
-      let x1 = emitAllocStack(for: LambdaType(f.type.ast)!.output, at: site)
+      let x1 = emitAllocStack(for: ArrowType(f.type.ast)!.output, at: site)
       let x2 = insert(module.makeAccess(.set, from: x1, at: site))!
       insert(module.makeCall(applying: .constant(f), to: [x0], writingResultTo: x2, at: site))
       insert(module.makeEndAccess(x2, at: site))
@@ -3055,7 +3055,7 @@ struct Emitter {
   /// function or method bundle.
   private func receiverCapabilities(_ callee: AnyType) -> AccessEffectSet {
     switch canonical(callee).base {
-    case let t as LambdaType:
+    case let t as ArrowType:
       return [RemoteType(t.captures[0].type)?.access ?? .sink]
     case let t as MethodType:
       return t.capabilities

--- a/Sources/IR/Mangling/DemangledEntity.swift
+++ b/Sources/IR/Mangling/DemangledEntity.swift
@@ -96,7 +96,7 @@ extension DemangledEntity: CustomStringConvertible {
 
   /// A textual representation of `self` assuming it is a function declaration.
   private var functionDescription: String {
-    guard case .lambda(_, _, let inputs, _) = type else {
+    guard case .arrow(_, _, let inputs, _) = type else {
       return "\(name)(???)"
     }
 
@@ -106,7 +106,7 @@ extension DemangledEntity: CustomStringConvertible {
 
   /// A textual representation of `self` assuming it is an initializer declaration.
   private var initializerDescription: String {
-    guard case .lambda(_, _, let inputs, _) = type else {
+    guard case .arrow(_, _, let inputs, _) = type else {
       return "init"
     }
 

--- a/Sources/IR/Mangling/DemangledType.swift
+++ b/Sources/IR/Mangling/DemangledType.swift
@@ -16,6 +16,13 @@ public indirect enum DemangledType: Hashable {
   /// The `Void` type.
   case void
 
+  /// An arrow type.
+  case arrow(
+    effect: AccessEffect,
+    environment: DemangledType,
+    inputs: [Parameter],
+    output: DemangledType)
+
   /// An associated type.
   case associatedType(domain: DemangledType, name: String)
 
@@ -35,13 +42,6 @@ public indirect enum DemangledType: Hashable {
   case existentialTrait([DemangledType])
 
   /// An existential trait type.
-
-  /// A lambda type.
-  case lambda(
-    effect: AccessEffect,
-    environment: DemangledType,
-    inputs: [Parameter],
-    output: DemangledType)
 
   /// A metatype.
   case metatype(DemangledType)
@@ -94,6 +94,12 @@ extension DemangledType: CustomStringConvertible {
     case .void:
       return "Void"
 
+    case .arrow(let effect, let environment, let inputs, let output):
+      let i = inputs.map { (p) -> String in
+        (p.label.map({ $0 + ": " }) ?? "") + p.type.description
+      }
+      return "[\(environment)](\(list: i) \(effect) -> \(output)"
+
     case .associatedType(let domain, let name):
       return "\(domain).\(name)"
 
@@ -111,12 +117,6 @@ extension DemangledType: CustomStringConvertible {
 
     case .existentialTrait(let interface):
       return "any \(list: interface)"
-
-    case .lambda(let effect, let environment, let inputs, let output):
-      let i = inputs.map { (p) -> String in
-        (p.label.map({ $0 + ": " }) ?? "") + p.type.description
-      }
-      return "[\(environment)](\(list: i) \(effect) -> \(output)"
 
     case .metatype(let t):
       return "Metatype<\(t)>"

--- a/Sources/IR/Mangling/Demangler.swift
+++ b/Sources/IR/Mangling/Demangler.swift
@@ -61,8 +61,8 @@ struct Demangler {
         demangled = takeNominalType(declaredBy: GenericParameterDecl.self, from: &stream)
       case .importDecl:
         demangled = take(ImportDecl.self, qualifiedBy: qualification, from: &stream)
-      case .lambdaType:
-        demangled = takeLambdaType(from: &stream)
+      case .arrowType:
+        demangled = takeArrowType(from: &stream)
       case .lookup:
         demangled = takeLookup(from: &stream)
       case .memberwiseInitializerDecl:
@@ -450,8 +450,8 @@ struct Demangler {
     return .type(.existentialTrait(traits))
   }
 
-  /// Demangles a lambda type from `stream`.
-  private mutating func takeLambdaType(from stream: inout Substring) -> DemangledSymbol? {
+  /// Demangles an arrow type from `stream`.
+  private mutating func takeArrowType(from stream: inout Substring) -> DemangledSymbol? {
     guard
       let environment = demangleType(from: &stream),
       let inputCount = takeInteger(from: &stream)
@@ -471,7 +471,7 @@ struct Demangler {
       let output = demangleType(from: &stream)
     else { return nil }
 
-    return .type(.lambda(effect: .let, environment: environment, inputs: inputs, output: output))
+    return .type(.arrow(effect: .let, environment: environment, inputs: inputs, output: output))
   }
 
   /// Demangles a nominal type declared as an entity of type `T` from `stream`.

--- a/Sources/IR/Mangling/Mangler.swift
+++ b/Sources/IR/Mangling/Mangler.swift
@@ -448,8 +448,8 @@ struct Mangler {
       write(operator: .genericTypeParameterType, to: &output)
       mangle(decl: AnyDeclID(t.decl), to: &output)
 
-    case let t as LambdaType:
-      write(lambda: t, to: &output)
+    case let t as ArrowType:
+      write(arrow: t, to: &output)
 
     case let t as MethodType:
       write(method: t, to: &output)
@@ -571,8 +571,8 @@ struct Mangler {
   }
 
   /// Writes the mangled representation of `symbol` to `output`.
-  private mutating func write(lambda t: LambdaType, to output: inout Output) {
-    write(operator: .lambdaType, to: &output)
+  private mutating func write(arrow t: ArrowType, to output: inout Output) {
+    write(operator: .arrowType, to: &output)
     mangle(type: t.environment, to: &output)
 
     write(integer: t.inputs.count, to: &output)

--- a/Sources/IR/Mangling/ManglingOperator.swift
+++ b/Sources/IR/Mangling/ManglingOperator.swift
@@ -86,7 +86,7 @@ public enum ManglingOperator: String {
 
   case methodType = "hT"
 
-  case lambdaType = "lT"
+  case arrowType = "lT"
 
   case metatypeType = "mT"
 

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -482,7 +482,7 @@ public struct Module {
 
   /// Returns the lowered declarations of `d`'s parameters.
   private func loweredParameters(of d: FunctionDecl.ID) -> [Parameter] {
-    let captures = LambdaType(program[d].type)!.captures.lazy.map { (e) in
+    let captures = ArrowType(program[d].type)!.captures.lazy.map { (e) in
       program.canonical(e.type, in: program[d].scope)
     }
     var result: [Parameter] = zip(program.captures(of: d), captures).map({ (c, e) in

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -20,7 +20,7 @@ public struct FunctionReference: Constant, Hashable {
     precondition(module[f].genericParameters.isEmpty, "underspecialized function reference")
 
     let v = module[f]
-    let t = LambdaType(inputs: v.inputs.map({ .init(type: ^$0.type) }), output: v.output)
+    let t = ArrowType(inputs: v.inputs.map({ .init(type: ^$0.type) }), output: v.output)
     assert(t[.isCanonical])
 
     self.function = f
@@ -43,7 +43,7 @@ public struct FunctionReference: Constant, Hashable {
     }
 
     let v = module[f]
-    let t = LambdaType(inputs: v.inputs.map({ .init(type: ^$0.type) }), output: v.output)
+    let t = ArrowType(inputs: v.inputs.map({ .init(type: ^$0.type) }), output: v.output)
     let u = module.program.canonical(
       module.program.specialize(^t, for: a, in: scopeOfUse), in: scopeOfUse)
 

--- a/Sources/IR/Operands/Instruction/Call.swift
+++ b/Sources/IR/Operands/Instruction/Call.swift
@@ -3,7 +3,7 @@ import Utils
 
 /// Invokes `callee` with `arguments` and writes its result to `output`.
 ///
-/// `callee` must have a lambda type; the type of the instruction must be the same as output type
+/// `callee` must have an arrow type; the type of the instruction must be the same as output type
 /// of the callee. `operands` must contain as many operands as the callee's type.
 public struct Call: Instruction {
 
@@ -69,7 +69,7 @@ extension Module {
     applying callee: Operand, to arguments: [Operand], writingResultTo output: Operand,
     at site: SourceRange
   ) -> Call {
-    let t = LambdaType(type(of: callee).ast)!.strippingEnvironment
+    let t = ArrowType(type(of: callee).ast)!.strippingEnvironment
     precondition(t.inputs.count == arguments.count)
     precondition(arguments.allSatisfy({ self[$0] is Access }))
     precondition(isBorrowSet(output))

--- a/Sources/IR/Operands/Instruction/Call.swift
+++ b/Sources/IR/Operands/Instruction/Call.swift
@@ -3,7 +3,7 @@ import Utils
 
 /// Invokes `callee` with `arguments` and writes its result to `output`.
 ///
-/// `callee` must have an arrow type; the type of the instruction must be the same as output type
+/// `callee` must have a lambda type; the type of the instruction must be the same as output type
 /// of the callee. `operands` must contain as many operands as the callee's type.
 public struct Call: Instruction {
 

--- a/Tests/HyloTests/BuiltinFunctionTests.swift
+++ b/Tests/HyloTests/BuiltinFunctionTests.swift
@@ -9,7 +9,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testAdvancedByBytes() throws {
-    let expectedType = { LambdaType(.builtin(.ptr), .builtin(.i($0)), to: .builtin(.ptr)) }
+    let expectedType = { ArrowType(.builtin(.ptr), .builtin(.i($0)), to: .builtin(.ptr)) }
     try assertParse(
       instructions: ["advanced_by_bytes"],
       parameterizedBy: [["i16"]],
@@ -21,7 +21,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerArithmetic() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    let expectedType = ArrowType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
     try assertParse(
       instructions: ["add", "sub", "mul"],
       parameterizedBy: [["i64"], ["nuw", "i64"], ["nsw", "i64"]],
@@ -29,7 +29,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerDivision() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    let expectedType = ArrowType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
     try assertParse(
       instructions: ["udiv", "sdiv"],
       parameterizedBy: [["i64"], ["exact", "i64"]],
@@ -37,7 +37,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerShiftLeft() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    let expectedType = ArrowType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
     try assertParse(
       instructions: ["shl"],
       parameterizedBy: [["i64"], ["nuw", "i64"], ["nsw", "i64"]],
@@ -45,7 +45,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerShiftRight() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    let expectedType = ArrowType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
     try assertParse(
       instructions: ["lshr", "ashr"],
       parameterizedBy: [["i64"], ["exact", "i64"]],
@@ -53,7 +53,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerRemainder() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    let expectedType = ArrowType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
     try assertParse(
       instructions: ["urem", "srem"],
       parameterizedBy: [["i64"]],
@@ -61,7 +61,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerLogic() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    let expectedType = ArrowType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
     try assertParse(
       instructions: ["and", "or", "xor"],
       parameterizedBy: [["i64"]],
@@ -69,7 +69,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerComparison() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(1)))
+    let expectedType = ArrowType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(1)))
     try assertParse(
       instructions: ["icmp"],
       parameterizedBy: [
@@ -88,7 +88,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerTruncate() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), to: .builtin(.i(32)))
+    let expectedType = ArrowType(.builtin(.i(64)), to: .builtin(.i(32)))
     try assertParse(
       instructions: ["trunc"],
       parameterizedBy: [["i64", "i32"]],
@@ -96,7 +96,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerExtend() throws {
-    let expectedType = LambdaType(.builtin(.i(32)), to: .builtin(.i(64)))
+    let expectedType = ArrowType(.builtin(.i(32)), to: .builtin(.i(64)))
     try assertParse(
       instructions: ["zext", "sext"],
       parameterizedBy: [["i32", "i64"]],
@@ -104,7 +104,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testIntegerToFloat() throws {
-    let expectedType = LambdaType(.builtin(.i(64)), to: .builtin(.float64))
+    let expectedType = ArrowType(.builtin(.i(64)), to: .builtin(.float64))
     try assertParse(
       instructions: ["uitofp", "sitofp"],
       parameterizedBy: [["i64", "float64"]],
@@ -112,7 +112,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testFloatArithmetic() throws {
-    let expectedType = LambdaType(.builtin(.float64), .builtin(.float64), to: .builtin(.float64))
+    let expectedType = ArrowType(.builtin(.float64), .builtin(.float64), to: .builtin(.float64))
     try assertParse(
       instructions: ["fadd", "fsub", "fmul", "fdiv", "frem"],
       parameterizedBy: [
@@ -124,7 +124,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testFloatComparison() throws {
-    let expectedType = LambdaType(.builtin(.float64), .builtin(.float64), to: .builtin(.i(1)))
+    let expectedType = ArrowType(.builtin(.float64), .builtin(.float64), to: .builtin(.i(1)))
     try assertParse(
       instructions: ["fcmp"],
       parameterizedBy: [
@@ -151,7 +151,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testFloatTruncate() throws {
-    let expectedType = LambdaType(.builtin(.float64), to: .builtin(.float32))
+    let expectedType = ArrowType(.builtin(.float64), to: .builtin(.float32))
     try assertParse(
       instructions: ["fptrunc"],
       parameterizedBy: [["float64", "float32"]],
@@ -159,7 +159,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testFloatExtend() throws {
-    let expectedType = LambdaType(.builtin(.float32), to: .builtin(.float64))
+    let expectedType = ArrowType(.builtin(.float32), to: .builtin(.float64))
     try assertParse(
       instructions: ["fpext"],
       parameterizedBy: [["float32", "float64"]],
@@ -167,7 +167,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testFloatToInteger() throws {
-    let expectedType = LambdaType(.builtin(.float32), to: .builtin(.i(64)))
+    let expectedType = ArrowType(.builtin(.float32), to: .builtin(.i(64)))
     try assertParse(
       instructions: ["fptoui", "fptosi"],
       parameterizedBy: [["float32", "i64"]],
@@ -175,7 +175,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testCountOnes() throws {
-    let expectedType = LambdaType(.builtin(.i(16)), to: .builtin(.i(16)))
+    let expectedType = ArrowType(.builtin(.i(16)), to: .builtin(.i(16)))
     try assertParse(
       instructions: ["ctpop"],
       parameterizedBy: [["i16"]],
@@ -183,7 +183,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testCountLeadingZeros() throws {
-    let expectedType = LambdaType(.builtin(.i(16)), to: .builtin(.i(16)))
+    let expectedType = ArrowType(.builtin(.i(16)), to: .builtin(.i(16)))
     try assertParse(
       instructions: ["ctlz"],
       parameterizedBy: [["i16"]],
@@ -191,7 +191,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testCountTrailingZeros() throws {
-    let expectedType = LambdaType(.builtin(.i(16)), to: .builtin(.i(16)))
+    let expectedType = ArrowType(.builtin(.i(16)), to: .builtin(.i(16)))
     try assertParse(
       instructions: ["cttz"],
       parameterizedBy: [["i16"]],
@@ -199,7 +199,7 @@ final class BuiltinFunctionTests: XCTestCase {
   }
 
   func testZeroInitializer() throws {
-    let expectedType = LambdaType(to: .builtin(.i(64)))
+    let expectedType = ArrowType(to: .builtin(.i(64)))
     try assertParse(
       instructions: ["zeroinitializer"],
       parameterizedBy: [["i64"]],
@@ -212,7 +212,7 @@ final class BuiltinFunctionTests: XCTestCase {
   private func assertParse(
     instructions: [String],
     parameterizedBy parameters: [[String]],
-    createInstanceWithType expectedType: LambdaType,
+    createInstanceWithType expectedType: ArrowType,
     file: StaticString = #filePath,
     line: UInt = #line
   ) throws {

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1347,37 +1347,37 @@ final class ParserTests: XCTestCase {
     XCTAssertEqual(expr.elements.count, 2)
   }
 
-  func testLambdaOrParenthesizedTypeExpr() throws {
+  func testArrowOrParenthesizedTypeExpr() throws {
     let input: SourceFile = "((A) -> (B)) -> C"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
-    let expr = try XCTUnwrap(ast[exprID] as? LambdaTypeExpr)
+    let expr = try XCTUnwrap(ast[exprID] as? ArrowTypeExpr)
     XCTAssertEqual(expr.output.kind, .init(NameExpr.self))
   }
 
-  func testLambdaTypeExpr() throws {
+  func testArrowTypeExpr() throws {
     let input: SourceFile = "[{ A, B }] (T, by: U) inout -> T"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
-    let expr = try XCTUnwrap(ast[exprID] as? LambdaTypeExpr)
+    let expr = try XCTUnwrap(ast[exprID] as? ArrowTypeExpr)
     XCTAssertEqual(expr.receiverEffect?.value, .inout)
     XCTAssertEqual(expr.environment?.kind, .init(TupleTypeExpr.self))
     XCTAssertEqual(expr.parameters.count, 2)
     XCTAssertEqual(expr.output.kind, .init(NameExpr.self))
   }
 
-  func testTypeErasedLambdaTypeExpr() throws {
+  func testTypeErasedArrowTypeExpr() throws {
     let input: SourceFile = "(T, by: U) inout -> T"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
-    let expr = try XCTUnwrap(ast[exprID] as? LambdaTypeExpr)
+    let expr = try XCTUnwrap(ast[exprID] as? ArrowTypeExpr)
     XCTAssertEqual(expr.receiverEffect?.value, .inout)
     XCTAssertEqual(expr.parameters.count, 2)
     XCTAssertEqual(expr.output.kind, .init(NameExpr.self))
     XCTAssertNil(expr.environment)
   }
 
-  func testThinLambdaTypeExpr() throws {
+  func testThinArrowTypeExpr() throws {
     let input: SourceFile = "[] () -> Int"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
-    let expr = try XCTUnwrap(ast[exprID] as? LambdaTypeExpr)
+    let expr = try XCTUnwrap(ast[exprID] as? ArrowTypeExpr)
     XCTAssertNil(expr.receiverEffect)
     XCTAssertEqual(expr.environment?.kind, .init(TupleTypeExpr.self))
     XCTAssert(expr.parameters.isEmpty)


### PR DESCRIPTION
Closes https://github.com/hylo-lang/hylo/issues/385

I did my best to change all references to "lambda" that aren't referring to *actual* lambda expressions. It wasn't immediately clear in some cases, so I might have made a mistake or missed some references.

I've included grep output below for convenience. Let me know if I've missed references that should be updated.

<details>
<summary>rg Lambda</summary>
<br />

```
rg Lambda
Sources/Core/AST/Expr/LambdaExpr.swift
2:public struct LambdaExpr: Expr {

Sources/Core/AST/Decl/SynthesizedFunctionDecl.swift
24:    /// Lambda generated for an autoclosure argument.

Sources/Core/AST/NodeIDs/NodeKind.swift
115:    LambdaExpr.self,

Sources/Core/AST/AST+Walk.swift
124:    case LambdaExpr.self:
125:      traverse(self[n] as! LambdaExpr, notifying: &o)
503:    _ n: LambdaExpr, notifying o: inout O

Sources/FrontEnd/Parse/Parser.swift
1679:      // Lambda expression.
1680:      return try parseLambdaExpr(in: &state).map(AnyExprID.init)
1962:  private static func parseLambdaExpr(in state: inout ParserState) throws -> LambdaExpr.ID? {
1983:      LambdaExpr(decl: decl, site: state.ast[decl].site))

Sources/FrontEnd/TypeChecking/TypeChecker.swift
2555:    of e: LambdaExpr.ID, withHint hint: ArrowType?
2593:    of e: LambdaExpr.ID, withHint hint: [CallableTypeParameter]?
4700:    case LambdaExpr.self:
4701:      return _inferredType(of: LambdaExpr.ID(e)!, withHint: hint, updating: &obligations)
4947:    of e: LambdaExpr.ID, withHint hint: AnyType? = nil,
5364:    of e: LambdaExpr.ID, withHint hint: AnyType? = nil,

Sources/IR/Emitter.swift
1413:    case LambdaExpr.self:
1414:      emitStore(LambdaExpr.ID(e)!, to: storage)
1597:  private mutating func emitStore(_ e: LambdaExpr.ID, to storage: Operand) {

Docs/MetatypeLowering.md
86:**Lambda types:**

Tests/HyloTests/ParserTests.swift
1275:  func testLambdaExpr() throws {
1278:    let expr = try XCTUnwrap(ast[exprID] as? LambdaExpr)
```
</details>

<details>
<summary>rg lambda</summary>
<br />

```
rg lambda
Sources/Core/Program.swift
459:        return qualification + ".lambda"

Sources/Core/AST/Expr/ParameterTypeExpr.swift
12:  /// `true` if arguments to the parameter are automatically wrapped in lambdas.

Sources/Core/AST/Expr/LambdaExpr.swift
1:/// A lambda.

Sources/FrontEnd/Parse/Parser.swift
1969:    let body = try state.expect("function body", using: lambdaBody)
1986:  private static let lambdaBody = inContext(
2131:      body = try state.expect("function body", using: lambdaBody)

Sources/FrontEnd/TypeChecking/TypeChecker.swift
890:  /// - Requires: `d` is not the underlying declaration of a lambda.
1094:  /// Type checks `d`, which declares a lambda, after its type has been inferred.
1096:    assert(program[d].isInExprContext, "expected lambda")
2548:  /// `hint` is used as contextual information to refine guesses if it is a lambda type with the
2565:    // Slow path: infer elided conventions from the uses in the lambda's body.
2903:  /// underlying declaration of a lambda). Otherwise, `.void` is returned.

StandardLibrary/Sources/Array.hylo
47:    // TODO: Call `self.copy()` directly in the lambda.

Docs/Subscripts.md
70:The caller initiates a projection by calling the ramp function and passing it a lambda representing at least the code using the projection.
71:This continuation is called with another lambda denoting the tail corresponding to the `yield` instruction executed by the ramp.
72:It is expected to call that lambda when it is done with the projection.

Docs/CPlusPlus.org
123:For interop purposes, projections could be translated into functions that accept a C++ lambda

Docs/MetatypeLowering.md
22:- Kind (e.g., product type, lambda type, etc.)
89:struct hylo_lambda_type_mirror {

Tools/gyb.py
320:            in tokenize.generate_tokens(lambda i=iter(source_lines):
367:            in tokenize.generate_tokens(lambda i=iter(source_lines): next(i)):

Tests/HyloTests/TestCases/Lowering/MemberLambda.hylo
4:// call to a member property with a lambda type.

Tests/EndToEndTests/TestCases/Lambda.hylo
8:  // Applies a thin, immutable lambda.
12:  // Applies a thick, immutable lambda.
17:  // Applies a mutable lambda with owned captures.
25:  // Applies a mutable lambda with borrowed captures.

Tests/ManglingTests/ManglingTests.swift
51:        let lambda = fun[let capture = local](x: Int) { local + x }
53:          let z = lambda(x: y)

Tests/LibraryTests/TestCases/PointerToMutableTests.hylo
27:fun test_initialize_pointee_lambda() {
46:  test_initialize_pointee_lambda()
```
</details>