### PR TITLE
Use function linkage attribute to improve optimization opportunities

### DIFF
--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -494,16 +494,7 @@ extension SwiftyLLVM.Module {
   private mutating func configureAttributes(
     _ llvmFunction: SwiftyLLVM.Function, transpiledFrom f: IR.Function.ID, of m: IR.Module
   ) {
-    // FIXME: See #888
-    // switch m[f].linkage {
-    // case .external:
-    //   setLinkage(.external, for: llvmFunction)
-    // case .module:
-    //   setLinkage(.private, for: llvmFunction)
-    // }
-
-    // Monomorphized functions always have private linkage.
-    if f.isMonomorphized {
+    if m[f].linkage == .module {
       setLinkage(.private, for: llvmFunction)
     }
 

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -505,9 +505,15 @@ extension SwiftyLLVM.Module {
       setLinkage(.private, for: llvmFunction)
     }
 
-    // Functions that return `Never` have the `noreturn` attribute.
-    if !m[f].isSubscript && (m[f].output == .never) {
-      addAttribute(.init(.noreturn, in: &self), to: llvmFunction)
+    if !m[f].isSubscript {
+      let r = llvmFunction.parameters.last!
+      addAttribute(.init(.noalias, in: &self), to: r)
+      addAttribute(.init(.nocapture, in: &self), to: r)
+      addAttribute(.init(.nofree, in: &self), to: r)
+
+      if m[f].output == .never {
+        addAttribute(.init(.noreturn, in: &self), to: llvmFunction)
+      }
     }
   }
 

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -115,10 +115,10 @@ extension SwiftyLLVM.Module {
     let transpilation = function(named: ir.llvmName(of: f))!
     setLinkage(.private, for: transpilation)
 
-    let val32 = ir.ast.coreType("Int32")!
+    let int32 = ir.ast.coreType("Int32")!
     switch m[f].output {
-    case val32:
-      let t = StructType(ir.llvm(val32, in: &self))!
+    case int32:
+      let t = StructType(ir.llvm(int32, in: &self))!
       let s = insertAlloca(t, at: p)
       _ = insertCall(transpilation, on: [s], at: p)
 

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -96,6 +96,12 @@ extension SwiftyLLVM.Module {
     insertReturn(x0, at: insertionPoint)
   }
 
+  /// Defines a "main" function calling the function `f`, which represents the entry point of the
+  /// entry module `m` of the program `ir`.
+  ///
+  /// This method creates a LLVM entry point calling `f`, which is the lowered form of a public
+  /// function named "main", taking no parameter and returning either `Void` or `Int32`. `f` will
+  /// be linked privately in `m`.
   private mutating func defineMain(
     calling f: IR.Function.ID,
     of m: IR.Module,
@@ -107,6 +113,7 @@ extension SwiftyLLVM.Module {
     let p = endOf(b)
 
     let transpilation = function(named: ir.llvmName(of: f))!
+    setLinkage(.private, for: transpilation)
 
     let val32 = ir.ast.coreType("Int32")!
     switch m[f].output {

--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -294,12 +294,16 @@ extension Program {
       return isExported(ConformanceDecl.ID(s)!)
     case ExtensionDecl.self:
       return isExported(ExtensionDecl.ID(s)!)
+    case MethodDecl.self:
+      return isExportingDecls(nodeToScope[s]!)
     case ModuleDecl.self:
       return true
     case NamespaceDecl.self:
       return isExported(NamespaceDecl.ID(s)!)
     case ProductTypeDecl.self:
       return isExported(ProductTypeDecl.ID(s)!)
+    case SubscriptDecl.self:
+      return isExportingDecls(nodeToScope[s]!)
     case TraitDecl.self:
       return isExported(TraitDecl.ID(s)!)
     case TypeAliasDecl.self:

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -280,10 +280,13 @@ public struct Module {
       (program[d].type.base as! CallableType).output, in: program[d].scope)
     let inputs = loweredParameters(of: d)
 
+    // External functions have external linkage at the IR level.
+    let linkage: Linkage = (program.isExported(d) || program[d].isExternal) ? .external : .module
+
     let entity = Function(
       isSubscript: false,
       site: program.ast[d].site,
-      linkage: program.isExported(d) ? .external : .module,
+      linkage: linkage,
       genericParameters: Array(parameters),
       inputs: inputs,
       output: output,


### PR DESCRIPTION
LLVM can more aggressively optimize functions lowered with the Hylo passing convention if it knows they are private to a particular module.