### PR TITLE
Support arm64 build for latest macos runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -141,6 +141,7 @@ jobs:
           - windows_only: '# WINDOWS ONLY:'
 
           - os: windows-latest
+            arch: x86_64
             unpackage_command: 7z x -t7z
             package_suffix: .7z
             triple_suffix: unknown-windows-msvc17
@@ -149,13 +150,14 @@ jobs:
             build_platform_subdirectory: x86_64-unknown-windows-msvc
 
           - os: macos-latest
+            arch: arm64
             triple_suffix: apple-darwin23.3.0
-            build_platform_subdirectory: x86_64-apple-macosx
+            build_platform_subdirectory: arm64-apple-macosx
 
     runs-on: ${{ matrix.os }}
     env:
       llvm_url_prefix: ${{ matrix.HYLO_LLVM_DOWNLOAD_URL }}/${{ matrix.HYLO_LLVM_BUILD_RELEASE }}
-      llvm_package_basename: llvm-${{ matrix.HYLO_LLVM_VERSION }}-x86_64-${{ matrix.triple_suffix }}-${{ matrix.HYLO_LLVM_BUILD_TYPE }}
+      llvm_package_basename: llvm-${{ matrix.HYLO_LLVM_VERSION }}-${{ matrix.arch }}-${{ matrix.triple_suffix }}-${{ matrix.HYLO_LLVM_BUILD_TYPE }}
 
     steps:
     - name: Checkout


### PR DESCRIPTION
I opened [this PR](https://github.com/hylo-lang/hylo/pull/1440), to pin to `macos-12`, but then found that adding support for arm64 runners isn't a big change.

~~Note: The build for this PR might fail if this repository hasn't completed the `macos-latest` [migration](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/) from `macos-12` to `macos-14` yet.~~
**Migration has completed because the macos-build is successful.**