### PR TITLE
Check the visibility of trait requirement implementations

### DIFF
--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -530,6 +530,59 @@ public struct AST {
     }
   }
 
+  /// Returns a site suitable to emit diagnostics related to `d` as a whole.
+  public func siteForDiagnostics<T: DeclID>(about d: T) -> SourceRange {
+    .empty(at: (introducerSite(of: d) ?? self[d].site).start)
+  }
+
+  /// Returns the site from which the introducer of `d` was parsed, if any.
+  public func introducerSite<T: DeclID>(of d: T) -> SourceRange? {
+    switch d.kind {
+    case AssociatedTypeDecl.self:
+      return self[AssociatedTypeDecl.ID(d)!].introducerSite
+    case AssociatedValueDecl.self:
+      return self[AssociatedValueDecl.ID(d)!].introducerSite
+    case BindingDecl.self:
+      return self[self[BindingDecl.ID(d)!].pattern].introducer.site
+    case ConformanceDecl.self:
+      return self[ConformanceDecl.ID(d)!].introducerSite
+    case ExtensionDecl.self:
+      return self[ExtensionDecl.ID(d)!].introducerSite
+    case FunctionDecl.self:
+      return self[FunctionDecl.ID(d)!].introducerSite
+    case GenericParameterDecl.self:
+      return nil
+    case ImportDecl.self:
+      return self[ImportDecl.ID(d)!].introducerSite
+    case InitializerDecl.self:
+      return self[InitializerDecl.ID(d)!].introducer.site
+    case MethodDecl.self:
+      return self[MethodDecl.ID(d)!].introducerSite
+    case MethodImpl.self:
+      return self[MethodImpl.ID(d)!].introducer.site
+    case ModuleDecl.self:
+      return nil
+    case NamespaceDecl.self:
+      return self[NamespaceDecl.ID(d)!].introducerSite
+    case OperatorDecl.self:
+      return self[OperatorDecl.ID(d)!].introducerSite
+    case ParameterDecl.self:
+      return nil
+    case ProductTypeDecl.self:
+      return self[ProductTypeDecl.ID(d)!].introducerSite
+    case SubscriptDecl.self:
+      return self[SubscriptDecl.ID(d)!].introducer.site
+    case SubscriptImpl.self:
+      return self[SubscriptImpl.ID(d)!].introducer.site
+    case TraitDecl.self:
+      return self[TraitDecl.ID(d)!].introducerSite
+    case TypeAliasDecl.self:
+      return self[TypeAliasDecl.ID(d)!].introducerSite
+    default:
+      return nil
+    }
+  }
+
 }
 
 extension AST: Codable {

--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -280,6 +280,12 @@ extension Program {
     }
   }
 
+  /// Returns `true` iff `d` has the appropriate visibility when used as the implementation of a
+  /// trait requirement.
+  public func isAccessibleAsRequirementImplementation<T: DeclID>(_ d: T) -> Bool {
+    (d.kind == GenericParameterDecl.self) || isPublic(d) || isRequirement(d)
+  }
+
   /// Returns `true` iff `d` is visible outside of its module.
   ///
   /// - Note: modules are considered exported.

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -190,6 +190,12 @@ extension Diagnostic {
     return .note("trait '\(x)' requires associated type '\(n)'", at: site)
   }
 
+  static func note(implementationMustBePublic d: AnyDeclID, in ast: AST) -> Diagnostic {
+    .note(
+      "implementation of trait requirement must be public",
+      at: ast.siteForDiagnostics(about: d))
+  }
+
   static func error(undefinedOperator name: String, at site: SourceRange) -> Diagnostic {
     .error("undefined operator '\(name)'", at: site)
   }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1495,8 +1495,8 @@ struct TypeChecker {
     /// A map from requirement to its implementation.
     var implementations = Conformance.ImplementationMap()
 
-    /// The diagnostics of the errors found during conformance checking.
-    var conformanceDiagnostics = DiagnosticSet()
+    /// The detailed diagnostics describing why the checked conformance does not hold.
+    var nonConformanceNotes = DiagnosticSet()
 
     /// A map associating the "Self" parameter of each trait to which `model` conforms to `model`.
     var traitReceiverToModel = GenericArguments()
@@ -1508,10 +1508,10 @@ struct TypeChecker {
       resolveImplementation(of: r)
     }
 
-    if !conformanceDiagnostics.isEmpty || !checkRequirementConstraints() {
+    if !nonConformanceNotes.isEmpty || !checkRequirementConstraints() {
       // Use `extendedModel(_:)` to get `model` as it was declared in program sources.
       let m = extendedModel(origin.source)
-      report(.error(m, doesNotConformTo: trait, at: origin.site, because: conformanceDiagnostics))
+      report(.error(m, doesNotConformTo: trait, at: origin.site, because: nonConformanceNotes))
       return
     }
 
@@ -1575,7 +1575,7 @@ struct TypeChecker {
       guard let d = implementation(of: requirement) else {
         let n = Diagnostic.note(
           trait: trait, requiresAssociatedType: program[requirement].baseName, at: origin.site)
-        conformanceDiagnostics.insert(n)
+        nonConformanceNotes.insert(n)
         return
       }
       implementations[requirement] = .concrete(d)
@@ -1605,7 +1605,7 @@ struct TypeChecker {
           trait: trait, requires: requirement.kind,
           named: expectedAPI.name, typed: t,
           at: origin.site)
-        conformanceDiagnostics.insert(n)
+        nonConformanceNotes.insert(n)
       }
     }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/Conformance.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Conformance.hylo
@@ -9,9 +9,9 @@ trait Q {}
 
 type A0: P, Q {
 
-  fun f() {}
+  public fun f() {}
 
-  fun g() {
+  public fun g() {
     let  {}
     sink {}
   }
@@ -45,8 +45,9 @@ trait S {
 
 type B: R, S {
   memberwise init
-  fun f() -> B { B() }
-  fun g() {
+
+  public fun f() -> B { B() }
+  public fun g() {
     let  {}
     sink {}
   }
@@ -58,7 +59,7 @@ trait T {
 }
 
 type C1: T {
-  init(x: Int) {}
+  public init(x: Int) {}
 }
 
 //! @+1 diagnostic type 'C2' does not conform to trait 'T'

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithAssociatedType.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithAssociatedType.hylo
@@ -6,5 +6,5 @@ trait P {
 }
 
 type B<X>: P {
-  fun f(_ x: X) {}
+  public fun f(_ x: X) {}
 }

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithPrivateImpl.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithPrivateImpl.hylo
@@ -1,0 +1,28 @@
+//- typeCheck expecting: failure
+
+// Implementations of the requirements of a trait `P` in a type `A` must be exposed to the same
+// scopes as the conformance `A : P`.
+
+public trait P {
+  type X
+  fun f(_ n: Int) -> Bool
+}
+
+type A<X>: Deinitializable, P {
+  public memberwise init
+  public fun f(_ n: Int) -> Bool { n < 0 }
+}
+
+//! @+1 diagnostic type 'B' does not conform to trait 'P'
+type B: Deinitializable, P {
+  public memberwise init
+  public typealias X = Int
+  fun f(_ n: Int) -> Bool { n < 0 }
+}
+
+//! @+1 diagnostic type 'C' does not conform to trait 'P'
+type C: Deinitializable, P {
+  public memberwise init
+  typealias X = Int
+  public fun f(_ n: Int) -> Bool { n < 0 }
+}

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithSubscript.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithSubscript.hylo
@@ -6,6 +6,6 @@ trait P {
 }
 
 type B: P {
-  typealias X = Bool
-  subscript(_ i: Int): Bool { true }
+  public typealias X = Bool
+  public subscript(_ i: Int): Bool { true }
 }

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupViaTraitExtension.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupViaTraitExtension.hylo
@@ -9,7 +9,7 @@ extension P {
 conformance Int: P {}
 
 conformance Bool: P {
-  fun foo() {}
+  public fun foo() {}
 }
 
 public fun main() {

--- a/Tests/LibraryTests/TestCases/StrideableTests.hylo
+++ b/Tests/LibraryTests/TestCases/StrideableTests.hylo
@@ -8,11 +8,11 @@ public type A: Deinitializable, Strideable {
 
   public typealias Stride = Int
 
-  fun offset(to other: Self) -> Stride {
+  public fun offset(to other: Self) -> Stride {
     other.n - self.n
   }
 
-  fun advance(by offset: Stride) -> Self {
+  public fun advance(by offset: Stride) -> Self {
     A(n: n + offset)
   }
 


### PR DESCRIPTION
Implementations of the requirements of a trait `P` in a type `A` must be exposed to the same scopes as the conformance `A : P`.