### PR TITLE
Correct the description of the -l option

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -92,7 +92,7 @@ public struct Driver: ParsableCommand {
   @Option(
     name: [.customShort("l")],
     help: ArgumentHelp(
-      "Link the generated crate(s) to the specified native library.",
+      "Link the generated module(s) to the specified native library.",
       valueName: "name"))
   private var libraries: [String] = []
 


### PR DESCRIPTION
Closes https://github.com/hylo-lang/hylo/issues/842

I'm guessing that `module` is what we want here, but please correct me if I'm wrong.