### PR TITLE
Remove 'FunctionWrapper'

### DIFF
--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -8,20 +8,20 @@ public type Future<E: Movable & Deinitializable> {
   private var base_frame: SpawnFrameBase
 
   /// What needs to be called to produce the value in the future.
-  private var f: FunctionWrapper<E, Int>
+  private var f: [E]() -> Int
 
   /// The result of the computation.
   private var r: Optional<Int>
 
   /// Initializes `self` with `f`, and spawns the computation.
-  public init(_ f: sink FunctionWrapper<E, Int>) {
+  public init(_ f: sink [E]() -> Int) {
     &self.base_frame = .new()
     &self.f = f
     &self.r = .none()
 
     let local_f = fun (_ frame: SpawnFrameBase) -> Void {
-      inout self = PointerToMutable<Self>(type_punning: mutable_pointer[to: frame]).unsafe[]
-      &self.do_call()
+      inout this = PointerToMutable<Self>(type_punning: mutable_pointer[to: frame]).unsafe[]
+      &this.do_call()
     }
     concore2full_spawn2(self.base_frame, local_f)
   }
@@ -41,7 +41,7 @@ public type Future<E: Movable & Deinitializable> {
   }
 
   private fun do_call() inout {
-    &r = self.f.f()
+    &r = self.f()
   }
 
 }
@@ -75,15 +75,6 @@ type SpawnFrameBase: Deinitializable, Movable {
     &self.target_thread_reclaimer = .null()
     &self.user_function = .null()
   }
-
-}
-
-// TODO: #1246
-type FunctionWrapper<E: Movable & Deinitializable, R>: Movable, Deinitializable {
-
-  let f: [E]() -> R
-
-  memberwise init
 
 }
 

--- a/StandardLibrary/Sources/Concurrency/Spawn.hylo
+++ b/StandardLibrary/Sources/Concurrency/Spawn.hylo
@@ -3,5 +3,5 @@
 ///
 /// The future cannot escape the current scope.
 public fun spawn_<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> Future<E> {
-  Future<E>(FunctionWrapper<E>(f: f))
+  Future<E>(f)
 }


### PR DESCRIPTION
Removes `FunctionWrapper`, which was a workaround #1246.