### PR TITLE
Bump swift-codecov-action version to fix deprecation warnings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,7 +79,7 @@ jobs:
               https://github.com/apple/swift-package-manager/issues/6595" && false) )
 
     - name: Check code coverage
-      uses: mattpolzin/swift-codecov-action@0.7.3
+      uses: mattpolzin/swift-codecov-action@0.7.5
       with:
         SORT_ORDER: +cov
         MINIMUM_COVERAGE: 84


### PR DESCRIPTION
These warning are caused by the action using a deprecated command on the GitHub Actions runner. The action author has fixed it in version [`0.7.4`](https://github.com/mattpolzin/swift-codecov-action/releases/tag/0.7.4), but we might as well bump to the latest version.

![image](https://github.com/hylo-lang/hylo/assets/18365890/cd2b780b-d0cf-4cab-9c4a-a1889af39fca)
