### PR TITLE
Add && and || operators to compile-time compilation conditions (#1358)

### DIFF
--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -55,7 +55,8 @@ public struct LLVMProgram {
   /// to `directory`, returning the URL of each written file.
   ///
   /// - Returns: The URL of each written product, one for each module in `self`.
-  public func write(_ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL) throws -> [URL] {
+  public func write(_ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL) throws -> [URL]
+  {
     precondition(directory.hasDirectoryPath)
     var result: [URL] = []
     for m in llvmModules.values {

--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -55,8 +55,9 @@ public struct LLVMProgram {
   /// to `directory`, returning the URL of each written file.
   ///
   /// - Returns: The URL of each written product, one for each module in `self`.
-  public func write(_ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL) throws -> [URL]
-  {
+  public func write(
+    _ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL
+  ) throws -> [URL] {
     precondition(directory.hasDirectoryPath)
     var result: [URL] = []
     for m in llvmModules.values {

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -322,7 +322,8 @@ extension SwiftyLLVM.Module {
     if !implementations.isEmpty {
       tableContents.append(
         SwiftyLLVM.ArrayConstant(
-          of: SwiftyLLVM.StructType([word(), ptr], in: &self), containing: implementations, in: &self))
+          of: SwiftyLLVM.StructType([word(), ptr], in: &self), containing: implementations,
+          in: &self))
     }
 
     let table = SwiftyLLVM.StructConstant(aggregating: tableContents, in: &self)
@@ -901,42 +902,48 @@ extension SwiftyLLVM.Module {
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.sadd.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .unsignedAdditionWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.uadd.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .signedSubtractionWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.ssub.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .unsignedSubtractionWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.usub.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .signedMultiplicationWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.smul.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .unsignedMultiplicationWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.umul.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .icmp(let p, _):
         let l = llvm(s.operands[0])
@@ -1020,7 +1027,8 @@ extension SwiftyLLVM.Module {
       case .ctpop(let t):
         let source = llvm(s.operands[0])
         let f = intrinsic(named: Intrinsic.llvm.ctpop, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [source], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [source], at: insertionPoint)
 
       case .ctlz(let t):
         let source = llvm(s.operands[0])

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -82,9 +82,9 @@ extension IR.Program {
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module)
-    -> SwiftyLLVM.IRType
-  {
+  func llvm(
+    boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module
+  ) -> SwiftyLLVM.IRType {
     precondition(val[.isCanonical])
 
     let fields = base.storage(of: val.base).map { (part) in

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -82,7 +82,9 @@ extension IR.Program {
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
+  func llvm(boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module)
+    -> SwiftyLLVM.IRType
+  {
     precondition(val[.isCanonical])
 
     let fields = base.storage(of: val.base).map { (part) in

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -94,14 +94,14 @@ public struct ConditionalCompilationStmt: Stmt {
 
   }
 
-  /// A sequence of structured conditions to elaborate a 1 to N operand compilation condition
-  public indirect enum SequenceCondition: Codable {
+  /// Abstracts the whole condition structure and its sub-conditions.
+  public indirect enum ConditionTree: Codable {
 
     case operand(Condition)
 
-    case and(Condition, SequenceCondition)
+    case and(ConditionTree, ConditionTree)
 
-    case or(Condition, SequenceCondition)
+    case or(ConditionTree, ConditionTree)
 
     public enum ConditionKind: String {
       case holdOnly
@@ -109,36 +109,21 @@ public struct ConditionalCompilationStmt: Stmt {
       case skipElse
     }
 
-    /// Visit the SequenceCondition tail to calculate the right case for executing the right branch
+    /// Visit the SequenceCondition tail to calculate the right case for executing the right branch.
     private func unroll(
       for factors: ConditionalCompilationFactors, conditionCase: ConditionKind
     ) -> Bool {
       switch self {
-      case .and(let cond, let seq):
-        switch condCase {
-        case .holdOnly:
-          return cond.holds(for: factors) && seq.unroll(for: factors, condCase: condCase)
-        case .skipMain:
-          return cond.mayNotNeedParsing && !cond.holds(for: factors)
-            && seq.unroll(for: factors, condCase: condCase)
-        case .skipElse:
-          return cond.mayNotNeedParsing && cond.holds(for: factors)
-            && seq.unroll(for: factors, condCase: condCase)
-        }
+      case .and(let leftSubtree, let rightSubtree):
+        return leftSubtree.unroll(for: factors, conditionCase: conditionCase)
+          && rightSubtree.unroll(for: factors, conditionCase: conditionCase)
 
-      case .or(let cond, let seq):
-        switch condCase {
-        case .holdOnly:
-          return cond.holds(for: factors) || seq.unroll(for: factors, condCase: condCase)
-        case .skipMain:
-          return cond.mayNotNeedParsing
-            || !cond.holds(for: factors) && seq.unroll(for: factors, condCase: condCase)
-        case .skipElse:
-          return cond.mayNotNeedParsing && cond.holds(for: factors)
-            || seq.unroll(for: factors, condCase: condCase)
-        }
+      case .or(let leftSubtree, let rightSubtree):
+        return leftSubtree.unroll(for: factors, conditionCase: conditionCase)
+          || rightSubtree.unroll(for: factors, conditionCase: conditionCase)
+
       case .operand(let cond):
-        switch condCase {
+        switch conditionCase {
         case .holdOnly: return cond.holds(for: factors)
         case .skipMain: return cond.mayNotNeedParsing && !cond.holds(for: factors)
         case .skipElse: return cond.mayNotNeedParsing && cond.holds(for: factors)
@@ -146,23 +131,26 @@ public struct ConditionalCompilationStmt: Stmt {
       }
     }
 
+    /// Return `true` iff the the full condition is satisfied.
     public func mustSkipMainBranch(for factors: ConditionalCompilationFactors) -> Bool {
-      self.unroll(for: factors, condCase: ConditionKind.skipMain)
+      self.unroll(for: factors, conditionCase: ConditionKind.skipMain)
     }
 
+    /// Return `true` iff the the full condition is unsatisfied.
     public func mustSkipElseBranch(for factors: ConditionalCompilationFactors) -> Bool {
-      self.unroll(for: factors, condCase: ConditionKind.skipElse)
+      self.unroll(for: factors, conditionCase: ConditionKind.skipElse)
     }
 
-    public func allHolds(for factors: ConditionalCompilationFactors) -> Bool {
-      self.unroll(for: factors, condCase: ConditionKind.holdOnly)
+    /// Return `true` iff the the full condition is satisfied.
+    fileprivate func holds(for factors: ConditionalCompilationFactors) -> Bool {
+      self.unroll(for: factors, conditionCase: ConditionKind.holdOnly)
     }
   }
 
   public let site: SourceRange
 
   /// The condition.
-  public let condition: SequenceCondition
+  public let condition: ConditionTree
 
   /// The statements in the block.
   public let stmts: [AnyStmtID]
@@ -172,7 +160,7 @@ public struct ConditionalCompilationStmt: Stmt {
 
   /// Creates an instance with the given properties.
   public init(
-    condition: SequenceCondition, stmts: [AnyStmtID], fallback: [AnyStmtID], site: SourceRange
+    condition: ConditionTree, stmts: [AnyStmtID], fallback: [AnyStmtID], site: SourceRange
   ) {
     self.site = site
     self.condition = condition
@@ -182,7 +170,7 @@ public struct ConditionalCompilationStmt: Stmt {
 
   /// Returns the statements that this expands to.
   public func expansion(for factors: ConditionalCompilationFactors) -> [AnyStmtID] {
-    condition.allHolds(for: factors) ? stmts : fallback
+    condition.holds(for: factors) ? stmts : fallback
   }
 
 }

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -96,8 +96,11 @@ public struct ConditionalCompilationStmt: Stmt {
 
   /// A sequence of structured conditions to elaborate a 1 to N operand compilation condition
   public indirect enum SequenceCondition: Codable {
+
     case operand(Condition)
+
     case and(Condition, SequenceCondition)
+
     case or(Condition, SequenceCondition)
 
     public enum ConditionKind: String {

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -107,8 +107,9 @@ public struct ConditionalCompilationStmt: Stmt {
     }
 
     /// Visit the SequenceCondition tail to calculate the right case for executing the right branch
-    private func unroll(for factors: ConditionalCompilationFactors, condCase: ConditionKind) -> Bool
-    {
+    private func unroll(
+      for factors: ConditionalCompilationFactors, conditionCase: ConditionKind
+    ) -> Bool {
       switch self {
       case .and(let cond, let seq):
         switch condCase {

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -106,9 +106,13 @@ public struct ConditionalCompilationStmt: Stmt {
     case or(ConditionTree, ConditionTree)
 
     public enum ConditionKind: String {
+
       case holdOnly
+
       case skipMain
+
       case skipElse
+
     }
 
     /// Visit the SequenceCondition tail to calculate the right case for executing the right branch.

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -143,7 +143,7 @@ public struct ConditionalCompilationStmt: Stmt {
       self.unroll(for: factors, conditionCase: ConditionKind.skipMain)
     }
 
-    /// Return `true` iff the the full condition is unsatisfied.
+    /// Returns `true` iff the condition is not unsatisfied.
     public func mustSkipElseBranch(for factors: ConditionalCompilationFactors) -> Bool {
       self.unroll(for: factors, conditionCase: ConditionKind.skipElse)
     }

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -94,7 +94,7 @@ public struct ConditionalCompilationStmt: Stmt {
 
   }
 
-  /// Abstracts the whole condition structure and its sub-conditions.
+  /// A condition in a conditional compilation statement expressed as a composition of predicates.
   public indirect enum ConditionTree: Codable {
 
     case operand(Condition)

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -148,7 +148,7 @@ public struct ConditionalCompilationStmt: Stmt {
       self.unroll(for: factors, conditionCase: ConditionKind.skipElse)
     }
 
-    /// Return `true` iff the the full condition is satisfied.
+    /// Returns `true` iff the the condition is satisfied.
     fileprivate func holds(for factors: ConditionalCompilationFactors) -> Bool {
       self.unroll(for: factors, conditionCase: ConditionKind.holdOnly)
     }

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -102,6 +102,7 @@ public struct ConditionalCompilationStmt: Stmt {
     /// A conjunction of conditions.
     case and(ConditionTree, ConditionTree)
 
+    /// A disjunction of conditions.
     case or(ConditionTree, ConditionTree)
 
     public enum ConditionKind: String {

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -125,6 +125,7 @@ public struct ConditionalCompilationStmt: Stmt {
           return cond.mayNotNeedParsing && cond.holds(for: factors)
             && seq.unroll(for: factors, condCase: condCase)
         }
+
       case .or(let cond, let seq):
         switch condCase {
         case .holdOnly:

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -138,7 +138,7 @@ public struct ConditionalCompilationStmt: Stmt {
       }
     }
 
-    /// Return `true` iff the the full condition is satisfied.
+    /// Returns `true` iff the condition is satisfied.
     public func mustSkipMainBranch(for factors: ConditionalCompilationFactors) -> Bool {
       self.unroll(for: factors, conditionCase: ConditionKind.skipMain)
     }

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -97,6 +97,7 @@ public struct ConditionalCompilationStmt: Stmt {
   /// A condition in a conditional compilation statement expressed as a composition of predicates.
   public indirect enum ConditionTree: Codable {
 
+    /// A proposition or the negation of a proposition.
     case operand(Condition)
 
     /// A conjunction of conditions.

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -116,7 +116,7 @@ public struct ConditionalCompilationStmt: Stmt {
 
     }
 
-    /// Visit the SequenceCondition tail to calculate the right case for executing the right branch.
+    /// Visits the SequenceCondition tail to calculate the right case for executing the right branch.
     private func unroll(
       for factors: ConditionalCompilationFactors, conditionCase: ConditionKind
     ) -> Bool {

--- a/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/Core/AST/Stmt/ConditionalCompilationStmt.swift
@@ -99,6 +99,7 @@ public struct ConditionalCompilationStmt: Stmt {
 
     case operand(Condition)
 
+    /// A conjunction of conditions.
     case and(ConditionTree, ConditionTree)
 
     case or(ConditionTree, ConditionTree)

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -335,8 +335,9 @@ private func mathFlags(_ stream: inout ArraySlice<Substring>) -> NativeInstructi
 }
 
 /// Returns an overflow behavior parsed from `stream` or `.ignore` if none can be parsed.
-private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> SwiftyLLVM.OverflowBehavior
-{
+private func overflowBehavior(
+  _ stream: inout ArraySlice<Substring>
+) -> SwiftyLLVM.OverflowBehavior {
   switch stream.first {
   case "nuw":
     stream.removeFirst()

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -335,7 +335,8 @@ private func mathFlags(_ stream: inout ArraySlice<Substring>) -> NativeInstructi
 }
 
 /// Returns an overflow behavior parsed from `stream` or `.ignore` if none can be parsed.
-private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> SwiftyLLVM.OverflowBehavior {
+private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> SwiftyLLVM.OverflowBehavior
+{
   switch stream.first {
   case "nuw":
     stream.removeFirst()

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -4,8 +4,8 @@ import Core
 import Foundation
 import FrontEnd
 import IR
-import SwiftyLLVM
 import StandardLibrary
+import SwiftyLLVM
 import Utils
 
 public struct Driver: ParsableCommand {

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2998,7 +2998,7 @@ public enum Parser {
     in state: inout ParserState
   ) throws -> ConditionalCompilationStmt.ConditionTree {
 
-    /// Calculates operator's precedence.
+    /// Returns the precedence of `tokenValue`, which is a either `||` or `&&`.
     func precedence(_ tokenValue: String) -> Int {
       switch tokenValue {
       case "||": 0

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -3020,7 +3020,7 @@ public enum Parser {
   ) throws -> AnyStmtID {
     // Parse the condition.
 
-    let conditionSeq = try buildSequenceCondition(in: &state)
+    let conditions = try buildSequenceCondition(in: &state)
 
     // Parse the body of the compiler condition.
     let stmts: [AnyStmtID]

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2993,25 +2993,60 @@ public enum Parser {
     return head != nil ? try parseCompilerConditionTail(head: head!, in: &state) : nil
   }
 
-  /// Builds the sequence of compiler conditions for the present CompilerConditionTail
-  private static func buildSequenceCondition(
+  /// Parses a ConditionTree for a ConditionalCompilationStmt.
+  private static func parseConditionTree(
     in state: inout ParserState
-  ) throws -> ConditionalCompilationStmt.SequenceCondition {
-    let condition = try parseCompilerCondition(in: &state)
-    let backup = state.backup()
+  ) throws -> ConditionalCompilationStmt.ConditionTree {
 
-    // Look for the next `&&` or `||` operator if exists.
-    guard let firstOperHalf = state.take(), ["||", "&&"].contains(state.token(firstOperHalf).value)
-    else {
-      state.restore(from: backup)
-      return .operand(condition)
+    /// Calculates operator's precedence.
+    func precedence(_ tokenValue: String) -> Int {
+      switch tokenValue {
+      case "||": 0
+      case "&&": 1
+      default: -1
+      }
     }
 
-    if state.token(firstOperHalf).value == "&&" {
-      return .and(condition, try buildSequenceCondition(in: &state))
-    } else {
-      return .or(condition, try buildSequenceCondition(in: &state))
+    /// Parses the tree using Precedence Climbing method.
+    func parseTree(
+      lhs: ConditionalCompilationStmt.ConditionTree,
+      minOpPrecedence: Int = 0,
+      in state: inout ParserState
+    ) throws -> ConditionalCompilationStmt.ConditionTree {
+      var lhs = lhs
+      var backup = state.backup()
+      while let op = state.take() {
+        let tokenValue = state.token(op).value
+        let opPrecedence = precedence(tokenValue)
+        guard opPrecedence >= 0 else {
+          /// Token is not a valid operator, but #elseif #else #endif or a wrong token instead.
+          state.restore(from: backup)
+          break
+        }
+
+        if opPrecedence < minOpPrecedence {
+          break
+        }
+
+        var rhs: ConditionalCompilationStmt.ConditionTree = .operand(
+          try parseCompilerCondition(in: &state))
+
+        backup = state.backup()
+        while let nextOp = state.peek() {
+          /// Check the precedence of an higher predence for left associative op. A right associative op like `==` cannot occur.
+          if precedence(state.token(nextOp).value) <= opPrecedence {
+            state.restore(from: backup)
+            break
+          }
+          rhs = try parseTree(lhs: rhs, minOpPrecedence: opPrecedence + 1, in: &state)
+        }
+
+        lhs = tokenValue == "&&" ? .and(lhs, rhs) : .or(lhs, rhs)
+      }
+      return lhs
     }
+
+    return try parseTree(lhs: .operand(try parseCompilerCondition(in: &state)), in: &state)
   }
 
   /// Parses a compiler condition structure, after the initial token (#if or #elseif).
@@ -3020,11 +3055,11 @@ public enum Parser {
   ) throws -> AnyStmtID {
     // Parse the condition.
 
-    let conditions = try buildSequenceCondition(in: &state)
+    let conditions = try parseConditionTree(in: &state)
 
     // Parse the body of the compiler condition.
     let stmts: [AnyStmtID]
-    if conditionSeq.mustSkipMainBranch(for: state.ast.compilationConditions) {
+    if conditions.mustSkipMainBranch(for: state.ast.compilationConditions) {
       try skipConditionalCompilationBranch(in: &state, stoppingAtElse: true)
       stmts = []
     } else {
@@ -3036,7 +3071,7 @@ public enum Parser {
     if state.take(.poundEndif) != nil {
       fallback = []
     } else if state.take(.poundElse) != nil {
-      if conditionSeq.mustSkipElseBranch(for: state.ast.compilationConditions) {
+      if conditions.mustSkipElseBranch(for: state.ast.compilationConditions) {
         try skipConditionalCompilationBranch(in: &state, stoppingAtElse: false)
         fallback = []
       } else {
@@ -3045,7 +3080,7 @@ public enum Parser {
       // Expect #endif.
       _ = try state.expect("'#endif'", using: { $0.take(.poundEndif) })
     } else if let head2 = state.take(.poundElseif) {
-      if conditionSeq.mustSkipElseBranch(for: state.ast.compilationConditions) {
+      if conditions.mustSkipElseBranch(for: state.ast.compilationConditions) {
         try skipConditionalCompilationBranch(in: &state, stoppingAtElse: false)
         fallback = []
       } else {
@@ -3059,7 +3094,7 @@ public enum Parser {
 
     let r = state.insert(
       ConditionalCompilationStmt(
-        condition: conditionSeq,
+        condition: conditions,
         stmts: stmts,
         fallback: fallback,
         site: head.site.extended(upTo: state.currentIndex)))

--- a/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
+++ b/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
@@ -32,13 +32,13 @@ struct GenerateHyloFileTests: ParsableCommand {
     return parsed.reduce(into: "") { (o, p) in
       o += """
 
-        func test_\(p.methodName)_\(testID)() throws {
-          try \(p.methodName)(
-            \(String(reflecting: source.fileSystemPath)),
-            expectSuccess: \(p.expectSuccess))
-        }
+          func test_\(p.methodName)_\(testID)() throws {
+            try \(p.methodName)(
+              \(String(reflecting: source.fileSystemPath)),
+              expectSuccess: \(p.expectSuccess))
+          }
 
-      """
+        """
     }
   }
 
@@ -123,7 +123,7 @@ extension StringProtocol where Self.SubSequence == Substring {
 }
 
 /// Information necessary to generate a test case.
-fileprivate struct TestDescription {
+private struct TestDescription {
 
   /// The name of the method implementing the logic of the test runner.
   let methodName: Substring

--- a/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
+++ b/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
@@ -170,16 +170,20 @@ fun testNot() {
 }
 
 fun testMultipleOperandConditions() {
-  #if arch(arm64) && false
-    let a = 1
+  #if os(windows)
+    <something that would not be parsed>
+  #elseif !arch(arm64) && !true
+    <something that would not be parsed>
+  #elseif arch(arm64) && false || !true || false
+    <something that would not be parsed>
   #elseif os(windows) || os(linux)
-    let b = 2
-  #elseif arch(x86_64) || arch(arm64) && !false
-    let c = 3
+    <something that would not be parsed>
+  #elseif arch(x86_64) || arch(arm64) && true || false
+    let message = "arm64 or x86_64"
   #else
-    let d = 4
+    <something that would not be parsed>
   #endif
-  use(c)
+  use(message)
 }
 
 public fun main() {

--- a/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
+++ b/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
@@ -169,6 +169,19 @@ fun testNot() {
   use(b)
 }
 
+fun testMultipleOperandConditions() {
+  #if arch(arm64) && false
+    let a = 1
+  #elseif os(windows) || os(linux)
+    let b = 2
+  #elseif arch(x86_64) || arch(arm64) && !false
+    let c = 3
+  #else
+    let d = 4
+  #endif
+  use(c)
+}
+
 public fun main() {
   testTrue()
   testFalse()
@@ -180,4 +193,5 @@ public fun main() {
   testHyloVersion()
   testSkipParsingNested()
   testNot()
+  testMultipleOperandConditions()
 }

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1695,7 +1695,11 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if os(macOs) foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .operatingSystem("macOs"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("macOs"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)
   }
@@ -1704,7 +1708,11 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if true foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .`true`)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .`true`)
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
   }
@@ -1713,7 +1721,11 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if false awgr() #else foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .`false`)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .`false`)
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
   }
@@ -1723,15 +1735,27 @@ final class ParserTests: XCTestCase {
       "#if os(macOs) foo() #elseif os(Linux) bar() #elseif os(Windows) bazz() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .operatingSystem("macOs"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("macOs"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt2.condition, .operatingSystem("Linux"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("Linux"))
     XCTAssertEqual(stmt2.stmts.count, 1)
     XCTAssertEqual(stmt2.fallback.count, 1)
     let stmt3 = try XCTUnwrap(ast[stmt2.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt3.condition, .operatingSystem("Windows"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("Windows"))
     XCTAssertEqual(stmt3.stmts.count, 1)
     XCTAssertEqual(stmt3.fallback.count, 1)
   }
@@ -1741,19 +1765,35 @@ final class ParserTests: XCTestCase {
       "#if arch(x86_64) foo() #elseif arch(i386) bar() #elseif arch(arm64) bazz() #elseif arch(arm) fizz() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .architecture("x86_64"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .architecture("x86_64"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt2.condition, .architecture("i386"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .architecture("i386"))
     XCTAssertEqual(stmt2.stmts.count, 1)
     XCTAssertEqual(stmt2.fallback.count, 1)
     let stmt3 = try XCTUnwrap(ast[stmt2.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt3.condition, .architecture("arm64"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .architecture("arm64"))
     XCTAssertEqual(stmt3.stmts.count, 1)
     XCTAssertEqual(stmt3.fallback.count, 1)
     let stmt4 = try XCTUnwrap(ast[stmt3.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt4.condition, .architecture("arm"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .architecture("arm"))
     XCTAssertEqual(stmt4.stmts.count, 1)
     XCTAssertEqual(stmt4.fallback.count, 1)
   }
@@ -1763,7 +1803,11 @@ final class ParserTests: XCTestCase {
       "#if feature(useLibC) foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .feature("useLibC"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .feature("useLibC"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)
   }
@@ -1772,7 +1816,11 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler(hc) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .compiler("hc"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .compiler("hc"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)  // Body not parsed
   }
@@ -1781,8 +1829,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler_version(>= 0.1) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .compilerVersion(
         comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1793,8 +1845,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler_version(< 100.1.2) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .compilerVersion(
         comparison: .less(SemanticVersion(major: 100, minor: 1, patch: 2))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1805,8 +1861,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(>= 0.1) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)  // Body not parsed
@@ -1816,8 +1876,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(< 100.1.2) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(
         comparison: .less(SemanticVersion(major: 100, minor: 1, patch: 2))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1838,8 +1902,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(< 0.1) <don't show parse error here> #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1850,8 +1918,12 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(< 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1862,13 +1934,21 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(< 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #elseif os(bla) #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 1)
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt2.condition, .operatingSystem("bla"))
+    guard case .operand(let condition) = stmt2.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("bla"))
     XCTAssertEqual(stmt2.stmts.count, 0)
     XCTAssertEqual(stmt2.fallback.count, 0)
   }
@@ -1878,8 +1958,12 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(>= 0.1) #else <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1890,8 +1974,12 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(>= 0.1) #elseif compiler_version(>= 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)
     XCTAssertEqual(stmt.fallback.count, 0)


### PR DESCRIPTION
This commit allow the use of something like this:
```
public fun main() {
    #if arch(arm64) && false
        print("False for sure!")
    #elseif os(windows) || os(linux)
        print("Win or linux")
    #elseif arch(x86_64) || arch(arm64) && !false
        let message = "Arm64 or x86_64 (multiple operators condition)"
    #else
        print("unreachable")
    #endif
    print(message)
}
```