### PR TITLE
Enable dependabot for the github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Follow-up to the discussion in Slack.

GitHub actions that run on Node 16 are now deprecated, so you'll see messages like this in workflow runs.
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4, compnerd/gha-setup-vsdevenv@a8b61f50b4ba55489b9ff4b1ccfbe65acb028b32. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
Most of these actions have probably already released updated versions that run on Node 20, or if they haven't, they will soon.

This PR enables dependabot for the GitHub Actions ecosystem so that Hylo will get automated PR requests for version updates of the actions in use.

I'm fairly sure that this config is all that is necessary to trigger dependabot to start sending PRs. Once it's committed to the default branch it will trigger. I think the maximum it will send in one go is five. If it's not helpful it can be turned off by removing the config and just closing the PRs.