### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,8 +2,8 @@ version: 1
 builder:
   configs:
   - platform: linux
-    swift_version: '5.9'
-    image: registry.gitlab.com/finestructure/spi-images:hylo-5.9-latest
+    swift_version: '5.10'
+    image: registry.gitlab.com/finestructure/spi-images:hylo-5.10-latest
     documentation_targets:
     - CLI
     - CodeGenLLVM
@@ -15,10 +15,18 @@ builder:
     - IR
     - TestUtils
     - Utils
-
     custom_documentation_parameters: [
     --include-extended-types, --enable-inherited-docs,
     --source-service, github,
     --source-service-base-url, https://github.com/hylo-lang/hylo/blob/main,
     --checkout-path, .
     ]
+  - platform: linux
+    swift_version: '5.9'
+    image: registry.gitlab.com/finestructure/spi-images:hylo-5.9-latest
+  - platform: linux
+    swift_version: '5.8'
+    image: registry.gitlab.com/finestructure/spi-images:hylo-5.8-latest
+  - platform: linux
+    swift_version: '5.7'
+    image: registry.gitlab.com/finestructure/spi-images:hylo-5.7-latest


### PR DESCRIPTION
I noticed we hadn't updated our Linux images with the name change from val → hylo and so the builds (including doc generation) were failing.

This should fix everything up and also move doc gen to be run with 5.10.