### PR TITLE
Fix write subscript

### DIFF
--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1068,7 +1068,7 @@ struct Emitter {
 
   private mutating func emit(assignStmt s: AssignStmt.ID) -> ControlFlow {
     // The LHS should must be marked for mutation even if the statement denotes initialization.
-    guard program[s].left.kind == InoutExpr.self else {
+    guard ast.isMarkedForMutation(ast[s].left) else {
       let p = program[s].left.site.start
       report(.error(assignmentLHSRequiresMutationMarkerAt: .empty(at: p)))
       return .next

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2238,7 +2238,7 @@ struct Emitter {
     case InoutExpr.self:
       return emitSubscriptCallee(ast[InoutExpr.ID(callee)!].subject, markedForMutation: true)
     default:
-      UNIMPLEMENTED()
+      UNIMPLEMENTED("call to an anonymous subscript of an rvalue")
     }
   }
 

--- a/Sources/IR/TypedProgram+Extensions.swift
+++ b/Sources/IR/TypedProgram+Extensions.swift
@@ -29,4 +29,28 @@ extension TypedProgram {
     }
   }
 
+  /// Returns a subscript bundle reference to `d`, which occurs specialized by `z` and is marked
+  /// for mutation iff `isMutating` is `true`.
+  func subscriptBundleReference(
+    to d: SubscriptDecl.ID, specializedBy z: GenericArguments, markedForMutation isMutating: Bool
+  ) -> BundleReference<SubscriptDecl> {
+    let t = SubscriptType(canonical(self[d].type, in: self[d].scope))!
+    let r = requestedCapabilities(
+      onBundleProviding: t.capabilities, forInPlaceMutation: isMutating)
+    return BundleReference(to: d, specializedBy: z, requesting: r)
+  }
+
+  /// Returns the capabilities potentially requested by an access on a subscript or method bundle
+  /// defining `available`, used for mutation iff `m` is `true`.
+  func requestedCapabilities(
+    onBundleProviding available: AccessEffectSet, forInPlaceMutation m: Bool
+  ) -> AccessEffectSet {
+    let requested = available.intersection(
+      AccessEffectSet.forUseOfBundle(performingInPlaceMutation: m))
+
+    // TODO: requested is empty iff the program is ill-typed w.r.t. mutation markers
+    // assert(!requested.isEmpty)
+    return requested.isEmpty ? available : requested
+  }
+
 }

--- a/StandardLibrary/Sources/Array.hylo
+++ b/StandardLibrary/Sources/Array.hylo
@@ -248,7 +248,7 @@ public conformance Array: Collection {
     }
     inout {
       // precondition(position >= 0 && position < count(), "position is out of bounds")
-      pointer_to_element[at: position].unsafe[]
+      &pointer_to_element[at: position].unsafe[]
     }
   }
 

--- a/StandardLibrary/Sources/BitArray.hylo
+++ b/StandardLibrary/Sources/BitArray.hylo
@@ -54,9 +54,9 @@ public type BitArray {
   fun set_value(_ b: Bool, for p: Position) inout {
     let m = 1 << p.offset
     if b {
-      bits[p.bucket] |= m
+      &bits[p.bucket] |= m
     } else {
-      bits[p.bucket] &= ~m
+      &bits[p.bucket] &= ~m
     }
   }
 

--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -20,8 +20,8 @@ public type Future<E: Movable & Deinitializable> {
     &self.r = .none()
 
     let local_f = fun (_ frame: inout SpawnFrameBase) -> Void {
-      inout this = PointerToMutable<Self>(type_punning: mutable_pointer[to: &frame]).unsafe[]
-      &this.do_call()
+      var this = PointerToMutable<Self>(type_punning: mutable_pointer[to: &frame])
+      &this.unsafe[].do_call()
     }
     concore2full_spawn2(&self.base_frame, local_f)
   }

--- a/StandardLibrary/Sources/DynamicBuffer.hylo
+++ b/StandardLibrary/Sources/DynamicBuffer.hylo
@@ -79,7 +79,7 @@ public type DynamicBuffer<Header: Deinitializable, Element>: Deinitializable, Mo
   /// - Requires: `capacity() > 0`.
   public property header: Header {
     let { buffer_header().unsafe[].1 }
-    inout { &buffer_header().unsafe[].1 }
+    inout { &(buffer_header()).unsafe[].1 }
   }
 
   /// Returns the address of the `self`'s header.

--- a/Tests/LibraryTests/TestCases/BitArrayTests.hylo
+++ b/Tests/LibraryTests/TestCases/BitArrayTests.hylo
@@ -1,0 +1,12 @@
+//- compileAndRun expecting: success
+
+fun test_modify() {
+  var b = BitArray()
+  &b.append(true)
+  &b[0] = false
+  precondition(!b[0])
+}
+
+public fun main() {
+  test_modify()
+}


### PR DESCRIPTION
Fixes #1351

The lowering of subscript didn't properly handled mutation. Fixing it surfaced a few missing mutation markers in the standard library as well as a puzzling use of a local `inout` binding.

@lucteo it would be good if you had a look at 6b0e524a92502e0e80aa2576d3126df60c0d367b and tell if the refactoring looks OK.