### PR TITLE
Pin macos-12 runner to fix build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,7 +120,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ macos-12, windows-latest ]
         configuration: [ debug, release ]
         exclude:
           - os: windows-latest
@@ -148,7 +148,7 @@ jobs:
             windows_only:
             build_platform_subdirectory: x86_64-unknown-windows-msvc
 
-          - os: macos-latest
+          - os: macos-12
             triple_suffix: apple-darwin23.3.0
             build_platform_subdirectory: x86_64-apple-macosx
 


### PR DESCRIPTION
I think the macos build is currently broken because `macos-latest` is migrating from `macos-12` to `macos-14`. See the announcement here: https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

As it's a gradual rollout, it looks like this repository hasn't been affected yet. The [last commit](https://github.com/hylo-lang/hylo/commit/5d2080b75d876382c7a740c967c1d50b71229a6b) with builds on `main` four days ago was successful. My fork, however, seems to be migrated and running `macos-14`. That leads to the following error:

```
+ hylo/Tools/make-pkgconfig.sh llvm.pc
hylo/Tools/make-pkgconfig.sh: line 17:  3660 Abort trap: 6           ! ( llvm-config > /dev/null 2>&1 )
dyld[3[66](https://github.com/peter-evans/hylo/actions/runs/8833015385/job/24255171882#step:7:67)6]: Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
  Referenced from: <6A87B086-F1E9-3471-8D2D-CD6808A1A2BF> /Users/runner/work/hylo/hylo/llvm-17.0.6-x86_64-apple-darwin23.3.0-MinSizeRel/bin/llvm-config
  Reason: tried: '/opt/homebrew/opt/zstd/lib/libzstd.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')), '/libzstd.1.dylib' (no such file), '/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/usr/local/lib/libzstd.1.dylib' (no such file), '/usr/lib/libzstd.1.dylib' (no such file, not in dyld cache)
Error: Process completed with exit code 134.
```

The most straightforward way to fix this is to pin to `macos-12` until the build can be fixed to support arm64.

For reference, you can see the available images at the following link, and which images currently map to the `*-latest` versions.
https://github.com/actions/runner-images?tab=readme-ov-file#available-images