### PR TITLE
Move non-argument-parsing code from Driver.swift to a new file.

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -1,34 +1,11 @@
 import ArgumentParser
-import CodeGenLLVM
 import Core
 import Foundation
-import FrontEnd
-import IR
-import LLVM
-import StandardLibrary
-import Utils
 
 public struct Driver: ParsableCommand {
 
-  /// A validation error that includes the command's full help message.
-  struct ValidationErrorWithHelp: Error, CustomStringConvertible {
-    var message: String
-
-    init(_ message: String) {
-      self.message = message
-    }
-
-    var description: String {
-      """
-      \(message)
-
-      \(Driver.helpMessage())
-      """
-    }
-  }
-
   /// The type of the output files to generate.
-  private enum OutputType: String, ExpressibleByArgument {
+  enum OutputType: String, ExpressibleByArgument {
 
     /// AST before type-checking.
     case rawAST = "raw-ast"
@@ -54,89 +31,89 @@ public struct Driver: ParsableCommand {
   @Flag(
     name: [.customLong("modules")],
     help: "Compile inputs as separate modules.")
-  private var compileInputAsModules: Bool = false
+  var compileInputAsModules: Bool = false
 
   @Flag(
     name: [.customLong("import-builtin")],
     help: "Import the built-in module.")
-  private var importBuiltinModule: Bool = false
+  var importBuiltinModule: Bool = false
 
   @Flag(
     name: [.customLong("freestanding")],
     help:
       "Import only the freestanding core of the standard library, omitting any definitions that depend on having an operating system."
   )
-  private var freestanding: Bool = false
+  var freestanding: Bool = false
 
   @Flag(
     name: [.customLong("experimental-parallel-typechecking")],
     help: "Parallelize the type checker")
-  private var experimentalParallelTypeChecking: Bool = false
+  var experimentalParallelTypeChecking: Bool = false
 
   @Flag(
     name: [.customLong("typecheck")],
     help: "Type-check the input file(s).")
-  private var typeCheckOnly: Bool = false
+  var typeCheckOnly: Bool = false
 
   @Option(
     name: [.customLong("trace-inference")],
     help: ArgumentHelp(
       "Enable tracing of type inference requests at the given line.",
       valueName: "file:line"))
-  private var inferenceTracingSite: SourceLine?
+  var inferenceTracingSite: SourceLine?
 
   @Option(
     name: [.customLong("emit")],
     help: ArgumentHelp(
       "Emit the specified type output files. From: raw-ast, raw-ir, ir, llvm, intel-asm, binary",
       valueName: "output-type"))
-  private var outputType: OutputType = .binary
+  var outputType: OutputType = .binary
 
   @Option(
     name: [.customLong("transform")],
     help: ArgumentHelp(
       "Apply the specify transformations after IR lowering.",
       valueName: "transforms"))
-  private var transforms: ModulePassList?
+  var transforms: ModulePassList?
 
   @Option(
     name: [.customShort("L")],
     help: ArgumentHelp(
       "Add a directory to the library search path.",
       valueName: "directory"))
-  private var librarySearchPaths: [String] = []
+  var librarySearchPaths: [String] = []
 
   @Option(
     name: [.customShort("l")],
     help: ArgumentHelp(
       "Link the generated module(s) to the specified native library.",
       valueName: "name"))
-  private var libraries: [String] = []
+  var libraries: [String] = []
 
   @Option(
     name: [.customShort("o")],
     help: ArgumentHelp("Write output to <file>.", valueName: "file"),
     transform: URL.init(fileURLWithPath:))
-  private var outputURL: URL?
+  var outputURL: URL?
 
   @Flag(
     name: [.short, .long],
     help: "Use verbose output.")
-  private var verbose: Bool = false
+  var verbose: Bool = false
 
   @Flag(
     name: [.customShort("V"), .long],
     help: "Output the compiler version.")
-  private var version: Bool = false
+  var version: Bool = false
 
   @Flag(
     name: [.customShort("O")],
     help: "Compile with optimizations.")
-  private var optimize: Bool = false
+  var optimize: Bool = false
 
   @Argument(
     transform: URL.init(fileURLWithPath:))
-  private var inputs: [URL] = []
+  var inputs: [URL] = []
 
   public init() {}
 
@@ -163,7 +140,8 @@ public struct Driver: ParsableCommand {
   public func execute() throws -> (ExitCode, DiagnosticSet) {
     var diagnostics = DiagnosticSet()
     do {
-      try executeCommand(diagnostics: &diagnostics)
+      let args = Execution(args: self)
+      try args.executeCommand(diagnostics: &diagnostics)
     } catch let d as DiagnosticSet {
       assert(d.containsError, "Diagnostics containing no errors were thrown")
       diagnostics.formUnion(d)
@@ -171,337 +149,4 @@ public struct Driver: ParsableCommand {
     }
     return (ExitCode.success, diagnostics)
   }
-
-  /// Executes the command, accumulating diagnostics in `diagnostics`.
-  private func executeCommand(diagnostics: inout DiagnosticSet) throws {
-
-    if version {
-      standardError.write("\(hcVersion)\n")
-      return
-    }
-
-    guard !inputs.isEmpty else {
-      throw ValidationErrorWithHelp("Missing expected argument '<inputs> ...'")
-    }
-
-    if compileInputAsModules {
-      fatalError("compilation as modules not yet implemented.")
-    }
-
-    let productName = makeProductName(inputs)
-
-    /// An instance that includes just the standard library.
-    var ast = try (freestanding ? Host.freestandingLibraryAST : Host.hostedLibraryAST).get()
-
-    // The module whose Hylo files were given on the command-line
-    let sourceModule = try ast.makeModule(
-      productName, sourceCode: sourceFiles(in: inputs),
-      builtinModuleAccess: importBuiltinModule, diagnostics: &diagnostics)
-
-    if outputType == .rawAST {
-      try write(ast, to: astFile(productName))
-      return
-    }
-
-    let program = try TypedProgram(
-      annotating: ScopedProgram(ast), inParallel: experimentalParallelTypeChecking,
-      reportingDiagnosticsTo: &diagnostics,
-      tracingInferenceIf: shouldTraceInference)
-    if typeCheckOnly { return }
-
-    // IR
-
-    var ir = try lower(program: program, reportingDiagnosticsTo: &diagnostics)
-
-    if outputType == .ir || outputType == .rawIR {
-      let m = ir.modules[sourceModule]!
-      try m.description.write(to: irFile(productName), atomically: true, encoding: .utf8)
-      return
-    }
-
-    // LLVM
-
-    if verbose {
-      standardError.write("begin depolymorphization pass.\n")
-    }
-    ir.depolymorphize()
-
-    if verbose {
-      standardError.write("create LLVM target machine.\n")
-    }
-    #if os(Windows)
-      let target = try LLVM.TargetMachine(for: .host())
-    #else
-      let target = try LLVM.TargetMachine(for: .host(), relocation: .pic)
-    #endif
-    if verbose {
-      standardError.write("create LLVM program.\n")
-    }
-    var llvmProgram = try LLVMProgram(ir, mainModule: sourceModule, for: target)
-
-    if optimize {
-      if verbose {
-        standardError.write("LLVM optimization.\n")
-      }
-      llvmProgram.optimize()
-    } else {
-      if verbose {
-        standardError.write("LLVM mandatory passes.\n")
-      }
-      llvmProgram.applyMandatoryPasses()
-    }
-
-    if verbose {
-      standardError.write("LLVM processing complete.\n")
-    }
-    if outputType == .llvm {
-      let m = llvmProgram.llvmModules[sourceModule]!
-      if verbose {
-        standardError.write("writing LLVM output.")
-      }
-      try m.description.write(to: llvmFile(productName), atomically: true, encoding: .utf8)
-      return
-    }
-
-    // Intel ASM
-
-    if outputType == .intelAsm {
-      try llvmProgram.llvmModules[sourceModule]!.write(
-        .assembly, for: target, to: intelASMFile(productName).fileSystemPath)
-      return
-    }
-
-    // Executables
-
-    assert(outputType == .binary)
-
-    let objectDir = try FileManager.default.makeTemporaryDirectory()
-    let objectFiles = try llvmProgram.write(.objectFile, to: objectDir)
-    let binaryPath = executableOutputPath(default: productName)
-
-    #if os(macOS)
-      try makeMacOSExecutable(at: binaryPath, linking: objectFiles, diagnostics: &diagnostics)
-    #elseif os(Linux)
-      try makeLinuxExecutable(at: binaryPath, linking: objectFiles, diagnostics: &diagnostics)
-    #elseif os(Windows)
-      try makeWindowsExecutable(at: binaryPath, linking: objectFiles, diagnostics: &diagnostics)
-
-    #else
-      _ = objectFiles
-      _ = binaryPath
-      UNIMPLEMENTED()
-    #endif
-  }
-
-  /// Returns `true` if type inference related to `n`, which is in `p`, would be traced.
-  private func shouldTraceInference(_ n: AnyNodeID, _ p: TypedProgram) -> Bool {
-    if let s = inferenceTracingSite {
-      return s.bounds.contains(p[n].site.start)
-    } else {
-      return false
-    }
-  }
-
-  /// Returns `program` lowered to Hylo IR, accumulating diagnostics in `log` and throwing if an
-  /// error occurred.
-  ///
-  /// Mandatory IR passes are applied unless `self.outputType` is `.rawIR`.
-  private func lower(
-    program: TypedProgram, reportingDiagnosticsTo log: inout DiagnosticSet
-  ) throws -> IR.Program {
-    var loweredModules: [ModuleDecl.ID: IR.Module] = [:]
-    for d in program.ast.modules {
-      loweredModules[d] = try lower(d, in: program, reportingDiagnosticsTo: &log)
-    }
-
-    var ir = IR.Program(syntax: program, modules: loweredModules)
-    if let t = transforms {
-      for p in t.elements { ir.applyPass(p) }
-    }
-    return ir
-  }
-
-  /// Returns `m`, which is `program`, lowered to Hylo IR, accumulating diagnostics in `log` and
-  /// throwing if an error occurred.
-  ///
-  /// Mandatory IR passes are applied unless `self.outputType` is `.rawIR`.
-  private func lower(
-    _ m: ModuleDecl.ID, in program: TypedProgram, reportingDiagnosticsTo log: inout DiagnosticSet
-  ) throws -> IR.Module {
-    var ir = try IR.Module(lowering: m, in: program, reportingDiagnosticsTo: &log)
-    if outputType != .rawIR {
-      try ir.applyMandatoryPasses(reportingDiagnosticsTo: &log)
-    }
-    return ir
-  }
-
-  /// Combines the object files located at `objects` into an executable file at `binaryPath`,
-  /// logging diagnostics to `log`.
-  private func makeMacOSExecutable(
-    at binaryPath: String, linking objects: [URL], diagnostics: inout DiagnosticSet
-  ) throws {
-    let xcrun = try findExecutable(invokedAs: "xcrun").fileSystemPath
-    let sdk =
-      try runCommandLine(xcrun, ["--sdk", "macosx", "--show-sdk-path"], diagnostics: &diagnostics)
-      ?? ""
-
-    var arguments = [
-      "-r", "ld", "-o", binaryPath,
-      "-L\(sdk)/usr/lib",
-    ]
-    arguments.append(contentsOf: librarySearchPaths.map({ "-L\($0)" }))
-    arguments.append(contentsOf: objects.map(\.fileSystemPath))
-    arguments.append("-lSystem")
-    arguments.append(contentsOf: libraries.map({ "-l\($0)" }))
-
-    try runCommandLine(xcrun, arguments, diagnostics: &diagnostics)
-  }
-
-  /// Combines the object files located at `objects` into an executable file at `binaryPath`,
-  /// logging diagnostics to `log`.
-  private func makeLinuxExecutable(
-    at binaryPath: String,
-    linking objects: [URL],
-    diagnostics: inout DiagnosticSet
-  ) throws {
-    var arguments = [
-      "-o", binaryPath,
-    ]
-    arguments.append(contentsOf: librarySearchPaths.map({ "-L\($0)" }))
-    arguments.append(contentsOf: objects.map(\.fileSystemPath))
-    arguments.append(contentsOf: libraries.map({ "-l\($0)" }))
-
-    // Note: We use "clang" rather than "ld" so that to deal with the entry point of the program.
-    // See https://stackoverflow.com/questions/51677440
-    try runCommandLine(
-      findExecutable(invokedAs: "clang++").fileSystemPath, arguments, diagnostics: &diagnostics)
-  }
-
-  /// Combines the object files located at `objects` into an executable file at `binaryPath`,
-  /// logging diagnostics to `log`.
-  private func makeWindowsExecutable(
-    at binaryPath: String,
-    linking objects: [URL],
-    diagnostics: inout DiagnosticSet
-  ) throws {
-    try runCommandLine(
-      findExecutable(invokedAs: "lld-link").fileSystemPath,
-      ["-defaultlib:HyloLibC", "-defaultlib:msvcrt", "-out:" + binaryPath]
-        + objects.map(\.fileSystemPath),
-      diagnostics: &diagnostics)
-  }
-
-  /// Returns `self.outputURL` transformed as a suitable executable file path, using `productName`
-  /// as a default name if `outputURL` is `nil`.
-  private func executableOutputPath(default productName: String) -> String {
-    var binaryPath = outputURL?.path ?? URL(fileURLWithPath: productName).fileSystemPath
-    if !binaryPath.hasSuffix(Host.executableSuffix) {
-      binaryPath += Host.executableSuffix
-    }
-    return binaryPath
-  }
-
-  /// If `inputs` contains a single URL `u` whose path is non-empty, returns the last component of
-  /// `u` without any path extension and stripping all leading dots; returns "Main" otherwise.
-  private func makeProductName(_ inputs: [URL]) -> String {
-    if let u = inputs.uniqueElement {
-      let n = u.deletingPathExtension().lastPathComponent.drop(while: { $0 == "." })
-      if !n.isEmpty { return String(n) }
-    }
-    return "Main"
-  }
-
-  /// Writes `source` to `url`, possibly with verbose logging.
-  private func write(_ source: String, toURL url: URL) throws {
-    if verbose {
-      standardError.write("Writing \(url)")
-    }
-    try source.write(to: url, atomically: true, encoding: .utf8)
-  }
-
-  /// Creates a module from the contents at `url` and adds it to the AST.
-  ///
-  /// - Requires: `url` must denote a directly.
-  private func addModule(url: URL) {
-    UNIMPLEMENTED()
-  }
-
-  /// Returns the path of the binary executable that is invoked at the command-line with the name
-  /// given by `invocationName`.
-  private func findExecutable(invokedAs invocationName: String) throws -> URL {
-    if let cached = Driver.executableLocationCache[invocationName] { return cached }
-
-    let executableFileName =
-      invocationName.hasSuffix(Host.executableSuffix)
-      ? invocationName : invocationName + Host.executableSuffix
-
-    // Search in the PATH.
-    let path = ProcessInfo.processInfo.environment[Host.pathEnvironmentVariable] ?? ""
-    for root in path.split(separator: Host.pathEnvironmentSeparator) {
-      let candidate = URL(fileURLWithPath: String(root)).appendingPathComponent(executableFileName)
-      if FileManager.default.fileExists(atPath: candidate.fileSystemPath) {
-        Driver.executableLocationCache[invocationName] = candidate
-        return candidate
-      }
-    }
-
-    throw EnvironmentError("not found: executable invoked as \(invocationName)")
-  }
-
-  /// Runs the executable at `path`, passing `arguments` on the command line, and returns
-  /// its standard output sans any leading or trailing whitespace.
-  @discardableResult
-  private func runCommandLine(
-    _ programPath: String,
-    _ arguments: [String] = [],
-    diagnostics: inout DiagnosticSet
-  ) throws -> String? {
-    if verbose {
-      standardError.write(([programPath] + arguments).joined(separator: " "))
-    }
-
-    let r = try Process.run(URL(fileURLWithPath: programPath), arguments: arguments)
-
-    return r.standardOutput[].trimmingCharacters(in: .whitespacesAndNewlines)
-  }
-
-  /// A map from the name by which an executable is invoked to path of the named binary.
-  private static var executableLocationCache: [String: URL] = [:]
-
-  /// Writes a textual description of `input` to the given `output` file.
-  func write(_ input: AST, to output: URL) throws {
-    let encoder = JSONEncoder().forAST
-    try encoder.encode(input).write(to: output, options: .atomic)
-  }
-
-  /// Given the desired name of the compiler's product, returns the file to write when "raw-ast" is
-  /// selected as the output type.
-  private func astFile(_ productName: String) -> URL {
-    outputURL ?? URL(fileURLWithPath: productName + ".ast.json")
-  }
-
-  /// Given the desired name of the compiler's product, returns the file to write when "ir" or
-  /// "raw-ir" is selected as the output type.
-  private func irFile(_ productName: String) -> URL {
-    outputURL ?? URL(fileURLWithPath: productName + ".ir")
-  }
-
-  /// Given the desired name of the compiler's product, returns the file to write when "llvm" is
-  /// selected as the output type.
-  private func llvmFile(_ productName: String) -> URL {
-    outputURL ?? URL(fileURLWithPath: productName + ".ll")
-  }
-
-  /// Given the desired name of the compiler's product, returns the file to write when "intel-asm" is
-  /// selected as the output type.
-  private func intelASMFile(_ productName: String) -> URL {
-    outputURL ?? URL(fileURLWithPath: productName + ".s")
-  }
-
-  /// Given the desired name of the compiler's product, returns the file to write when "binary" is
-  /// selected as the output type.
-  private func binaryFile(_ productName: String) -> URL {
-    outputURL ?? URL(fileURLWithPath: productName)
-  }
-
 }

--- a/Sources/Driver/Execution.swift
+++ b/Sources/Driver/Execution.swift
@@ -1,0 +1,368 @@
+import CodeGenLLVM
+import Core
+import Foundation
+import FrontEnd
+import IR
+import LLVM
+import StandardLibrary
+import Utils
+
+struct Execution {
+  private let args: Driver
+
+  init(args: Driver) {
+    self.args = args
+  }
+
+  /// Executes the command, accumulating diagnostics in `diagnostics`.
+  func executeCommand(diagnostics: inout DiagnosticSet) throws {
+
+    if args.version {
+      standardError.write("\(hcVersion)\n")
+      return
+    }
+
+    guard !args.inputs.isEmpty else {
+      throw ValidationErrorWithHelp("Missing expected argument '<inputs> ...'")
+    }
+
+    if args.compileInputAsModules {
+      fatalError("compilation as modules not yet implemented.")
+    }
+
+    let productName = makeProductName(args.inputs)
+
+    /// An instance that includes just the standard library.
+    var ast = try (args.freestanding ? Host.freestandingLibraryAST : Host.hostedLibraryAST).get()
+
+    // The module whose Hylo files were given on the command-line
+    let sourceModule = try ast.makeModule(
+      productName, sourceCode: sourceFiles(in: args.inputs),
+      builtinModuleAccess: args.importBuiltinModule, diagnostics: &diagnostics)
+
+    if args.outputType == .rawAST {
+      try write(ast, to: astFile(productName))
+      return
+    }
+
+    let program = try TypedProgram(
+      annotating: ScopedProgram(ast), inParallel: args.experimentalParallelTypeChecking,
+      reportingDiagnosticsTo: &diagnostics,
+      tracingInferenceIf: shouldTraceInference)
+    if args.typeCheckOnly { return }
+
+    // IR
+
+    var ir = try lower(program: program, reportingDiagnosticsTo: &diagnostics)
+
+    if args.outputType == .ir || args.outputType == .rawIR {
+      let m = ir.modules[sourceModule]!
+      try m.description.write(to: irFile(productName), atomically: true, encoding: .utf8)
+      return
+    }
+
+    // LLVM
+
+    if args.verbose {
+      standardError.write("begin depolymorphization pass.\n")
+    }
+    ir.depolymorphize()
+
+    if args.verbose {
+      standardError.write("create LLVM target machine.\n")
+    }
+    #if os(Windows)
+      let target = try LLVM.TargetMachine(for: .host())
+    #else
+      let target = try LLVM.TargetMachine(for: .host(), relocation: .pic)
+    #endif
+    if args.verbose {
+      standardError.write("create LLVM program.\n")
+    }
+    var llvmProgram = try LLVMProgram(ir, mainModule: sourceModule, for: target)
+
+    if args.optimize {
+      if args.verbose {
+        standardError.write("LLVM optimization.\n")
+      }
+      llvmProgram.optimize()
+    } else {
+      if args.verbose {
+        standardError.write("LLVM mandatory passes.\n")
+      }
+      llvmProgram.applyMandatoryPasses()
+    }
+
+    if args.verbose {
+      standardError.write("LLVM processing complete.\n")
+    }
+    if args.outputType == .llvm {
+      let m = llvmProgram.llvmModules[sourceModule]!
+      if args.verbose {
+        standardError.write("writing LLVM output.")
+      }
+      try m.description.write(to: llvmFile(productName), atomically: true, encoding: .utf8)
+      return
+    }
+
+    // Intel ASM
+
+    if args.outputType == .intelAsm {
+      try llvmProgram.llvmModules[sourceModule]!.write(
+        .assembly, for: target, to: intelASMFile(productName).fileSystemPath)
+      return
+    }
+
+    // Executables
+
+    assert(args.outputType == .binary)
+
+    let objectDir = try FileManager.default.makeTemporaryDirectory()
+    let objectFiles = try llvmProgram.write(.objectFile, to: objectDir)
+    let binaryPath = executableOutputPath(default: productName)
+
+    #if os(macOS)
+      try makeMacOSExecutable(at: binaryPath, linking: objectFiles, diagnostics: &diagnostics)
+    #elseif os(Linux)
+      try makeLinuxExecutable(at: binaryPath, linking: objectFiles, diagnostics: &diagnostics)
+    #elseif os(Windows)
+      try makeWindowsExecutable(at: binaryPath, linking: objectFiles, diagnostics: &diagnostics)
+
+    #else
+      _ = objectFiles
+      _ = binaryPath
+      UNIMPLEMENTED()
+    #endif
+  }
+
+  /// Returns `true` if type inference related to `n`, which is in `p`, would be traced.
+  private func shouldTraceInference(_ n: AnyNodeID, _ p: TypedProgram) -> Bool {
+    if let s = args.inferenceTracingSite {
+      return s.bounds.contains(p[n].site.start)
+    } else {
+      return false
+    }
+  }
+
+  /// Returns `program` lowered to Hylo IR, accumulating diagnostics in `log` and throwing if an
+  /// error occurred.
+  ///
+  /// Mandatory IR passes are applied unless `args.outputType` is `.rawIR`.
+  private func lower(
+    program: TypedProgram, reportingDiagnosticsTo log: inout DiagnosticSet
+  ) throws -> IR.Program {
+    var loweredModules: [ModuleDecl.ID: IR.Module] = [:]
+    for d in program.ast.modules {
+      loweredModules[d] = try lower(d, in: program, reportingDiagnosticsTo: &log)
+    }
+
+    var ir = IR.Program(syntax: program, modules: loweredModules)
+    if let t = args.transforms {
+      for p in t.elements { ir.applyPass(p) }
+    }
+    return ir
+  }
+
+  /// Returns `m`, which is `program`, lowered to Hylo IR, accumulating diagnostics in `log` and
+  /// throwing if an error occurred.
+  ///
+  /// Mandatory IR passes are applied unless `args.outputType` is `.rawIR`.
+  private func lower(
+    _ m: ModuleDecl.ID, in program: TypedProgram, reportingDiagnosticsTo log: inout DiagnosticSet
+  ) throws -> IR.Module {
+    var ir = try IR.Module(lowering: m, in: program, reportingDiagnosticsTo: &log)
+    if args.outputType != .rawIR {
+      try ir.applyMandatoryPasses(reportingDiagnosticsTo: &log)
+    }
+    return ir
+  }
+
+  /// Combines the object files located at `objects` into an executable file at `binaryPath`,
+  /// logging diagnostics to `log`.
+  private func makeMacOSExecutable(
+    at binaryPath: String, linking objects: [URL], diagnostics: inout DiagnosticSet
+  ) throws {
+    let xcrun = try findExecutable(invokedAs: "xcrun").fileSystemPath
+    let sdk =
+      try runCommandLine(xcrun, ["--sdk", "macosx", "--show-sdk-path"], diagnostics: &diagnostics)
+      ?? ""
+
+    var arguments = [
+      "-r", "ld", "-o", binaryPath,
+      "-L\(sdk)/usr/lib",
+    ]
+    arguments.append(contentsOf: args.librarySearchPaths.map({ "-L\($0)" }))
+    arguments.append(contentsOf: objects.map(\.fileSystemPath))
+    arguments.append("-lSystem")
+    arguments.append(contentsOf: args.libraries.map({ "-l\($0)" }))
+
+    try runCommandLine(xcrun, arguments, diagnostics: &diagnostics)
+  }
+
+  /// Combines the object files located at `objects` into an executable file at `binaryPath`,
+  /// logging diagnostics to `log`.
+  private func makeLinuxExecutable(
+    at binaryPath: String,
+    linking objects: [URL],
+    diagnostics: inout DiagnosticSet
+  ) throws {
+    var arguments = [
+      "-o", binaryPath,
+    ]
+    arguments.append(contentsOf: args.librarySearchPaths.map({ "-L\($0)" }))
+    arguments.append(contentsOf: objects.map(\.fileSystemPath))
+    arguments.append(contentsOf: args.libraries.map({ "-l\($0)" }))
+
+    // Note: We use "clang" rather than "ld" so that to deal with the entry point of the program.
+    // See https://stackoverflow.com/questions/51677440
+    try runCommandLine(
+      findExecutable(invokedAs: "clang++").fileSystemPath, arguments, diagnostics: &diagnostics)
+  }
+
+  /// Combines the object files located at `objects` into an executable file at `binaryPath`,
+  /// logging diagnostics to `log`.
+  private func makeWindowsExecutable(
+    at binaryPath: String,
+    linking objects: [URL],
+    diagnostics: inout DiagnosticSet
+  ) throws {
+    try runCommandLine(
+      findExecutable(invokedAs: "lld-link").fileSystemPath,
+      ["-defaultlib:HyloLibC", "-defaultlib:msvcrt", "-out:" + binaryPath]
+        + objects.map(\.fileSystemPath),
+      diagnostics: &diagnostics)
+  }
+
+  /// Returns `args.outputURL` transformed as a suitable executable file path, using `productName`
+  /// as a default name if `outputURL` is `nil`.
+  private func executableOutputPath(default productName: String) -> String {
+    var binaryPath = args.outputURL?.path ?? URL(fileURLWithPath: productName).fileSystemPath
+    if !binaryPath.hasSuffix(Host.executableSuffix) {
+      binaryPath += Host.executableSuffix
+    }
+    return binaryPath
+  }
+
+  /// If `inputs` contains a single URL `u` whose path is non-empty, returns the last component of
+  /// `u` without any path extension and stripping all leading dots; returns "Main" otherwise.
+  private func makeProductName(_ inputs: [URL]) -> String {
+    if let u = inputs.uniqueElement {
+      let n = u.deletingPathExtension().lastPathComponent.drop(while: { $0 == "." })
+      if !n.isEmpty { return String(n) }
+    }
+    return "Main"
+  }
+
+  /// Writes `source` to `url`, possibly with verbose logging.
+  private func write(_ source: String, toURL url: URL) throws {
+    if args.verbose {
+      standardError.write("Writing \(url)")
+    }
+    try source.write(to: url, atomically: true, encoding: .utf8)
+  }
+
+  /// Creates a module from the contents at `url` and adds it to the AST.
+  ///
+  /// - Requires: `url` must denote a directly.
+  private func addModule(url: URL) {
+    UNIMPLEMENTED()
+  }
+
+  /// Returns the path of the binary executable that is invoked at the command-line with the name
+  /// given by `invocationName`.
+  private func findExecutable(invokedAs invocationName: String) throws -> URL {
+    if let cached = Execution.executableLocationCache[invocationName] { return cached }
+
+    let executableFileName =
+      invocationName.hasSuffix(Host.executableSuffix)
+      ? invocationName : invocationName + Host.executableSuffix
+
+    // Search in the PATH.
+    let path = ProcessInfo.processInfo.environment[Host.pathEnvironmentVariable] ?? ""
+    for root in path.split(separator: Host.pathEnvironmentSeparator) {
+      let candidate = URL(fileURLWithPath: String(root)).appendingPathComponent(executableFileName)
+      if FileManager.default.fileExists(atPath: candidate.fileSystemPath) {
+        Execution.executableLocationCache[invocationName] = candidate
+        return candidate
+      }
+    }
+
+    throw EnvironmentError("not found: executable invoked as \(invocationName)")
+  }
+
+  /// Runs the executable at `path`, passing `arguments` on the command line, and returns
+  /// its standard output sans any leading or trailing whitespace.
+  @discardableResult
+  private func runCommandLine(
+    _ programPath: String,
+    _ arguments: [String] = [],
+    diagnostics: inout DiagnosticSet
+  ) throws -> String? {
+    if args.verbose {
+      standardError.write(([programPath] + arguments).joined(separator: " "))
+    }
+
+    let r = try Process.run(URL(fileURLWithPath: programPath), arguments: arguments)
+
+    return r.standardOutput[].trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  /// A map from the name by which an executable is invoked to path of the named binary.
+  private static var executableLocationCache: [String: URL] = [:]
+
+  /// Writes a textual description of `input` to the given `output` file.
+  private func write(_ input: AST, to output: URL) throws {
+    let encoder = JSONEncoder().forAST
+    try encoder.encode(input).write(to: output, options: .atomic)
+  }
+
+  /// Given the desired name of the compiler's product, returns the file to write when "raw-ast" is
+  /// selected as the output type.
+  private func astFile(_ productName: String) -> URL {
+    args.outputURL ?? URL(fileURLWithPath: productName + ".ast.json")
+  }
+
+  /// Given the desired name of the compiler's product, returns the file to write when "ir" or
+  /// "raw-ir" is selected as the output type.
+  private func irFile(_ productName: String) -> URL {
+    args.outputURL ?? URL(fileURLWithPath: productName + ".ir")
+  }
+
+  /// Given the desired name of the compiler's product, returns the file to write when "llvm" is
+  /// selected as the output type.
+  private func llvmFile(_ productName: String) -> URL {
+    args.outputURL ?? URL(fileURLWithPath: productName + ".ll")
+  }
+
+  /// Given the desired name of the compiler's product, returns the file to write when "intel-asm" is
+  /// selected as the output type.
+  private func intelASMFile(_ productName: String) -> URL {
+    args.outputURL ?? URL(fileURLWithPath: productName + ".s")
+  }
+
+  /// Given the desired name of the compiler's product, returns the file to write when "binary" is
+  /// selected as the output type.
+  private func binaryFile(_ productName: String) -> URL {
+    args.outputURL ?? URL(fileURLWithPath: productName)
+  }
+
+}
+
+extension Execution {
+  /// A validation error that includes the command's full help message.
+  private struct ValidationErrorWithHelp: Error, CustomStringConvertible {
+    var message: String
+
+    init(_ message: String) {
+      self.message = message
+    }
+
+    var description: String {
+      """
+      \(message)
+
+      \(Driver.helpMessage())
+      """
+    }
+  }
+}


### PR DESCRIPTION
Running [SwiftLint](https://github.com/realm/SwiftLint) against Driver.swift brought up these two issues:

1. hylo/Sources/Driver/Driver.swift:507:1: warning: File Length Violation: File should contain 400 lines or less: currently contains 507 (file_length)
2. hylo/Sources/Driver/Driver.swift:11:8: error: Type Body Length Violation: Type body should span 350 lines or less excluding comments and whitespace: currently spans 351 lines (type_body_length)

To help remedy the above issues, this pull request extracts code from Driver.swift and places it in a new file: Execution.swift.

The code extracted out of Driver.swift is code that is not associated with argument parsing. The code that remains in Driver.swift is associated with argument parsing and conformance to the ParsableCommand protocol. Several unused imports can thus be removed from the top of Driver.swift.

The code placed in Execution.swift is associated with executing the primary compiler code, and the code is wrapped by a new Execution struct. The initializer takes one parameter, which is a Driver struct to get access to the parsed arguments from the Driver struct.

This is essentially a refactor to help prevent Driver.swift from growing too large. I hope it is a useful refactor. Thanks for your consideration.