### PR TITLE
Refactor arg label for expect function signature in ParserState

### DIFF
--- a/Sources/FrontEnd/Parse/ParserState.swift
+++ b/Sources/FrontEnd/Parse/ParserState.swift
@@ -284,7 +284,7 @@ struct ParserState {
   /// diagnosing that we expected `expectedConstruct`.
   mutating func expect<T>(
     _ expectedConstruct: String,
-    using parse: (inout ParserState) throws -> T?
+    parsedWith parse: (inout ParserState) throws -> T?
   ) throws -> T {
     if let element = try parse(&self) {
       return element
@@ -298,9 +298,9 @@ struct ParserState {
   /// an error diagnosing that we expected `expectedConstruct`.
   mutating func expect<C: Combinator>(
     _ expectedConstruct: String,
-    using parser: C
+    parsedWith parser: C
   ) throws -> C.Element where C.Context == Self {
-    try expect(expectedConstruct, using: parser.parse(_:))
+    try expect(expectedConstruct, parsedWith: parser.parse(_:))
   }
 
   /// Consumes tokens as long as they satisfy `predicate`.


### PR DESCRIPTION
Closes https://github.com/hylo-lang/hylo/issues/416

Refactor the argument label from `using` -> `parsedWith`