### PR TITLE
Add a concurrency example using a massive number of spawns

### DIFF
--- a/Tests/EndToEndTests/TestCases/Concurrency/skynet_bulk.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/skynet_bulk.hylo
@@ -7,7 +7,7 @@ fun skynet(num: Int, size: Int, div: Int) -> Int {
     var results = Array<Int>(count: div, initialized_with: fun (_ i: Int) { 0 })
     let sub_size = size / div
     let p = mutable_pointer[to: &results]
-    spawn_(count: div, action: fun[sink let q=p.copy(), sink let n = num.copy(), sink let s = sub_size.copy(), sink let d = div.copy()] (index: Int) -> Void {
+    spawn_(count: div, action: fun[sink let q = p.copy(), sink let n = num.copy(), sink let s = sub_size.copy(), sink let d = div.copy()] (index: Int) -> Void {
       inout results = q.copy().unsafe[]
       &results[index] = skynet(num: n + index * s, size: s, div: d)
     }).await()

--- a/Tests/EndToEndTests/TestCases/Concurrency/skynet_bulk.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/skynet_bulk.hylo
@@ -1,0 +1,32 @@
+//- compileToLLVM expecting: success
+
+fun skynet(num: Int, size: Int, div: Int) -> Int {
+  if size == 1 {
+    return num.copy()
+  } else {
+    var results = Array<Int>(count: div, initialized_with: fun (_ i: Int) { 0 })
+    let sub_size = size / div
+    let p = mutable_pointer[to: &results]
+    spawn_(count: div, action: fun[sink let q=p.copy(), sink let n = num.copy(), sink let s = sub_size.copy(), sink let d = div.copy()] (index: Int) -> Void {
+      inout results = q.copy().unsafe[]
+      &results[index] = skynet(num: n + index * s, size: s, div: d)
+    }).await()
+
+    return sum(results)
+  }
+}
+
+fun sum(_ array: Array<Int>) -> Int {
+  var result = 0
+  var i = 0
+  while i != array.count() {
+    &result += array[i]
+    &i += 1
+  }
+  return result
+}
+
+public fun main() {
+  let result = skynet(num: 0, size: 1_000_000, div: 10);
+  precondition(result == 499999500000, "invalid result")
+}

--- a/Tests/EndToEndTests/TestCases/Concurrency/skynet_bulk.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/skynet_bulk.hylo
@@ -26,7 +26,17 @@ fun sum(_ array: Array<Int>) -> Int {
   return result
 }
 
+@ffi("clock")
+public fun clock() -> Int
+
+fun time_in_ms(_ clock_diff: Int) -> Int {
+  return clock_diff / 10_000 // TODO: constant dependent on the platform
+}
+
 public fun main() {
+  let start = clock()
   let result = skynet(num: 0, size: 1_000_000, div: 10);
+  let end = clock()
+  print(time_in_ms(end - start), terminator: " ms\n")
   precondition(result == 499999500000, "invalid result")
 }

--- a/Tests/EndToEndTests/TestCases/Concurrency/skynet_strict.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/skynet_strict.hylo
@@ -51,7 +51,17 @@ fun skynet(num: Int, size: Int, div: Int) -> Int {
   }
 }
 
+@ffi("clock")
+public fun clock() -> Int
+
+fun time_in_ms(_ clock_diff: Int) -> Int {
+  return clock_diff / 10_000 // TODO: constant dependent on the platform
+}
+
 public fun main() {
+  let start = clock()
   let result = skynet(num: 0, size: 1_000_000, div: 10);
+  let end = clock()
+  print(time_in_ms(end - start), terminator: " ms\n")
   precondition(result == 499999500000, "invalid result")
 }

--- a/Tests/EndToEndTests/TestCases/Concurrency/skynet_strict.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/skynet_strict.hylo
@@ -1,0 +1,57 @@
+//- compileToLLVM expecting: success
+
+fun skynet(num: Int, size: Int, div: Int) -> Int {
+  if size == 1 {
+    return num.copy()
+  } else {
+    let sub_size = size / div
+    let f1 = spawn_(fun[sink let n = num.copy(), sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f2 = spawn_(fun[sink let n = num + sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f3 = spawn_(fun[sink let n = num + 2 * sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f4 = spawn_(fun[sink let n = num + 3 * sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f5 = spawn_(fun[sink let n = num + 4 * sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f6 = spawn_(fun[sink let n = num + 5 * sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f7 = spawn_(fun[sink let n = num + 6 * sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f8 = spawn_(fun[sink let n = num + 7 * sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f9 = spawn_(fun[sink let n = num + 8 * sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+    let f10 = spawn_(fun[sink let n = num + 9 * sub_size, sink let s = sub_size.copy(), sink let d = div.copy()] () {
+      skynet(num: n, size: s, div: d)
+    })
+
+    var sum = 0
+    sum += f1.await()
+    sum += f2.await()
+    sum += f3.await()
+    sum += f4.await()
+    sum += f5.await()
+    sum += f6.await()
+    sum += f7.await()
+    sum += f8.await()
+    sum += f9.await()
+    sum += f10.await()
+    return sum
+  }
+}
+
+public fun main() {
+  let result = skynet(num: 0, size: 1_000_000, div: 10);
+  precondition(result == 499999500000, "invalid result")
+}

--- a/Tests/EndToEndTests/TestCases/Concurrency/skynet_weak.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/skynet_weak.hylo
@@ -37,7 +37,17 @@ public conformance EscapingFuture: SemiRegular {
 
 }
 
+@ffi("clock")
+public fun clock() -> Int
+
+fun time_in_ms(_ clock_diff: Int) -> Int {
+  return clock_diff / 10_000 // TODO: constant dependent on the platform
+}
+
 public fun main() {
+  let start = clock()
   let result = skynet(num: 0, size: 1_000_000, div: 10);
+  let end = clock()
+  print(time_in_ms(end - start), terminator: " ms\n")
   precondition(result == 499999500000, "invalid result")
 }

--- a/Tests/EndToEndTests/TestCases/Concurrency/skynet_weak.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/skynet_weak.hylo
@@ -1,0 +1,43 @@
+//- compileToLLVM expecting: success
+
+fun skynet(num: Int, size: Int, div: Int) -> Int {
+  if size == 1 {
+    return num.copy()
+  } else {
+    let sub_size = size / div
+    var futures = Array<EscapingFuture<{n: Int, s: Int, d: Int}>>()
+    &futures.reserve_capacity(div)
+    var i = 0
+    while i != div {
+      let cur_num = num + i * sub_size
+      let f = escaping_spawn_(fun[sink let n = cur_num.copy(), sink let s = sub_size.copy(), sink let d = div.copy()] () -> Int {
+        skynet(num: n, size: s, div: d)
+      })
+      &futures.append(f)
+      &i += 1
+    }
+
+    var sum = 0
+    var i2 = 0
+    while i2 != div {
+      if inout f: EscapingFuture<{n: Int, s: Int, d: Int}> = &futures.pop_last() {
+        sum += &f.await()
+      }
+      &i2 += 1
+    }
+    return sum
+  }
+}
+
+public conformance EscapingFuture: SemiRegular {
+
+  public fun infix== (_ other: Self) -> Bool {
+    return false
+  }
+
+}
+
+public fun main() {
+  let result = skynet(num: 0, size: 1_000_000, div: 10);
+  precondition(result == 499999500000, "invalid result")
+}


### PR DESCRIPTION
This example is a test with a massive amount of spawns.

We implement this with our 3 spawn types:
- strict concurrency spawn (non-movable future)
- weak concurrency spawn (movable future)
- bulk spawn

Except the bulk spawn implementation we get better results than the corresponding Go code.