### PR TITLE
Fix the synthethization of structural conformances for lambda types

### DIFF
--- a/Sources/Core/AST/Decl/SynthesizedFunctionDecl.swift
+++ b/Sources/Core/AST/Decl/SynthesizedFunctionDecl.swift
@@ -29,6 +29,9 @@ public struct SynthesizedFunctionDecl: Hashable {
   /// The type of this declaration.
   public let type: LambdaType
 
+  /// The generic parameters of the declaration.
+  public let genericParameters: [GenericParameterDecl.ID]
+
   /// The scope in which the declaration is defined.
   public let scope: AnyScopeID
 
@@ -36,34 +39,26 @@ public struct SynthesizedFunctionDecl: Hashable {
   public let kind: Kind
 
   /// Creates an instance with the given properties.
-  public init(_ kind: Kind, typed type: LambdaType, in scope: AnyScopeID) {
-    self.kind = kind
+  ///
+  /// - Requires: The environment of `type` is a tuple.
+  public init(
+    _ kind: Kind,
+    typed type: LambdaType,
+    parameterizedBy genericParameters: [GenericParameterDecl.ID],
+    in scope: AnyScopeID
+  ) {
+    precondition(type.environment.base is TupleType)
     self.type = type
+    self.genericParameters = genericParameters
     self.scope = scope
+    self.kind = kind
   }
 
   /// The type of the declaration's receiver.
   ///
   /// - Requires: `self` is a synthethic implementation of a member function.
   public var receiver: AnyType {
-    let r = type.captures[0].type
-    return RemoteType(r)?.bareType ?? r
-  }
-
-  /// Returns the generic parameters of the declaration.
-  public var genericParameters: [GenericParameterDecl.ID] {
-    guard
-      !type.captures.isEmpty,
-      let t = BoundGenericType(receiver)
-    else { return [] }
-
-    return t.arguments.compactMap { (k, v) -> GenericParameterDecl.ID? in
-      if case .type(let u) = v {
-        return GenericTypeParameterType(u)?.decl == k ? k : nil
-      } else {
-        UNIMPLEMENTED("compile time values")
-      }
-    }
+    read(type.captures[0].type, { RemoteType($0)?.bareType ?? $0 })
   }
 
 }

--- a/Sources/Core/Types/AnyType.swift
+++ b/Sources/Core/Types/AnyType.swift
@@ -1,3 +1,4 @@
+import OrderedCollections
 import Utils
 
 /// A box wrapping a type.
@@ -221,6 +222,46 @@ public struct AnyType {
         return .stepInto(t)
       } else {
         return .stepOver(t)
+      }
+    }
+  }
+
+  /// Returns the generic parameters occurring free in `self`.
+  public var skolems: OrderedSet<GenericParameterDecl.ID> {
+    var r = OrderedSet<GenericParameterDecl.ID>()
+    collectGenericTypeParameters(in: &r, ignoring: [])
+    return r
+  }
+
+  /// Inserts generic parameters occurring free in `self` into `open`, unless they're in `bound`.
+  private func collectGenericTypeParameters(
+    in open: inout OrderedSet<GenericParameterDecl.ID>,
+    ignoring bound: Set<GenericParameterDecl.ID>
+  ) {
+    var state = (bound: bound, open: open)
+    defer { open = state.open }
+
+    _ = self.transform(mutating: &state) { (s, t) in
+      switch t.base {
+      case let u as BoundGenericType:
+        var b = s.bound
+        for (k, v) in u.arguments {
+          b.insert(k)
+          if let g = GenericTypeParameterType(v.asType), g.decl == k {
+            if !s.bound.contains(k) { s.open.append(k) }
+          }
+        }
+        for a in u.arguments.values {
+          a.asType?.collectGenericTypeParameters(in: &s.open, ignoring: b)
+        }
+        return .stepOver(t)
+
+      case let u as GenericTypeParameterType:
+        if !s.bound.contains(u.decl) { s.open.append(u.decl) }
+        return .stepOver(t)
+
+      default:
+        return t[.hasGenericTypeParameter] ? .stepInto(t) :.stepOver(t)
       }
     }
   }

--- a/Sources/Core/Types/LambdaType.swift
+++ b/Sources/Core/Types/LambdaType.swift
@@ -93,7 +93,20 @@ public struct LambdaType: TypeProtocol {
   }
 
   /// Accesses the individual elements of the lambda's environment.
-  public var captures: [TupleType.Element] { TupleType(environment)?.elements ?? [] }
+  public var captures: [TupleType.Element] {
+    func elements(_ t: AnyType) -> [TupleType.Element] {
+      switch t.base {
+      case let u as TupleType:
+        return u.elements
+      case let u as TypeAliasType:
+        return elements(u.resolved)
+      default:
+        return [.init(label: nil, type: t)]
+      }
+    }
+
+    return elements(environment)
+  }
 
   public func transformParts<M>(
     mutating m: inout M, _ transformer: (inout M, AnyType) -> TypeTransformAction

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -232,7 +232,7 @@ struct ConstraintSystem {
 
     switch model.base {
     case let t as LambdaType:
-      return delegate(structuralConformance: goal, for: t.captures.lazy.map(\.type))
+      return delegate(structuralConformance: goal, for: [t.environment])
     case let t as TupleType:
       return delegate(structuralConformance: goal, for: t.elements.lazy.map(\.type))
     case let t as UnionType:

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1615,8 +1615,11 @@ struct TypeChecker {
         structurallyConforms(model, to: trait, in: scopeOfDefinition)
       else { return nil }
 
+      let t = LambdaType(expectedAPI.type)!
+      let h = Array(t.environment.skolems)
+
       // Note: compiler-known requirement is assumed to be well-typed.
-      return .init(k, typed: LambdaType(expectedAPI.type)!, in: AnyScopeID(origin.source)!)
+      return .init(k, typed: t, parameterizedBy: h, in: AnyScopeID(origin.source)!)
     }
 
     /// Returns a concrete implementation of `requirement` for `model` with given `expectedAPI`,

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -403,7 +403,7 @@ struct TypeChecker {
       // FIXME: To remove once conditional conformance is implemented
       return conforms(m.element, to: trait, in: scopeOfUse)
     case let m as LambdaType:
-      return m.captures.allSatisfy({ conforms($0.type, to: trait, in: scopeOfUse) })
+      return conforms(m.environment, to: trait, in: scopeOfUse)
     case is MetatypeType:
       return true
     case let m as ProductType:

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -454,6 +454,8 @@ public struct TypedProgram {
       return nil
     }
 
+    // We could predict that codegen won't need some of the skolems we gather here to reduce the
+    // number of generic functions that we define.
     let g = accumulatedGenericParameters(in: scopeOfUse)
     let h = g.filter(model.skolems.contains(_:))
 

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -441,7 +441,7 @@ public struct TypedProgram {
       // FIXME: To remove once conditional conformance is implemented
       guard conforms(m.element, to: concept, in: scopeOfUse) else { return nil }
     case let m as LambdaType:
-      guard allConform(m.captures.map(\.type), to: concept, in: scopeOfUse) else { return nil }
+      guard conforms(m.environment, to: concept, in: scopeOfUse) else { return nil }
     case let m as TupleType:
       guard allConform(m.elements.map(\.type), to: concept, in: scopeOfUse) else { return nil }
     case let m as UnionType:

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -563,7 +563,9 @@ extension Module {
     let receiver = ir.base[trait.decl].receiver.id
     let model = z[receiver]!.asType!
 
-    let c = ir.base.conformance(of: model, to: trait, exposedTo: scopeOfUse)!
+    guard let c = ir.base.conformance(of: model, to: trait, exposedTo: scopeOfUse) else {
+      fatalError("expected '\(model)' to conform to '\(trait)'")
+    }
     let i = c.implementations[requirement]!
     let d = demandDeclaration(lowering: i)
 

--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -1,10 +1,10 @@
 /// A future that cannot escape the local scope.
-public type Future<E> {
+public type Future<E: Movable & Deinitializable> {
 
   // TODO
   public typealias Result = Int
 
-  /// The base frame object needed by the underlying implementation. 
+  /// The base frame object needed by the underlying implementation.
   private var base_frame: SpawnFrameBase
 
   /// What needs to be called to produce the value in the future.
@@ -67,9 +67,9 @@ type SpawnFrameBase: Deinitializable {
 }
 
 // TODO: #1246
-type FunctionWrapper<E, R>: Movable, Deinitializable {
+type FunctionWrapper<E: Movable & Deinitializable, R>: Movable, Deinitializable {
 
-  let f: [E]()->R
+  let f: [E]() -> R
 
   memberwise init
 
@@ -85,4 +85,3 @@ fun concore2full_spawn2(_ frame: set SpawnFrameBase, _ f: [](SpawnFrameBase) let
 /// Awaits the completion of the computation started in `frame`.
 @external("concore2full_await")
 fun concore2full_await(_ frame: SpawnFrameBase);
-

--- a/StandardLibrary/Sources/Concurrency/Spawn.hylo
+++ b/StandardLibrary/Sources/Concurrency/Spawn.hylo
@@ -2,6 +2,6 @@
 /// Spawns a computation and returns a future that can be used to await its completion.
 ///
 /// The future cannot escape the current scope.
-public fun spawn_<E>(_ f: sink [E]()->Int) -> Future<E> {
-  return Future<E>(FunctionWrapper<E>(f: f))
+public fun spawn_<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> Future<E> {
+  Future<E>(FunctionWrapper<E>(f: f))
 }

--- a/Tests/HyloTests/TestCases/Lowering/Deinit.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Deinit.hylo
@@ -10,5 +10,10 @@ type A {
 public fun main() {
   var a = A(x: 1)
   use(a)
+
+  var b = fun[var a = A(x: 1)]() { () }
+  b()
+
+  //! @+2 diagnostic type '[{a: A}] () inout -> {}' does not conform to trait 'Deinitializable'
   //! @+1 diagnostic type 'A' does not conform to trait 'Deinitializable'
 }


### PR DESCRIPTION
Code before the patch would ignore the trait bounds on a lambda's environment, allowing the compiler to synthesized a denitializer for `[E](T) -> U` even when `E` isn't `Deinitializable`.