### PR TITLE
Concurrency with mutation example

### DIFF
--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -45,34 +45,34 @@ public type Future<E: Movable & Deinitializable> {
 
 }
 
-/// Describes the frame needed to spawn a computation. Mimics the C implementation.
+/// Describes the frame needed to spawn a computation.
+///
+/// Needs to have the same size and the same alignment as the C implementation.
+/// That is, 10 pointers, with the alignment of a pointer.
 public type SpawnFrameBase: Deinitializable, Movable {
 
-  let task_function: MemoryAddress
-
-  let next_task: MemoryAddress
-
-  let sync_state: Int32
-
-  let originator_context: MemoryAddress
-
-  let originator_thread_reclaimer: MemoryAddress
-
-  let target_context: MemoryAddress
-
-  let target_thread_reclaimer: MemoryAddress
-
-  let user_function: MemoryAddress
+  let p1: MemoryAddress
+  let p2: MemoryAddress
+  let p3: MemoryAddress
+  let p4: MemoryAddress
+  let p5: MemoryAddress
+  let p6: MemoryAddress
+  let p7: MemoryAddress
+  let p8: MemoryAddress
+  let p9: MemoryAddress
+  let p10: MemoryAddress
 
   public init() {
-    &self.task_function = .null()
-    &self.next_task = .null()
-    &self.sync_state = 0
-    &self.originator_context = .null()
-    &self.originator_thread_reclaimer = .null()
-    &self.target_context = .null()
-    &self.target_thread_reclaimer = .null()
-    &self.user_function = .null()
+    &self.p1 = .null()
+    &self.p2 = .null()
+    &self.p3 = .null()
+    &self.p4 = .null()
+    &self.p5 = .null()
+    &self.p6 = .null()
+    &self.p7 = .null()
+    &self.p8 = .null()
+    &self.p9 = .null()
+    &self.p10 = .null()
   }
 
 }

--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -46,7 +46,7 @@ public type Future<E: Movable & Deinitializable> {
 }
 
 /// Describes the frame needed to spawn a computation. Mimics the C implementation.
-type SpawnFrameBase: Deinitializable, Movable {
+public type SpawnFrameBase: Deinitializable, Movable {
 
   let task_function: MemoryAddress
 

--- a/Tests/EndToEndTests/TestCases/Concurrency/mutating_spawn.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/mutating_spawn.hylo
@@ -1,0 +1,23 @@
+//- compileToLLVM expecting: success
+
+
+fun test_mutating_spawn() -> Int {
+  var local_variable = 0
+  let p = mutable_pointer[to: &local_variable]
+
+  var future = spawn_(fun[sink let q=p.copy()] () -> Int {
+    &(q.unsafe[]) = 19
+    return 1
+  })
+  let y = future.await()
+  return y + local_variable // 20
+}
+
+public fun main() {
+  print("Starting...")
+  print(test_mutating_spawn())
+  print("Finishing...")
+}
+
+// Compile this with:
+// > hc conc.hylo -l concore2full -l context_core_api -l boost_context -l c++ -L <path-to-concore2full> -L <path-to-boost>

--- a/Tests/EndToEndTests/TestCases/Concurrency/mutating_spawn.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/mutating_spawn.hylo
@@ -6,7 +6,7 @@ fun test_mutating_spawn() -> Int {
   let p = mutable_pointer[to: &local_variable]
 
   var future = spawn_(fun[sink let q=p.copy()] () -> Int {
-    &(q.unsafe[]) = 19
+    &(q.copy().unsafe[]) = 19
     return 1
   })
   let y = future.await()


### PR DESCRIPTION
Add example/test for concurrency with mutation.

Make the spawn functionality work with the newest version of `concore2full` library.