### PR TITLE
Adopts the rename of the Swifty-LLVM module to SwiftyLLVM.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Swift Package Manager
 /.build
+/.*-build
 /Packages
 
 # IDEs

--- a/Package.resolved
+++ b/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hylo-lang/Swifty-LLVM",
       "state" : {
-        "branch" : "main",
-        "revision" : "650686ff5cc0db22efea0e4fa11942881ad91c73"
+        "branch" : "cmake",
+        "revision" : "2e36dccbd58588b979bb9a49ef005728c648155a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
       from: "5.3.0"),
     .package(
       url: "https://github.com/hylo-lang/Swifty-LLVM",
-      branch: "main"),
+      branch: "cmake"),
     .package(
       url: "https://github.com/apple/swift-format",
       from: "508.0.1"),
@@ -105,7 +105,7 @@ let package = Package(
       dependencies: [
         "Utils",
         .product(name: "Collections", package: "swift-collections"),
-        .product(name: "LLVM", package: "Swifty-LLVM"),
+        .product(name: "SwiftyLLVM", package: "Swifty-LLVM"),
       ],
       swiftSettings: allTargetsSwiftSettings),
 
@@ -120,7 +120,7 @@ let package = Package(
         "Core",
         "IR",
         "Utils",
-        .product(name: "LLVM", package: "Swifty-LLVM"),
+        .product(name: "SwiftyLLVM", package: "Swifty-LLVM"),
       ],
       path: "Sources/CodeGen/LLVM",
       swiftSettings: allTargetsSwiftSettings),

--- a/Sources/CodeGen/LLVM/ConcreteTypeLayout.swift
+++ b/Sources/CodeGen/LLVM/ConcreteTypeLayout.swift
@@ -1,6 +1,6 @@
 import Core
 import IR
-import LLVM
+import SwiftyLLVM
 import Utils
 
 /// The concrete layout of a type, describing the byte offsets of its stored properties.
@@ -27,7 +27,7 @@ struct ConcreteTypeLayout {
   /// Creates the concrete form of the layout `l` of a type defined in `ir`, for use in `m`.
   ///
   /// - Requires: `l.type` is representable in LLVM.
-  init(_ l: AbstractTypeLayout, definedIn ir: IR.Program, forUseIn m: inout LLVM.Module) {
+  init(_ l: AbstractTypeLayout, definedIn ir: IR.Program, forUseIn m: inout SwiftyLLVM.Module) {
     switch l.type.base {
     case let t as BuiltinType:
       self.init(of: t, forUseIn: &m)
@@ -46,14 +46,14 @@ struct ConcreteTypeLayout {
   /// Creates the layout of `t`, which is defined in `ir`, for use in `m`.
   ///
   /// - Requires: `t` is representable in LLVM.
-  init(of t: AnyType, definedIn ir: IR.Program, forUseIn m: inout LLVM.Module) {
+  init(of t: AnyType, definedIn ir: IR.Program, forUseIn m: inout SwiftyLLVM.Module) {
     self.init(AbstractTypeLayout(of: t, definedIn: ir.base), definedIn: ir, forUseIn: &m)
   }
 
   /// Creates the layout of `t` for use in `m`.
   ///
   /// - Requires: `t` is not `.module`.
-  init(of t: BuiltinType, forUseIn m: inout LLVM.Module) {
+  init(of t: BuiltinType, forUseIn m: inout SwiftyLLVM.Module) {
     switch t {
     case .ptr:
       let s = m.layout.storageSize(of: m.ptr)

--- a/Sources/CodeGen/LLVM/LLVM+Word.swift
+++ b/Sources/CodeGen/LLVM/LLVM+Word.swift
@@ -1,9 +1,9 @@
-import LLVM
+import SwiftyLLVM
 
-extension LLVM.Module {
+extension SwiftyLLVM.Module {
 
   /// Returns the LLVM type of a machine word.
-  mutating func word() -> LLVM.IntegerType {
+  mutating func word() -> SwiftyLLVM.IntegerType {
     IntegerType(layout.bitWidth(of: ptr), in: &self)
   }
 

--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -1,17 +1,17 @@
 import Core
 import Foundation
 import IR
-import LLVM
+import SwiftyLLVM
 import Utils
 
 /// A Hylo program transpiled to LLVM.
 public struct LLVMProgram {
 
   /// The machine for which the program is compiled.
-  public let target: LLVM.TargetMachine
+  public let target: SwiftyLLVM.TargetMachine
 
   /// The LLVM modules in the program.
-  public private(set) var llvmModules: [ModuleDecl.ID: LLVM.Module] = [:]
+  public private(set) var llvmModules: [ModuleDecl.ID: SwiftyLLVM.Module] = [:]
 
   /// Creates a transpiling `ir`, whose main module is `mainModule`, for `target`.
   ///
@@ -20,11 +20,11 @@ public struct LLVMProgram {
   public init(
     _ ir: IR.Program,
     mainModule: ModuleDecl.ID,
-    for target: LLVM.TargetMachine? = nil
+    for target: SwiftyLLVM.TargetMachine? = nil
   ) throws {
-    self.target = try target ?? LLVM.TargetMachine(for: .host())
+    self.target = try target ?? SwiftyLLVM.TargetMachine(for: .host())
     for m in ir.modules.keys {
-      let transpilation = LLVM.Module(transpiling: m, from: ir)
+      let transpilation = SwiftyLLVM.Module(transpiling: m, from: ir)
       do {
         try transpilation.verify()
       } catch {
@@ -55,7 +55,7 @@ public struct LLVMProgram {
   /// to `directory`, returning the URL of each written file.
   ///
   /// - Returns: The URL of each written product, one for each module in `self`.
-  public func write(_ type: LLVM.CodeGenerationResultType, to directory: URL) throws -> [URL] {
+  public func write(_ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL) throws -> [URL] {
     precondition(directory.hasDirectoryPath)
     var result: [URL] = []
     for m in llvmModules.values {

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -1,6 +1,6 @@
 import Core
 import IR
-import LLVM
+import SwiftyLLVM
 import Utils
 
 extension IR.Program {
@@ -8,7 +8,7 @@ extension IR.Program {
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm<T: TypeProtocol>(_ val: T, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm<T: TypeProtocol>(_ val: T, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
     switch val {
     case let t as AnyType:
       return llvm(t.base, in: &module)
@@ -38,40 +38,40 @@ extension IR.Program {
   /// Returns the LLVM form of `t` in `module`.
   ///
   /// - Requires: `t` is representable in LLVM.
-  func llvm(arrowType t: ArrowType, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm(arrowType t: ArrowType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
     precondition(t[.isCanonical])
     let e = llvm(t.environment, in: &module)
-    return LLVM.StructType([module.ptr, e], in: &module)
+    return SwiftyLLVM.StructType([module.ptr, e], in: &module)
   }
 
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(bufferType val: BufferType, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm(bufferType val: BufferType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
     let e = llvm(val.element, in: &module)
     guard let n = val.count.asCompilerKnown(Int.self) else {
       notLLVMRepresentable(val)
     }
-    return LLVM.ArrayType(n, e, in: &module)
+    return SwiftyLLVM.ArrayType(n, e, in: &module)
   }
 
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(builtinType val: BuiltinType, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm(builtinType val: BuiltinType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
     switch val {
     case .i(let width):
-      return LLVM.IntegerType(width, in: &module)
+      return SwiftyLLVM.IntegerType(width, in: &module)
     case .word:
       return module.word()
     case .float16:
-      return LLVM.FloatingPointType.half(in: &module)
+      return SwiftyLLVM.FloatingPointType.half(in: &module)
     case .float32:
-      return LLVM.FloatingPointType.float(in: &module)
+      return SwiftyLLVM.FloatingPointType.float(in: &module)
     case .float64:
-      return LLVM.FloatingPointType.double(in: &module)
+      return SwiftyLLVM.FloatingPointType.double(in: &module)
     case .float128:
-      return LLVM.FloatingPointType.fp128(in: &module)
+      return SwiftyLLVM.FloatingPointType.fp128(in: &module)
     case .ptr:
       return module.ptr
     case .module:
@@ -82,7 +82,7 @@ extension IR.Program {
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(boundGenericType val: BoundGenericType, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm(boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
     precondition(val[.isCanonical])
 
     let fields = base.storage(of: val.base).map { (part) in
@@ -92,9 +92,9 @@ extension IR.Program {
 
     switch val.base.base {
     case let u as ProductType:
-      return LLVM.StructType(named: u.name.value, fields, in: &module)
+      return SwiftyLLVM.StructType(named: u.name.value, fields, in: &module)
     case is TupleType:
-      return LLVM.StructType(fields, in: &module)
+      return SwiftyLLVM.StructType(fields, in: &module)
     default:
       unreachable()
     }
@@ -103,45 +103,45 @@ extension IR.Program {
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(productType val: ProductType, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm(productType val: ProductType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
     precondition(val[.isCanonical])
 
     let n = base.mangled(val)
     if let t = module.type(named: n) {
-      assert(LLVM.StructType(t) != nil)
+      assert(SwiftyLLVM.StructType(t) != nil)
       return t
     }
 
     let l = AbstractTypeLayout(of: val, definedIn: base)
-    var fields: [LLVM.IRType] = []
+    var fields: [SwiftyLLVM.IRType] = []
     for p in l.properties {
       fields.append(llvm(p.type, in: &module))
     }
 
-    return LLVM.StructType(named: n, fields, in: &module)
+    return SwiftyLLVM.StructType(named: n, fields, in: &module)
   }
 
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(tupleType val: TupleType, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm(tupleType val: TupleType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
     precondition(val[.isCanonical])
 
-    var fields: [LLVM.IRType] = []
+    var fields: [SwiftyLLVM.IRType] = []
     for e in val.elements {
       fields.append(llvm(e.type, in: &module))
     }
 
-    return LLVM.StructType(fields, in: &module)
+    return SwiftyLLVM.StructType(fields, in: &module)
   }
 
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(unionType val: UnionType, in module: inout LLVM.Module) -> LLVM.IRType {
+  func llvm(unionType val: UnionType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
     precondition(val[.isCanonical])
 
-    var payload: LLVM.IRType = LLVM.StructType([], in: &module)
+    var payload: SwiftyLLVM.IRType = SwiftyLLVM.StructType([], in: &module)
     if val == .never {
       return payload
     }

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -1,4 +1,4 @@
-import LLVM
+import SwiftyLLVM
 import Utils
 
 /// A function representing an IR instruction in Hylo source code.
@@ -335,7 +335,7 @@ private func mathFlags(_ stream: inout ArraySlice<Substring>) -> NativeInstructi
 }
 
 /// Returns an overflow behavior parsed from `stream` or `.ignore` if none can be parsed.
-private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> LLVM.OverflowBehavior {
+private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> SwiftyLLVM.OverflowBehavior {
   switch stream.first {
   case "nuw":
     stream.removeFirst()
@@ -362,7 +362,7 @@ private let integerArithmeticTail =
 
 /// Parses the parameters and type of `icmp`.
 private let integerComparisonTail =
-  take(LLVM.IntegerPredicate.self) ++ builtinType
+  take(SwiftyLLVM.IntegerPredicate.self) ++ builtinType
 
 /// Parses the parameters and type of a floating-point arithmetic instruction.
 private let floatingPointArithmeticTail =
@@ -370,4 +370,4 @@ private let floatingPointArithmeticTail =
 
 /// Parses the parameters and type of `fcmp`.
 private let floatingPointComparisonTail =
-  mathFlags ++ take(LLVM.FloatingPointPredicate.self) ++ builtinType
+  mathFlags ++ take(SwiftyLLVM.FloatingPointPredicate.self) ++ builtinType

--- a/Sources/Core/NativeInstruction.swift
+++ b/Sources/Core/NativeInstruction.swift
@@ -1,4 +1,4 @@
-import LLVM
+import SwiftyLLVM
 
 /// The name of an native instruction mapped to a built-in function.
 ///
@@ -27,13 +27,13 @@ import LLVM
 /// integral and floating-point numbers as well as conversions from and to these types.
 public enum NativeInstruction: Hashable {
 
-  case add(LLVM.OverflowBehavior, BuiltinType)
+  case add(SwiftyLLVM.OverflowBehavior, BuiltinType)
 
-  case sub(LLVM.OverflowBehavior, BuiltinType)
+  case sub(SwiftyLLVM.OverflowBehavior, BuiltinType)
 
-  case mul(LLVM.OverflowBehavior, BuiltinType)
+  case mul(SwiftyLLVM.OverflowBehavior, BuiltinType)
 
-  case shl(LLVM.OverflowBehavior, BuiltinType)
+  case shl(SwiftyLLVM.OverflowBehavior, BuiltinType)
 
   case udiv(exact: Bool, BuiltinType)
 
@@ -71,7 +71,7 @@ public enum NativeInstruction: Hashable {
   // Corresponding LLVM instruction: umul.with.overflow
   case unsignedMultiplicationWithOverflow(BuiltinType)
 
-  case icmp(LLVM.IntegerPredicate, BuiltinType)
+  case icmp(SwiftyLLVM.IntegerPredicate, BuiltinType)
 
   case trunc(BuiltinType, BuiltinType)
 
@@ -97,7 +97,7 @@ public enum NativeInstruction: Hashable {
 
   case frem(MathFlags, BuiltinType)
 
-  case fcmp(MathFlags, LLVM.FloatingPointPredicate, BuiltinType)
+  case fcmp(MathFlags, SwiftyLLVM.FloatingPointPredicate, BuiltinType)
 
   case fptrunc(BuiltinType, BuiltinType)
 

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -4,7 +4,7 @@ import Core
 import Foundation
 import FrontEnd
 import IR
-import LLVM
+import SwiftyLLVM
 import StandardLibrary
 import Utils
 
@@ -230,9 +230,9 @@ public struct Driver: ParsableCommand {
       standardError.write("create LLVM target machine.\n")
     }
     #if os(Windows)
-      let target = try LLVM.TargetMachine(for: .host())
+      let target = try SwiftyLLVM.TargetMachine(for: .host())
     #else
-      let target = try LLVM.TargetMachine(for: .host(), relocation: .pic)
+      let target = try SwiftyLLVM.TargetMachine(for: .host(), relocation: .pic)
     #endif
     if verbose {
       standardError.write("create LLVM program.\n")


### PR DESCRIPTION
Apparently needed for CMake/LLVM compatibility, since LLVM's own CMake files declare "LLVM" as a target.

This commit points hylo at the "cmake" branch of the Swifty-LLVM project until that branch can be merged to "main".