### PR TITLE
Interpret wildcard without let as sugar for let wildcard

### DIFF
--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2619,6 +2619,9 @@ public enum Parser {
         site: state.range(from: introducer.site.startIndex)))
   }
 
+  /// Parses a binding introducer.
+  ///
+  /// Should not be called before checking if the next token is `_` if another wildcard rule could apply.
   private static func parseBindingIntroducer(
     in state: inout ParserState
   ) throws -> SourceRepresentable<BindingPattern.Introducer>? {

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2624,6 +2624,13 @@ public enum Parser {
   ) throws -> SourceRepresentable<BindingPattern.Introducer>? {
     guard let head = state.peek() else { return nil }
 
+    // Interpret `_ = rhs` as a sugar for `let _ = rhs`
+    if head.kind == .under {
+      return SourceRepresentable(
+        value: .let,
+        range: state.lexer.sourceCode.emptyRange(at: state.currentIndex))
+    }
+
     let introducer: BindingPattern.Introducer
     switch head.kind {
     case .let:

--- a/Tests/EndToEndTests/TestCases/ExhaustiveBranchReturns.hylo
+++ b/Tests/EndToEndTests/TestCases/ExhaustiveBranchReturns.hylo
@@ -1,7 +1,7 @@
 //- compileAndRun expecting: success
 
 public fun main() {
-  let _ = f()
+  _ = f()
 }
 
 public fun f() -> Int {

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1492,6 +1492,13 @@ final class ParserTests: XCTestCase {
     }
   }
 
+  func testLetSugarBindingPattern() throws {
+    let input: SourceFile = "_ = foo"
+    let (p, ast) = try input.parse(with: Parser.parseBindingPattern(in:))
+    let pattern = try XCTUnwrap(ast[p])
+    XCTAssertEqual(pattern.introducer.value, .let)
+  }
+
   func testBindingPatternWithAnnotation() throws {
     let input: SourceFile = "inout x: T)"
     let (p, ast) = try input.parse(with: Parser.parseBindingPattern(in:))


### PR DESCRIPTION
Closes https://github.com/hylo-lang/hylo/issues/977

- Returns `.let` as the introducer from `parseBindingIntroducer` when the current token is `_`