### PR TITLE
Make parallel typechecking an experimental feature

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -52,9 +52,9 @@ public struct Driver: ParsableCommand {
   private var freestanding: Bool = false
 
   @Flag(
-    name: [.customLong("sequential")],
-    help: "Execute the compilation pipeline sequentially.")
-  private var compileSequentially: Bool = false
+    name: [.customLong("experimental-parallel-typechecking")],
+    help: "Parallelize the type checker")
+  private var experimentalParallelTypeChecking: Bool = false
 
   @Flag(
     name: [.customLong("typecheck")],
@@ -173,7 +173,7 @@ public struct Driver: ParsableCommand {
     }
 
     let program = try TypedProgram(
-      annotating: ScopedProgram(ast), inParallel: !compileSequentially,
+      annotating: ScopedProgram(ast), inParallel: experimentalParallelTypeChecking,
       reportingDiagnosticsTo: &diagnostics,
       tracingInferenceIf: shouldTraceInference)
     if typeCheckOnly { return }

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -64,9 +64,6 @@ public struct TypedProgram {
     tracingInferenceIf shouldTraceInference: ((AnyNodeID, TypedProgram) -> Bool)? = nil
   ) throws {
     let instanceUnderConstruction = SharedMutable(TypedProgram(partiallyFormedFrom: base))
-    #if os(macOS) && DEBUG
-      let typeCheckingIsParallel = typeCheckingIsParallel && false
-    #endif
 
     if typeCheckingIsParallel {
       let sources = base.ast[base.ast.modules].map(\.sources).joined()


### PR DESCRIPTION
It's currently the cause of stack overflows. This change actually speeds up (`--parallel`) testing a little bit.

Fixes #1162