### PR TITLE
Stand up support for inlining

### DIFF
--- a/Sources/IR/Analysis/InliningPredicate.swift
+++ b/Sources/IR/Analysis/InliningPredicate.swift
@@ -1,0 +1,15 @@
+/// A predicate testing whether inlining should apply.
+public enum InliningPredicate {
+
+  /// The function is inlined iff it has no control flow.
+  case hasNoControlFlow
+
+  /// Returns `true` iff `f`, which is defined in `m`, satisfies `self`.
+  func callAsFunction(_ f: Function.ID, definedIn m: Module) -> Bool {
+    switch self {
+    case .hasNoControlFlow:
+      return m[f].blocks.count == 1
+    }
+  }
+
+}

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -7,12 +7,12 @@ extension IR.Program {
   /// Generates the non-parametric reslient APIs of the modules in `self`.
   public mutating func depolymorphize() {
     for m in modules.keys {
-      depolymorphize(m: m)
+      depolymorphize(m)
     }
   }
 
   /// Generates the non-parametric resilient API of `m`.
-  public mutating func depolymorphize(m: ModuleDecl.ID) {
+  public mutating func depolymorphize(_ m: ModuleDecl.ID) {
     for k in modules[m]!.functions.keys {
       let f = modules[m]!.functions[k]!
 

--- a/Sources/IR/Analysis/Module+Inlining.swift
+++ b/Sources/IR/Analysis/Module+Inlining.swift
@@ -1,0 +1,123 @@
+import Core
+import Utils
+
+extension IR.Program {
+
+  /// Inlines calls in `self` satisfying `shouldInline`.
+  public mutating func inlineCalls(where shouldInline: InliningPredicate) {
+    for m in modules.keys {
+      inlineCalls(in: m, where: shouldInline)
+    }
+  }
+
+  /// Inlines calls in `m` satisfying `shouldInline`.
+  public mutating func inlineCalls(in m: ModuleDecl.ID, where shouldInline: InliningPredicate) {
+    for k in modules[m]!.functions.keys {
+      inlineCalls(in: k, definedIn: m, where: shouldInline)
+    }
+  }
+
+  /// Inlines calls in `f` satisfying `shouldInline`, reading the definition of `f` from `m`.
+  public mutating func inlineCalls(
+    in f: Function.ID, definedIn m: ModuleDecl.ID, where shouldInline: InliningPredicate
+  ) {
+    var work: [InstructionID] = []
+    for b in modules[m]!.blocks(in: f) {
+      for i in modules[m]!.instructions(in: b) {
+        if modules[m]![i] is Call {
+          work.append(i)
+        }
+      }
+    }
+
+    while let i = work.popLast() {
+      _ = inline(functionCall: i, definedIn: m, if: shouldInline)
+    }
+  }
+
+  /// Inlines the contents of function called by `i` if it satisfies `shouldInline`, reading the
+  /// contents of the instruction from `m`.
+  ///
+  /// This methods returns `true` if `shouldInline` is satisfied and the callee is a reference to
+  /// a non-generic function. Otherwise, it returns `false` without modifying anything.
+  ///
+  /// The contents of the callee is inserted in the function containing `i`, applying one "level"
+  /// of inlining. For example, if `i` is a call to F, the functions called by F are not inlined.
+  /// Likewise, if F is recursive, only one level of recursion is inlined.
+  private mutating func inline(
+    functionCall i: InstructionID, definedIn m: ModuleDecl.ID, if shouldInline: InliningPredicate
+  ) -> Bool {
+    let s = modules[m]![i] as! Call
+
+    // Can't inline the call if the callee isn't a function reference.
+    guard let callee = s.callee.constant as? FunctionReference else {
+      return false
+    }
+
+    // Can't inline the call if the callee is generic.
+    if !callee.specialization.isEmpty {
+      return false
+    }
+
+    // Can't inline if the function has no implementation.
+    let source = module(defining: callee.function)
+    if modules[source]![callee.function].entry == nil {
+      return false
+    }
+
+    // Can't inline if `shouldInline` doesn't hold.
+    if !shouldInline(callee.function, definedIn: modules[source]!) {
+      return false
+    }
+
+    var translation = InliningTranslation(rewrittenBlock: [:])
+
+    // Simplest case: the inlined function has no control flow.
+    if modules[source]![callee.function].blocks.count == 1 {
+      let e = Block.ID(callee.function, modules[source]![callee.function].entry!)
+
+      translation.rewrittenOperand[.parameter(e, s.arguments.count)] = s.output
+      for (n, o) in s.arguments.enumerated() {
+        translation.rewrittenOperand[.parameter(e, n)] = o
+      }
+
+      for j in modules[source]!.instructions(in: e) {
+        if modules[source]![j] is Terminator { break }
+        let k = self.rewrite(j, from: source, transformedBy: &translation, at: .before(i), in: m)
+        translation.rewrittenOperand[.register(j)] = .register(k)
+      }
+
+      modules[m]!.removeInstruction(i)
+      return true
+    }
+
+    return false
+  }
+
+}
+
+/// How to translate the contents of a function being inlined.
+private struct InliningTranslation: InstructionTransformer {
+
+  /// A map from basic block to its rewritten form in the inlined function.
+  let rewrittenBlock: [Block.ID: Block.ID]
+
+  /// A map from operand to its rewritten form in the inlined function.
+  var rewrittenOperand: [Operand: Operand] = [:]
+
+  /// Returns `t`.
+  func transform(_ t: AnyType, in ir: inout Program) -> AnyType {
+    t
+  }
+
+  /// Returns a transformed copy of `o` for use in `ir`.
+  func transform(_ o: Operand, in ir: inout IR.Program) -> Operand {
+    o.isConstant ? o : rewrittenOperand[o]!
+  }
+
+  /// Returns a transformed copy of `b` for use in `ir`.
+  func transform(_ b: Block.ID, in ir: inout IR.Program) -> Block.ID {
+    rewrittenBlock[b]!
+  }
+
+}

--- a/Sources/IR/ModulePass.swift
+++ b/Sources/IR/ModulePass.swift
@@ -3,4 +3,6 @@ public enum ModulePass: String {
 
   case depolymorphize
 
+  case inline
+
 }

--- a/Sources/IR/Operands/Instruction/ConstantString.swift
+++ b/Sources/IR/Operands/Instruction/ConstantString.swift
@@ -31,7 +31,7 @@ public struct ConstantString: Instruction {
 extension ConstantString: CustomStringConvertible {
 
   public var description: String {
-    "constant_string \(String(data: value, encoding: .utf8)!)"
+    "constant_string \(String(data: value, encoding: .utf8)!.debugDescription)"
   }
 
 }

--- a/Sources/IR/Program.swift
+++ b/Sources/IR/Program.swift
@@ -35,6 +35,8 @@ public struct Program: Core.Program {
     switch p {
     case .depolymorphize:
       depolymorphize()
+    case .inline:
+      inlineCalls(where: .hasNoControlFlow)
     }
   }
 


### PR DESCRIPTION
This PR implements initial support for inlining IR function calls. Only functions without any control flow are inlined for now.

One can run the inliner with the following command:
```
hc --emit ir --transform inline input.hylo
```