### PR TITLE
Concurrent sort example.

### DIFF
--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -46,23 +46,6 @@ public type EscapingFuture<E: Movable & Deinitializable>: Movable {
 
 }
 
-/// Mimics a future, but runs the computation inplace. Used for testing purposes.
-public type InplaceFuture<E: Movable & Deinitializable> {
-
-  /// The result of the computation.
-  let r: Int
-
-  /// Initializes `self` with `f`, and spawns the computation.
-  public init(_ f: sink [E]() -> Int) {
-    &self.r = f()
-  }
-
-  /// Awaits the result of the computation.
-  public fun await() sink -> Int {
-    return self.r
-  }
-
-}
 /// Describes the frame needed to spawn a computation.
 ///
 /// This object will be shared between the spawned computation (e.g., as it will store the result

--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -46,6 +46,23 @@ public type EscapingFuture<E: Movable & Deinitializable>: Movable {
 
 }
 
+/// Mimics a future, but runs the computation inplace. Used for testing purposes.
+public type InplaceFuture<E: Movable & Deinitializable> {
+
+  /// The result of the computation.
+  let r: Int
+
+  /// Initializes `self` with `f`, and spawns the computation.
+  public init(_ f: sink [E]() -> Int) {
+    &self.r = f()
+  }
+
+  /// Awaits the result of the computation.
+  public fun await() sink -> Int {
+    return self.r
+  }
+
+}
 /// Describes the frame needed to spawn a computation.
 ///
 /// This object will be shared between the spawned computation (e.g., as it will store the result

--- a/StandardLibrary/Sources/Concurrency/Spawn.hylo
+++ b/StandardLibrary/Sources/Concurrency/Spawn.hylo
@@ -6,6 +6,14 @@ public fun spawn_<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> Futur
   Future<E>(f)
 }
 
+/// Spawns a computation and returns a future that can be used to await its completion.
+///
+/// The future can escape the current scope.
 public fun escaping_spawn_<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> EscapingFuture<E> {
   EscapingFuture<E>(f)
+}
+
+/// Mimics `spawn_` but runs the computation inplace. For testing purposes.
+public fun spawn_inplace<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> InplaceFuture<E> {
+  InplaceFuture<E>(f)
 }

--- a/StandardLibrary/Sources/Concurrency/Spawn.hylo
+++ b/StandardLibrary/Sources/Concurrency/Spawn.hylo
@@ -12,8 +12,3 @@ public fun spawn_<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> Futur
 public fun escaping_spawn_<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> EscapingFuture<E> {
   EscapingFuture<E>(f)
 }
-
-/// Mimics `spawn_` but runs the computation inplace. For testing purposes.
-public fun spawn_inplace<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> InplaceFuture<E> {
-  InplaceFuture<E>(f)
-}

--- a/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
@@ -1,0 +1,217 @@
+//- compileAndRun expecting: success
+
+let size_threshold = 16
+
+/// Sorts the elements in `a` concurrently.
+fun my_concurrent_sort<Element: Regular & Comparable>(_ a: inout ArraySlice<Element>) -> Int {
+  if a.count() < size_threshold {
+    // Use serial sort under a certain threshold.
+    a.sort()
+  } else {
+    // Partition the data, such as elements [0, mid) < [mid] <= [mid+1, n).
+    let (m1, m2) = sort_partition(&a)
+    inout (lhs, rhs) = &a.split(at: m1)
+    &rhs.drop_first(m2 - m1)
+
+    // Spawn work to sort the right-hand side.
+    let future = spawn_inplace(fun[sink let q=mutable_pointer[to: &rhs].copy()]() -> Int {
+      inout rhs = &(q.copy().unsafe[])
+      return my_concurrent_sort(&rhs)
+    })
+    // Execute the sorting on the left side, on the current thread.
+    let _ = my_concurrent_sort(&lhs)
+    let _ = future.await()
+  }
+  return a.count()
+}
+
+fun sort_partition<Element: Regular & Comparable>(_ a: inout ArraySlice<Element>) -> {Int, Int} {
+  let mid_value = median9(a)
+  return a.partition(on: mid_value)
+}
+/// Returns the median of 3 values.
+fun median3<Element: Regular & Comparable>(_ v1: Element, _ v2: Element, _ v3: Element) -> Element {
+  if v1 < v2 {
+    if v2 < v3 {
+      return v2.copy()
+    }
+    if v1 < v3 {
+      return v3.copy()
+    }
+    return v1.copy()
+  } else {
+    if v1 < v3 {
+      return v1.copy()
+    }
+    if v2 < v3 {
+      return v3.copy()
+    }
+    return v2.copy()
+  }
+}
+/// Returns a median of 9 values taken from the slice `a`.
+fun median9<Element: Regular & Comparable>(_ a: ArraySlice<Element>) -> Element {
+  let n = a.count()
+  precondition(n >= 8)
+  let stride = n / 8
+  let m1 = median3(a[0], a[stride], a[stride * 2])
+  let m2 = median3(a[stride * 3], a[stride * 4], a[stride * 5])
+  let m3 = median3(a[stride * 6], a[stride * 7], a[n - 1])
+  return median3(m1, m2, m3)
+}
+
+
+// TODO: this should be cleaned up and put in the standard library.
+type ArraySlice<Element: Regular & Comparable> : Deinitializable, Movable {
+
+  // TODO: utterly unsafe
+
+  /// The origin of the slice.
+  public var origin: PointerToMutable<Array<Element>>
+
+  /// The absolute index of the first element in the slice.
+  public let start_index: Int
+  /// The absolute index of the ending element in the slice.
+  public let end_index: Int
+
+  /// Initializes `self` with an empty array.
+  public init() {
+    &self.origin = PointerToMutable<Array<Element>>.null()
+    &self.start_index = 0
+    &self.end_index = 0
+  }
+
+  /// Initializes `self` to represent all the elements of `full_array`.
+  public init(full_array: inout Array<Element>) {
+    &self.origin = mutable_pointer[to: &full_array].copy()
+    &self.start_index = full_array.start_position()
+    &self.end_index = full_array.end_position()
+  }
+  /// Initializes `self` to represent elements [`start`, `end`) of `full_array`.
+  public init(source: Self, from start: Int, to end: Int) {
+    precondition(start >= 0 && start <= end && end <= source.count())
+    &self.origin = source.origin.copy()
+    &self.start_index = source.start_index + start
+    &self.end_index = source.start_index + end
+  }
+
+  /// Returns the number of elements in the slice.
+  public fun count() -> Int {
+    end_index - start_index
+  }
+
+  /// Sorts the elements in `self`.
+  public fun sort() {
+    // Use bubble sort for simplicity.
+    inout elements = origin.unsafe[]
+    do {
+      var swapped = false
+      var i = start_index.copy()
+      while i < end_index - 1 {
+        if elements[i] > elements[i + 1] {
+          &elements.swap_at(i, i + 1)
+          &swapped = true
+        }
+        i += 1
+      }
+    } while swapped
+  }
+
+  /// Split this slice in two parts, at `index`.
+  public fun split(at index: Int) -> {ArraySlice<Element>, ArraySlice<Element>} {
+    precondition(0 <= index && index <= count())
+    return (slice(from: 0, to: index), slice(from: index, to: count()))
+  }
+
+  /// Partitions the slice in 3 parts: one with elements lower than `mid_value`, one with elements equal to `mid_value` and one with elements greater than `mid_value`, returning the indices that separates these parts.
+  public fun partition(on mid_value: Element) -> {Int, Int} {
+    inout elements = origin.unsafe[]
+    // First pass to move elements smaller than mid_value to the left.
+    var i = start_index.copy()
+    var j = end_index.copy()
+    while true {
+      while i < j && elements[i] < mid_value { &i += 1 }
+      while i < j && elements[j - 1] >= mid_value { &j -= 1 }
+      if i >= j { break }
+      &elements.swap_at(i, j - 1)
+      &i += 1
+      &j -= 1
+    }
+    let m1 = i - start_index
+
+    // Second pass to move the elements equal to mid_value to the left.
+    &j = end_index.copy()
+    while true {
+      while i < j && elements[i] <= mid_value { &i += 1 }
+      while i < j && elements[j - 1] > mid_value { &j -= 1 }
+      if i >= j { break }
+      &elements.swap_at(i, j - 1)
+      &i += 1
+      &j -= 1
+    }
+    let m2 = i - start_index
+
+    return (m1, m2)
+  }
+
+  /// Returns a slice of `self` from `start` to `end` (relative indices).
+  public fun slice(from start: Int, to end: Int) -> Self {
+    precondition(0 <= start && start <= end && end <= count())
+    let r: Self = .new(full_array: &origin.unsafe[])
+    &r.start_index = start_index + start
+    &r.end_index = start_index + end
+    return r
+  }
+
+  /// Drop the first `n` elements from `self`.
+  public fun drop_first(_ n: Int) inout {
+    precondition(n <= count())
+    &start_index += n
+  }
+
+  /// Returns the element at `position` (relative index).
+  public subscript(_ position: Int): Element {
+    precondition(position < count())
+    let elements = origin.unsafe[]
+    yield elements[start_index + position].copy()
+  }
+
+}
+
+
+@ffi("rand")
+public fun rand() -> Int
+
+/// Generate an array of random integers.
+fun generate_random_array(size: Int) -> Array<Int> {
+  var r = Array<Int>()
+  r.reserve_capacity(size)
+  var i = 0
+  while i < size {
+    r.append(rand() % 100)
+    &i += 1
+  }
+  return r
+}
+
+/// Checks if `a` is sorted.
+fun is_sorted(_ a: Array<Int>) -> Bool {
+  var i = 0
+  while i < a.count() - 1 {
+    if a[i] > a[i + 1] {
+      return false
+    }
+    &i += 1
+  }
+  return true
+}
+
+public fun main() {
+  let size = 100
+  var a = generate_random_array(size: size)
+
+  var slice = ArraySlice<Int>(full_array: &a)
+  let _ = my_concurrent_sort(&slice)
+
+  precondition(is_sorted(a), "resulting array is not sorted")
+}

--- a/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
@@ -9,7 +9,7 @@ fun my_concurrent_sort<Element: Regular & Comparable>(_ a: inout ArraySlice<Elem
     a.sort()
   } else {
     // Partition the data, such as elements [0, mid) < [mid] <= [mid+1, n).
-    let (m1, m2) = sort_partition(&a)
+    let (m1, m2) = partition(&a)
     inout (lhs, rhs) = &a.split(at: m1)
     &rhs.drop_first(m2 - m1)
 
@@ -26,7 +26,7 @@ fun my_concurrent_sort<Element: Regular & Comparable>(_ a: inout ArraySlice<Elem
   return a.count()
 }
 
-fun sort_partition<Element: Regular & Comparable>(_ a: inout ArraySlice<Element>) -> {Int, Int} {
+fun partition<Element: Regular & Comparable>(_ a: inout ArraySlice<Element>) -> {Int, Int} {
   let mid_value = median9(a)
   return a.partition(on: mid_value)
 }
@@ -57,10 +57,33 @@ fun median9<Element: Regular & Comparable>(_ a: ArraySlice<Element>) -> Element 
   let n = a.count()
   precondition(n >= 8)
   let stride = n / 8
-  let m1 = median3(a[0], a[stride], a[stride * 2])
-  let m2 = median3(a[stride * 3], a[stride * 4], a[stride * 5])
-  let m3 = median3(a[stride * 6], a[stride * 7], a[n - 1])
-  return median3(m1, m2, m3)
+  let m1 = median(a[0], a[stride], a[stride * 2])
+  let m2 = median(a[stride * 3], a[stride * 4], a[stride * 5])
+  let m3 = median(a[stride * 6], a[stride * 7], a[n - 1])
+  return median(m1, m2, m3)
+}
+
+/// Mimics a future, but runs the computation inplace. Used for testing purposes.
+public type InplaceFuture<E: Movable & Deinitializable> {
+
+  /// The result of the computation.
+  let r: Int
+
+  /// Initializes `self` with `f`, and spawns the computation.
+  public init(_ f: sink [E]() -> Int) {
+    &self.r = f()
+  }
+
+  /// Awaits the result of the computation.
+  public fun await() sink -> Int {
+    return self.r
+  }
+
+}
+
+/// Mimics `spawn_` but runs the computation inplace. For testing purposes.
+public fun spawn_inplace<E: Movable & Deinitializable>(_ f: sink [E]() -> Int) -> InplaceFuture<E> {
+  InplaceFuture<E>(f)
 }
 
 // TODO: this should be cleaned up and put in the standard library.

--- a/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
@@ -18,9 +18,10 @@ fun my_concurrent_sort<Element: Regular & Comparable>(_ a: inout ArraySlice<Elem
       inout rhs = &(q.copy().unsafe[])
       return my_concurrent_sort(&rhs)
     })
+
     // Execute the sorting on the left side, on the current thread.
-    let _ = my_concurrent_sort(&lhs)
-    let _ = future.await()
+    _ = my_concurrent_sort(&lhs)
+    _ = future.await()
   }
   return a.count()
 }
@@ -29,8 +30,9 @@ fun sort_partition<Element: Regular & Comparable>(_ a: inout ArraySlice<Element>
   let mid_value = median9(a)
   return a.partition(on: mid_value)
 }
+
 /// Returns the median of 3 values.
-fun median3<Element: Regular & Comparable>(_ v1: Element, _ v2: Element, _ v3: Element) -> Element {
+fun median<Element: Regular & Comparable>(_ v1: Element, _ v2: Element, _ v3: Element) -> Element {
   if v1 < v2 {
     if v2 < v3 {
       return v2.copy()
@@ -49,6 +51,7 @@ fun median3<Element: Regular & Comparable>(_ v1: Element, _ v2: Element, _ v3: E
     return v2.copy()
   }
 }
+
 /// Returns a median of 9 values taken from the slice `a`.
 fun median9<Element: Regular & Comparable>(_ a: ArraySlice<Element>) -> Element {
   let n = a.count()
@@ -59,7 +62,6 @@ fun median9<Element: Regular & Comparable>(_ a: ArraySlice<Element>) -> Element 
   let m3 = median3(a[stride * 6], a[stride * 7], a[n - 1])
   return median3(m1, m2, m3)
 }
-
 
 // TODO: this should be cleaned up and put in the standard library.
 type ArraySlice<Element: Regular & Comparable> : Deinitializable, Movable {


### PR DESCRIPTION
Using a mock for `spawn`/`await` so that the example runs without concurrent libraries.