### PR TITLE
Expose Frontend Library through Package.swfit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
   products: [
     .executable(name: "hc", targets: ["hc"]),
     .executable(name: "hylo-demangle", targets: ["hylo-demangle"]),
+    .library(name: "FrontEnd", targets: ["FrontEnd"]),
   ],
 
   dependencies: [


### PR DESCRIPTION
This PR adds support for importing the Hylo front-end as a library through SPM builds.