### PR TITLE
Ban most implicit conversions

### DIFF
--- a/Sources/FrontEnd/TypeChecking/Constraints/EqualityConstraint.swift
+++ b/Sources/FrontEnd/TypeChecking/Constraints/EqualityConstraint.swift
@@ -19,13 +19,6 @@ struct EqualityConstraint: Constraint, Hashable {
     self.origin = origin
   }
 
-  /// Creates an instance transforming by `constraint`.
-  init(_ constraint: SubtypingConstraint) {
-    self.left = constraint.left
-    self.right = constraint.right
-    self.origin = constraint.origin
-  }
-
   /// Inserts the type variables that occur free in `self` into `s`.
   func collectOpenVariables(in s: inout Set<TypeVariable>) {
     left.collectOpenVariables(in: &s)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1176,17 +1176,6 @@ struct TypeChecker {
     discharge(obligations, relatedTo: e)
   }
 
-  /// Checks that the type of `e` is subtype of `supertype`.
-  private mutating func check(_ e: AnyExprID, coercibleTo supertype: AnyType) {
-    var obligations = ProofObligations(scope: program[e].scope)
-
-    let t = inferredType(of: e, withHint: supertype, updating: &obligations)
-    obligations.insert(
-      SubtypingConstraint(t, supertype, origin: .init(.structural, at: program[e].site)))
-
-    discharge(obligations, relatedTo: e)
-  }
-
   /// Type checks `s`.
   private mutating func check<T: StmtID>(_ s: T) {
     switch s.kind {
@@ -1293,7 +1282,7 @@ struct TypeChecker {
   /// Type checks `s`.
   private mutating func check(_ s: DoWhileStmt.ID) {
     check(program[s].body)
-    check(program[s].condition.value, coercibleTo: ^program.ast.coreType("Bool")!)
+    check(program[s].condition.value, instanceOf: ^program.ast.coreType("Bool")!)
   }
 
   /// Type checks `s`.
@@ -1303,7 +1292,7 @@ struct TypeChecker {
     let e = checkedType(of: program[s].binding, usedAs: .filter(matching: element))
     checkedType(of: program[s].binding, usedAs: .filter(matching: e), ignoringSharedCache: true)
     if let e = program[s].filter {
-      check(e.value, coercibleTo: ^program.ast.coreType("Bool")!)
+      check(e.value, instanceOf: ^program.ast.coreType("Bool")!)
     }
     check(program[s].body)
   }
@@ -1337,7 +1326,7 @@ struct TypeChecker {
     for item in condition {
       switch item {
       case .expr(let e):
-        check(e, coercibleTo: bool)
+        check(e, instanceOf: bool)
       case .decl(let d):
         checkedType(of: d, usedAs: .condition, ignoringSharedCache: true)
       }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1229,10 +1229,10 @@ struct TypeChecker {
     obligations.insert(
       ConformanceConstraint(lhs, conformsTo: program.ast.core.movable.type, origin: o))
 
-    // `rhs` must be subtype of `lhs`.
+    // `rhs` must be equal of `lhs`.
     let rhs = inferredType(
       of: program[s].right, withHint: lhs, updating: &obligations)
-    obligations.insert(SubtypingConstraint(rhs, lhs, origin: o))
+    obligations.insert(EqualityConstraint(rhs, lhs, origin: o))
 
     discharge(obligations, relatedTo: s)
   }
@@ -5405,7 +5405,7 @@ struct TypeChecker {
 
     let preferred: ConstraintSet = [
       EqualityConstraint(t, defaultType, origin: cause),
-      SubtypingConstraint(defaultType, h, origin: cause),
+      EqualityConstraint(defaultType, h, origin: cause),
     ]
     let alternative: ConstraintSet = [
       EqualityConstraint(t, h, origin: cause),

--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -40,7 +40,7 @@ public type Future<E: Movable & Deinitializable> {
   }
 
   private fun do_call() inout {
-    &r = self.f()
+    &r = self.f() as _
   }
 
 }

--- a/StandardLibrary/Sources/Core/Range.hylo
+++ b/StandardLibrary/Sources/Core/Range.hylo
@@ -56,7 +56,7 @@ public conformance Range: Iterator where
     if lower_bound == upper_bound { return .none() }
     let r = lower_bound.copy()
     &lower_bound = lower_bound.advance(by: .zero().successor())
-    return r as Optional
+    return r as _
   }
 
 }

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalStmt.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalStmt.hylo
@@ -7,13 +7,13 @@ fun test(b: Bool, i: Int) {
 
   if b, b { use(b) }
 
-  //! @+1 diagnostic 'Int' is not subtype of 'Bool'
+  //! @+1 diagnostic incompatible types 'Bool' and 'Int'
   if i { use(b) }
 
   let x: Union<Int, Bool> = 1 as _
 
   if let y: Int = x, y != 0 { use(b) }
 
-  //! @+1 diagnostic 'Int' is not subtype of 'Bool'
+  //! @+1 diagnostic incompatible types 'Bool' and 'Int'
   if let y: Int = x, y { use(b) }
 }

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalStmt.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalStmt.hylo
@@ -10,7 +10,7 @@ fun test(b: Bool, i: Int) {
   //! @+1 diagnostic 'Int' is not subtype of 'Bool'
   if i { use(b) }
 
-  let x: Union<Int, Bool> = 1
+  let x: Union<Int, Bool> = 1 as _
 
   if let y: Int = x, y != 0 { use(b) }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/DoWhile.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/DoWhile.hylo
@@ -8,5 +8,5 @@ public fun main() {
   var x = 0
   do {
     &x = 1
-  } while x   //! diagnostic 'Int' is not subtype of 'Bool'
+  } while x   //! diagnostic incompatible types 'Bool' and 'Int'
 }

--- a/Tests/HyloTests/TestCases/TypeChecking/Existential.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Existential.hylo
@@ -18,7 +18,7 @@ public fun main() {
   let x0: any A = A<Int>()
   check<any A>(x0)
 
-  let x1: any Copyable = 0
+  let x1: any Copyable = 0 as _
   check<any Copyable>(x1)
 
   let x2: any P1 & P2 = B()

--- a/Tests/HyloTests/TestCases/TypeChecking/For.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/For.hylo
@@ -43,6 +43,6 @@ public fun main() {
   //! @+1 diagnostic consuming for loop requires 'CollectionOfOne<Optional<Int>>' to conform to 'Iterator'
   for sink let _ in a {}
 
-  //! @+1 diagnostic '{}' is not subtype of 'Bool'
+  //! @+1 diagnostic incompatible types 'Bool' and '{}'
   for let _ in a where () {}
 }

--- a/Tests/HyloTests/TestCases/TypeChecking/For.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/For.hylo
@@ -4,7 +4,9 @@ type Counter: Iterator, Deinitializable {
   public var n: Int
   public memberwise init
   public typealias Element = Int
-  public fun next() inout -> Optional<Int> { (n.copy(), &n += 1).0 }
+  public fun next() inout -> Optional<Int> {
+    (n.copy(), &n += 1).0 as _
+  }
 }
 
 fun check<T>(_ x: T) {}

--- a/Tests/HyloTests/TestCases/TypeChecking/UnionTypeGeneric.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/UnionTypeGeneric.hylo
@@ -8,7 +8,7 @@ type B<T> { public memberwise init }
 extension MysteryBox {
 
   static fun make() -> Self {
-    A()
+    A() as _
   }
 
 }

--- a/Tests/HyloTests/TestCases/TypeChecking/While.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/While.hylo
@@ -7,7 +7,8 @@ public fun main() {
   }
 
   var y = 1
-  while y {   //! diagnostic 'Int' is not subtype of 'Bool'
+  //! @+1 diagnostic incompatible types 'Bool' and 'Int'
+  while y {
     &y = 0
   }
 }

--- a/Tests/LibraryTests/TestCases/OptionalTests.hylo
+++ b/Tests/LibraryTests/TestCases/OptionalTests.hylo
@@ -1,7 +1,7 @@
 //- compileAndRun expecting: success
 
 public fun main() {
-  var x: Optional<Int> = 42
+  var x = 42 as Optional<Int>
   let y = if let i: Int = x { i.copy() } else { 0 }
   precondition(y == 42)
 


### PR DESCRIPTION
This PR bans implicit conversions everywhere except at binding declaration (see [rationale](https://github.com/orgs/hylo-lang/discussions/1165)). We might eventually remove those as well.