### PR TITLE
Enforce access modifiers

### DIFF
--- a/Sources/Core/AST/DeclModifiers/AccessModifier.swift
+++ b/Sources/Core/AST/DeclModifiers/AccessModifier.swift
@@ -4,6 +4,9 @@ public enum AccessModifier: Codable {
   /// Denotes (the default) private declaration.
   case `private`
 
+  /// Denotes a declaration public up to the module boundary.
+  case `internal`
+
   /// Denotes a public declaration.
   case `public`
 

--- a/Sources/Core/AST/NodeIDs/DeclID.swift
+++ b/Sources/Core/AST/NodeIDs/DeclID.swift
@@ -25,6 +25,11 @@ extension DeclID {
     (kind.value as! Decl.Type).isCallable
   }
 
+  /// `true` iff `self` is the implementation of a variant in a bundle.
+  public var isBundleImpl: Bool {
+    kind.value is BundleImpl.Type
+  }
+
   /// `true` iff `self` denotes a type extending declaration.
   public var isTypeExtendingDecl: Bool {
     (kind == ExtensionDecl.self) || (kind == ConformanceDecl.self)

--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -57,6 +57,15 @@ extension Program {
     }
   }
 
+  /// Returns whether `l` and `r` are in the same module.
+  public func areInSameModule<L: NodeIDProtocol, R: NodeIDProtocol>(_ l: L, _ r: R) -> Bool {
+    if let m = ModuleDecl.ID(l) {
+      return isContained(r, in: m)
+    } else {
+      return isContained(r, in: module(containing: nodeToScope[l]!))
+    }
+  }
+
   /// Returns whether `l` overlaps with `r`.
   public func areOverlapping(_ l: AnyScopeID, _ r: AnyScopeID) -> Bool {
     isContained(l, in: r) || isContained(r, in: l)

--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -44,10 +44,7 @@ extension Program {
   /// - `isContained(parent[child], ancestor)`.
   ///
   /// - Requires: `child` is the identifier of a scope in this hierarchy.
-  public func isContained<T: NodeIDProtocol, U: ScopeID>(
-    _ child: T,
-    in ancestor: U
-  ) -> Bool {
+  public func isContained<T: NodeIDProtocol, U: ScopeID>(_ child: T, in ancestor: U) -> Bool {
     var current = AnyNodeID(child)
     while true {
       if ancestor.rawValue == current.rawValue {

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -106,6 +106,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       case "infix": token.kind = .`infix`
       case "init": token.kind = .`init`
       case "inout": token.kind = .`inout`
+      case "internal": token.kind = .`internal`
       case "let": token.kind = .`let`
       case "match": token.kind = .`match`
       case "namespace": token.kind = .`namespace`

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1293,6 +1293,7 @@ public enum Parser {
       }))
 
   static let accessModifier = translate([
+    .internal: AccessModifier.internal,
     .private: AccessModifier.private,
     .public: AccessModifier.public,
   ])

--- a/Sources/FrontEnd/Parse/Token.swift
+++ b/Sources/FrontEnd/Parse/Token.swift
@@ -42,10 +42,6 @@ public struct Token {
     case `match`
     case `namespace`
     case `operator`
-    case `poundElse`
-    case `poundElseif`
-    case `poundEndif`
-    case `poundIf`
     case `postfix`
     case `prefix`
     case `property`
@@ -68,6 +64,11 @@ public struct Token {
     case `while`
     case `yield`
     case `yielded`
+
+    case `poundElse`
+    case `poundElseif`
+    case `poundEndif`
+    case `poundIf`
 
     // Attributes
     case attribute = 4000

--- a/Sources/FrontEnd/Parse/Token.swift
+++ b/Sources/FrontEnd/Parse/Token.swift
@@ -38,6 +38,7 @@ public struct Token {
     case `infix`
     case `init`
     case `inout`
+    case `internal`
     case `let`
     case `match`
     case `namespace`

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -364,6 +364,14 @@ extension Diagnostic {
       """, at: site)
   }
 
+  static func error(
+    invalidReferenceToInaccessible ds: [AnyDeclID], named n: SourceRepresentable<Name>, in ast: AST
+  ) -> Diagnostic {
+    .error(
+      "'\(n.value)' is inaccessible due to its protection level", at: n.site,
+      notes: ds.map { (d) in .note("'\(n.value)' declared here", at: ast[d].site) })
+  }
+
   static func warning(needlessImport d: ImportDecl.ID, in ast: AST) -> Diagnostic {
     let s = ast[d].identifier
     return .warning("needless import: source file is part of '\(s.value)'", at: s.site)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -2585,7 +2585,7 @@ struct TypeChecker {
 
   /// Returns the passing conventions of `e`'s parameters inferred from uses in `e`'s body.
   ///
-  /// Parameters used immutably is inferred to be passed `let` unless corresponding hints specify
+  /// Parameters used immutably are inferred to be passed `let` unless corresponding hints specify
   /// a different convention. Parameters used mutably are inferred to be passed `inout` unless
   /// corresponding hints specify a convention other than `let`.
   ///
@@ -3091,8 +3091,8 @@ struct TypeChecker {
 
   /// Returns the declarations that introduce `name` and are exposed to `scopeOfUse`.
   ///
-  /// Declarations are lookup up qualified in the declaration space of `nominalScope` if it isn't
-  /// `nil`. Otherwise, they are looked up unqualified from `scopeOfuse`.
+  /// Declarations are lookup up qualified in `nominalScope` if it isn't `nil`. Otherwise, they are
+  /// looked up unqualified from `scopeOfuse`. Access modifiers are ignored.
   private mutating func lookup(
     _ name: SourceRepresentable<Name>, memberOf nominalScope: AnyType?,
     exposedTo scopeOfuse: AnyScopeID

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3637,7 +3637,7 @@ struct TypeChecker {
   }
 
   /// Returns the labels of `d`s name.
-  private mutating func labels(_ d: FunctionDecl.ID) -> [String?] {
+  private func labels(_ d: FunctionDecl.ID) -> [String?] {
     program.ast[program[FunctionDecl.ID(d)!].parameters].map(\.label?.value)
   }
 

--- a/StandardLibrary/Sources/BitArray.hylo
+++ b/StandardLibrary/Sources/BitArray.hylo
@@ -67,20 +67,21 @@ public conformance BitArray: Deinitializable {}
 // TODO: Make 'BitArray' conform to 'MutableCollection'
 public extension BitArray {
 
+  // TODO: public[to: BitArray]
   /// A position identifying a bit in a `BitArray`.
-  public type Position {
+  internal type Position {
 
     /// The bucket containing the bit.
-    let bucket: Int
+    internal let bucket: Int
 
     /// The offset of the bit in its bucket.
-    let offset: Int
+    internal let offset: Int
 
     /// Creates an instance with the given properties.
-    memberwise init
+    internal memberwise init
 
     /// Creates an instance identifying the bit at index `i` in a `BitArray`.
-    init(_ i: Int) {
+    internal init(_ i: Int) {
       &self.bucket = i >> Int.bit_width().trailing_zeros()
       &self.offset = i & (Int.bit_width() - 1)
     }

--- a/StandardLibrary/Sources/Core/Bool.hylo
+++ b/StandardLibrary/Sources/Core/Bool.hylo
@@ -1,9 +1,9 @@
 /// A value that can be either `true` or `false`.
 public type Bool {
 
-  var value: Builtin.i1
+  internal var value: Builtin.i1
 
-  memberwise init
+  internal memberwise init
 
   /// Creates an instance with value `false`.
   public init() {

--- a/StandardLibrary/Sources/Core/Hasher.hylo
+++ b/StandardLibrary/Sources/Core/Hasher.hylo
@@ -1,8 +1,10 @@
 namespace FNV {
 
-  let offset_basis = Int(bit_pattern: 0xcbf29ce484222325)
+  // TODO: public[to: Hasher]
+  internal let offset_basis = Int(bit_pattern: 0xcbf29ce484222325)
 
-  let prime = Int(bit_pattern: 0x100000001b3)
+  // TODO: public[to: Hasher]
+  internal let prime = Int(bit_pattern: 0x100000001b3)
 
 }
 

--- a/StandardLibrary/Sources/Core/Numbers/Floats/Float32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Floats/Float32.hylo
@@ -1,7 +1,7 @@
 /// A singe-precision, floating-point value.
 public type Float32 {
 
-  var value: Builtin.float32
+  internal var value: Builtin.float32
 
   memberwise init
 

--- a/StandardLibrary/Sources/Core/Numbers/Floats/Float64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Floats/Float64.hylo
@@ -1,7 +1,7 @@
 /// A double-precision, floating-point value.
 public type Float64 {
 
-  var value: Builtin.float64
+  internal var value: Builtin.float64
 
   memberwise init
 

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int.hylo
@@ -1,9 +1,9 @@
 /// A signed integer value.
 public type Int {
 
-  var value: Builtin.word
+  internal var value: Builtin.word
 
-  memberwise init
+  internal memberwise init
 
   /// Creates an instance with the same memory representation as `other`.
   public init(bit_pattern other: UInt) {

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int32.hylo
@@ -1,9 +1,9 @@
 /// A 32-bit signed integer value.
 public type Int32: Regular {
 
-  var value: Builtin.i32
+  internal var value: Builtin.i32
 
-  memberwise init
+  internal memberwise init
 
   /// Creates an instance with the same memory representation as `other`.
   public init(bit_pattern other: UInt32) {

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int8.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int8.hylo
@@ -1,9 +1,9 @@
 /// A 8-bit signed integer value.
 public type Int8 {
 
-  var value: Builtin.i8
+  internal var value: Builtin.i8
 
-  memberwise init
+  internal memberwise init
 
   /// Creates an instance with the same memory representation as `other`.
   public init(bit_pattern other: UInt8) {

--- a/StandardLibrary/Sources/Core/Numbers/Integers/UInt.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/UInt.hylo
@@ -1,9 +1,9 @@
 /// An unsigned integer value.
 public type UInt {
 
-  var value: Builtin.word
+  internal var value: Builtin.word
 
-  memberwise init
+  internal memberwise init
 
   /// Creates an instance with the same memory representation as `other`.
   public init(bit_pattern other: Int) {

--- a/StandardLibrary/Sources/Core/Numbers/Integers/UInt32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/UInt32.hylo
@@ -1,9 +1,9 @@
 /// A 32-bit unsigned integer value.
 public type UInt32: Regular {
 
-  var value: Builtin.i32
+  internal var value: Builtin.i32
 
-  memberwise init
+  internal memberwise init
 
   /// Creates an instance with the same memory representation as `other`.
   public init(bit_pattern other: Int32) {

--- a/StandardLibrary/Sources/Core/Numbers/Integers/UInt8.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/UInt8.hylo
@@ -1,9 +1,9 @@
 /// A 8-bit unsigned integer value.
 public type UInt8 {
 
-  var value: Builtin.i8
+  internal var value: Builtin.i8
 
-  memberwise init
+  internal memberwise init
 
   /// Creates an instance with the same memory representation as `other`.
   public init(bit_pattern other: Int8) {

--- a/StandardLibrary/Sources/Core/Pointer.hylo
+++ b/StandardLibrary/Sources/Core/Pointer.hylo
@@ -2,9 +2,9 @@
 public type Pointer<Pointee>: Regular {
 
   /// The raw bits of the address.
-  var base: Builtin.ptr
+  internal var base: Builtin.ptr
 
-  memberwise init
+  internal memberwise init
 
   /// The value at the given address.
   ///

--- a/StandardLibrary/Sources/Core/PointerToMutable.hylo
+++ b/StandardLibrary/Sources/Core/PointerToMutable.hylo
@@ -2,9 +2,9 @@
 public type PointerToMutable<Pointee>: Regular {
 
   /// The raw bits of the address.
-  var base: Builtin.ptr
+  internal var base: Builtin.ptr
 
-  memberwise init
+  internal memberwise init
 
   /// The value at the address represented by `self`.
   ///

--- a/StandardLibrary/Sources/Core/Runtime.hylo
+++ b/StandardLibrary/Sources/Core/Runtime.hylo
@@ -11,17 +11,17 @@ public namespace Runtime {
   public type MetatypeHeader {
 
     /// The contiguous memory footprint of the type's instances, in bytes.
-    let size: Int
+    public let size: Int
 
     /// The preferred memory alignment of the type's instances, in bytes.
-    let alignment: Int
+    public let alignment: Int
 
     /// The number of bytes from the start of one instance to the start of the next when stored in
     /// contiguous memory.
-    let stride: Int
+    public let stride: Int
 
     /// The description of the type's layout.
-    let representation: MemoryAddress
+    public let representation: MemoryAddress
 
   }
 

--- a/Tests/EndToEndTests/TestCases/CustomMove.hylo
+++ b/Tests/EndToEndTests/TestCases/CustomMove.hylo
@@ -1,7 +1,7 @@
 //- compileAndRun expecting: success
 
 type A: Deinitializable {
-  var witness: Int
+  public var witness: Int
   public var x: Int
   public init(x: sink Int) {
     &self.x = x

--- a/Tests/EndToEndTests/TestCases/Existential.hylo
+++ b/Tests/EndToEndTests/TestCases/Existential.hylo
@@ -7,7 +7,7 @@ trait T: Deinitializable {
 }
 
 type A: T {
-  memberwise init
+  public memberwise init
   public fun foo() -> Int { 42 }
 }
 

--- a/Tests/EndToEndTests/TestCases/MonomorphizeRequirements.hylo
+++ b/Tests/EndToEndTests/TestCases/MonomorphizeRequirements.hylo
@@ -7,7 +7,7 @@ trait P {
 
 type A<T>: Deinitializable, P {
   var x: Int
-  memberwise init
+  public memberwise init
   public fun f() -> Int { x.copy() }
   public property n: Int { let { yield x } }
 }

--- a/Tests/HyloTests/LexerTests.swift
+++ b/Tests/HyloTests/LexerTests.swift
@@ -133,8 +133,8 @@ final class LexerTests: XCTestCase {
   func testKeywords() {
     let input: SourceFile = """
       any break catch conformance continue do else extension for fun if import in infix init inout
-      let match namespace operator postfix prefix property private public remote return set sink
-      some spawn static subscript trait try type typealias var where while yield yielded
+      internal let match namespace operator postfix prefix property private public remote return
+      set sink some spawn static subscript trait try type typealias var where while yield yielded
       """
 
     assert(
@@ -156,6 +156,7 @@ final class LexerTests: XCTestCase {
         TokenSpecification(.`infix`, "infix"),
         TokenSpecification(.`init`, "init"),
         TokenSpecification(.`inout`, "inout"),
+        TokenSpecification(.`internal`, "internal"),
         TokenSpecification(.`let`, "let"),
         TokenSpecification(.`match`, "match"),
         TokenSpecification(.`namespace`, "namespace"),

--- a/Tests/HyloTests/LexerTests.swift
+++ b/Tests/HyloTests/LexerTests.swift
@@ -134,8 +134,7 @@ final class LexerTests: XCTestCase {
     let input: SourceFile = """
       any break catch conformance continue do else extension for fun if import in infix init inout
       let match namespace operator postfix prefix property private public remote return set sink
-      some spawn static subscript trait try type typealias var where while yield yielded #if #else
-      #elseif #endif
+      some spawn static subscript trait try type typealias var where while yield yielded
       """
 
     assert(
@@ -183,6 +182,15 @@ final class LexerTests: XCTestCase {
         TokenSpecification(.`while`, "while"),
         TokenSpecification(.`yield`, "yield"),
         TokenSpecification(.`yielded`, "yielded"),
+      ],
+      in: input)
+  }
+
+  func testPoundKeywords() {
+    let input: SourceFile = "#if #else #elseif #endif"
+    assert(
+      tokenize(input),
+      matches: [
         TokenSpecification(.`poundIf`, "#if"),
         TokenSpecification(.`poundElse`, "#else"),
         TokenSpecification(.`poundElseif`, "#elseif"),

--- a/Tests/HyloTests/TestCases/Lowering/MemberLambda.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/MemberLambda.hylo
@@ -4,7 +4,7 @@
 // call to a member property with a lambda type.
 
 type Holder: Deinitializable {
-  var f: []() -> Int
+  public var f: []() -> Int
   public memberwise init
 }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/AccessModifiers.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/AccessModifiers.hylo
@@ -1,0 +1,12 @@
+//- typeCheck expecting: failure
+
+type A: Deinitializable {
+  public memberwise init
+  fun one() -> Int { 1 }
+}
+
+public fun main() {
+  //! @+2 diagnostic type 'A' has no member 'one'
+  //! @+1 diagnostic 'one' is inaccessible due to its protection level
+  _ = A().one()
+}

--- a/Tests/HyloTests/TestCases/TypeChecking/CallInit.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallInit.hylo
@@ -2,9 +2,9 @@
 
 type A: Movable {
 
-  var x: Int
+  public var x: Int
 
-  memberwise init
+  public memberwise init
 
   public init(value: sink Int) {
     &self = A(x: value)

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension.hylo
@@ -7,14 +7,14 @@ trait T {
 type A<X> {}
 
 type B<X>: Deinitializable {
-  memberwise init
+  public memberwise init
 }
 
 //! @+1 diagnostic undefined name 'S' in this scope
 extension A where X: S {}
 
 extension B where X: T {
-  fun foo() {}
+  public fun foo() {}
 }
 
 public fun main() {

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension2.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension2.hylo
@@ -8,7 +8,7 @@ type A<E>: Deinitializable {
 }
 
 extension A where E: P, E.X: Q {
-  fun foo() {}
+  public fun foo() {}
 }
 
 type B<X: Q>: P {}

--- a/Tests/HyloTests/TestCases/TypeChecking/WhereClause.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/WhereClause.hylo
@@ -5,7 +5,7 @@ type A<X>: Deinitializable {
 }
 
 extension A where X == Bool {
-  fun koala() {}
+  public fun koala() {}
 }
 
 public fun main() {

--- a/Tests/ManglingTests/ManglingTests.swift
+++ b/Tests/ManglingTests/ManglingTests.swift
@@ -13,7 +13,7 @@ final class ManglingTests: XCTestCase {
       import Hylo
 
       namespace Stash {
-        type A {}
+        public type A {}
 
         trait Indexable {
           value size


### PR DESCRIPTION
This PR is step 1 of the support for access modifiers. Modifiers on declarations are now enforced by name resolution, meaning that a private declaration isn't accessible outside of the scope that introduced it.

The current design includes `private` (which is the default), `internal` and `public`. These modifiers work similarly to Swift with the exception that private declarations introduced in extensions are visible to the entire scope of the extended type, within a module boundary.

A next PR will implement `public[in:]` (syntax strawman), which will remove some of the TODOs placed on some `internal` member declarations.