### PR TITLE
Don't discard any diagnostics from parsing the standard library.

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -144,6 +144,7 @@ public struct Driver: ParsableCommand {
       try executeCommand(diagnostics: &diagnostics)
     } catch let d as DiagnosticSet {
       assert(d.containsError, "Diagnostics containing no errors were thrown")
+      diagnostics.formUnion(d)
       return (ExitCode.failure, diagnostics)
     }
     return (ExitCode.success, diagnostics)


### PR DESCRIPTION
fixes #1287