### PR TITLE
Fix tests where test functions are not being executed

### DIFF
--- a/Tests/LibraryTests/TestCases/ArrayTests.hylo
+++ b/Tests/LibraryTests/TestCases/ArrayTests.hylo
@@ -144,6 +144,7 @@ fun test_array_is_copyable() {
 
 public fun main() {
   test_init_empty()
+  test_init_with_lambda()
   test_append()
   test_insert_at()
   test_remove_at()

--- a/Tests/LibraryTests/TestCases/IntTests.hylo
+++ b/Tests/LibraryTests/TestCases/IntTests.hylo
@@ -64,6 +64,7 @@ public fun main() {
 
   test_min()
   test_max()
+  test_init_truncating_or_extending()
   test_signum()
   test_adding_reporting_overflow()
   test_multiplied_reporting_overflow()


### PR DESCRIPTION
Found a couple of cases where test functions are not included in `main()`, and are therefore not executed.