### PR TITLE
Pin to macos-13 to fix build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,7 +120,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ macos-13, windows-latest ]
         configuration: [ debug, release ]
         exclude:
           - os: windows-latest
@@ -148,7 +148,7 @@ jobs:
             windows_only:
             build_platform_subdirectory: x86_64-unknown-windows-msvc
 
-          - os: macos-latest
+          - os: macos-13
             triple_suffix: apple-darwin23.3.0
             build_platform_subdirectory: x86_64-apple-macosx
 


### PR DESCRIPTION
Following https://github.com/hylo-lang/hylo/pull/1441, perhaps it makes sense to pin to `macos-13` to fix the build errors on `main`, until https://github.com/hylo-lang/hylo/pull/1439 is ready.