### PR TITLE
Refactor specialization maps

### DIFF
--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -511,7 +511,7 @@ extension SwiftyLLVM.Module {
       addAttribute(.init(.nocapture, in: &self), to: r)
       addAttribute(.init(.nofree, in: &self), to: r)
 
-      if m[f].output == .never {
+      if m[f].output.isNever {
         addAttribute(.init(.noreturn, in: &self), to: llvmFunction)
       }
     }

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -86,7 +86,8 @@ extension IR.Program {
     precondition(val[.isCanonical])
 
     let fields = base.storage(of: val.base).map { (part) in
-      let u = base.specialize(part.type, for: val.arguments, in: AnyScopeID(base.ast.coreLibrary!))
+      let z = GenericArguments(val)
+      let u = base.specialize(part.type, for: z, in: AnyScopeID(base.ast.coreLibrary!))
       return llvm(u, in: &module)
     }
 

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -143,7 +143,7 @@ extension IR.Program {
     precondition(val[.isCanonical])
 
     var payload: SwiftyLLVM.IRType = SwiftyLLVM.StructType([], in: &module)
-    if val == .never {
+    if val.isNever {
       return payload
     }
 

--- a/Sources/FrontEnd/CompileTimeValues/GenericArguments.swift
+++ b/Sources/FrontEnd/CompileTimeValues/GenericArguments.swift
@@ -21,7 +21,7 @@ public struct GenericArguments: Hashable {
     self.contents = contents
   }
 
-  /// Creates an empty dictionary.
+  /// Creates an empty instance.
   public init() {
     self.contents = [:]
   }
@@ -29,11 +29,6 @@ public struct GenericArguments: Hashable {
   /// Creates a new map with the arguments of `t`.
   public init(_ t: BoundGenericType) {
     self.contents = .init(uniqueKeysWithValues: t.arguments.lazy.map({ (k, v) in (k, v) }))
-  }
-
-  /// Creates a new map from the key-value pairs in the given sequence.
-  public init<S: Sequence>(uniqueKeysWithValues keysAndValues: S) where S.Element == (Key, Value) {
-    self.contents = .init(uniqueKeysWithValues: keysAndValues)
   }
 
   /// Creates an instance mapping each element of `parameters`, which is defined in `ast`, to its
@@ -97,13 +92,8 @@ public struct GenericArguments: Hashable {
     contents.merge(suffix.contents, uniquingKeysWith: { (_, _) in unreachable() })
   }
 
-}
-
-extension GenericArguments: ExpressibleByDictionaryLiteral {
-
-  public init(dictionaryLiteral elements: (Key, Value)...) {
-    self.init(uniqueKeysWithValues: elements)
-  }
+  /// An empty instance.
+  public static var empty: Self = .init()
 
 }
 

--- a/Sources/FrontEnd/CompileTimeValues/GenericArguments.swift
+++ b/Sources/FrontEnd/CompileTimeValues/GenericArguments.swift
@@ -11,7 +11,7 @@ public struct GenericArguments: Hashable {
   public typealias Value = CompileTimeValue
 
   /// The type of this map's contents.
-  fileprivate typealias Contents = OrderedDictionary<GenericParameterDecl.ID, Value>
+  public typealias Contents = [GenericParameterDecl.ID: Value]
 
   /// The contents of `self`.
   fileprivate var contents: Contents
@@ -24,6 +24,11 @@ public struct GenericArguments: Hashable {
   /// Creates an empty dictionary.
   public init() {
     self.contents = [:]
+  }
+
+  /// Creates a new map with the arguments of `t`.
+  public init(_ t: BoundGenericType) {
+    self.contents = .init(uniqueKeysWithValues: t.arguments.lazy.map({ (k, v) in (k, v) }))
   }
 
   /// Creates a new map from the key-value pairs in the given sequence.
@@ -106,18 +111,22 @@ extension GenericArguments: Collection {
 
   public typealias Element = (key: Key, value: Value)
 
-  public typealias Index = Int
+  public typealias Index = Contents.Index
 
-  public var startIndex: Index { 0 }
+  public var startIndex: Index {
+    contents.startIndex
+  }
 
-  public var endIndex: Index { contents.count }
+  public var endIndex: Index {
+    contents.endIndex
+  }
 
   public func index(after position: Index) -> Index {
-    position + 1
+    contents.index(after: position)
   }
 
   public subscript(position: Index) -> Element {
-    contents.elements[position]
+    contents[position]
   }
 
 }

--- a/Sources/FrontEnd/DeclReference.swift
+++ b/Sources/FrontEnd/DeclReference.swift
@@ -86,7 +86,7 @@ public enum DeclReference: Hashable {
     case .constructor(_, let a):
       return a
     default:
-      return [:]
+      return .empty
     }
   }
 

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -213,18 +213,10 @@ struct ConstraintSystem {
       return nil
     }
 
-    // Process explicit conformances.
-    if checker.conformedTraits(of: goal.model, in: scope).contains(goal.concept) {
+    // Check whether the conformance holds, either explicitly or structually.
+    if checker.conforms(goal.model, to: goal.concept, in: scope) {
       return .success
-    }
-
-    // Process structural conformances.
-    switch goal.concept {
-    case checker.program.ast.core.movable.type:
-      return solve(structuralConformance: goal)
-    case checker.program.ast.core.deinitializable.type:
-      return solve(structuralConformance: goal)
-    default:
+    } else {
       return .failure(failureToSolve(goal))
     }
   }

--- a/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
@@ -1,16 +1,18 @@
 /// The context in which a component of a name expression gets resolved.
 ///
 /// This structure is used during name resolution to identify the type of which an entity is member
-/// and the generic arguments captured by that entity. The following invariants are maintained:
-/// - `arguments` contains the arguments of `type`'s generic parameters (if any) and the arguments
-///   to generic parameters captured by the scope in which name resolution takes place.
-/// - if `type` is a bound generic type, `type.arguments[k] = arguments[k]` for all keys in `type`.
+/// and the generic arguments captured by that entity.
 struct NameResolutionContext {
 
   /// The type of the receiver.
+  ///
+  /// If `type` is a bound generic type, `type.arguments[k] = arguments[k]` for all keys in `type`.
   let type: AnyType
 
   /// The arguments parameterizing the generic environment of the receiver.
+  ///
+  /// This property contains the arguments of `type`'s generic parameters (if any) and the
+  /// arguments to generic parameters captured by the scope in which name resolution takes place.
   let arguments: GenericArguments
 
   /// The expression of the receiver, unless it is elided.

--- a/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
@@ -17,7 +17,7 @@ struct NameResolutionContext {
   let receiver: DeclReference.Receiver?
 
   /// Creates an instance with the given properties.
-  init(type: AnyType, arguments: GenericArguments = [:], receiver: DeclReference.Receiver?) {
+  init(type: AnyType, arguments: GenericArguments = .empty, receiver: DeclReference.Receiver?) {
     self.type = type
     self.receiver = receiver
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -360,6 +360,26 @@ extension Diagnostic {
   }
 
   static func error(
+    referenceTo d: SourceRepresentable<Name>, requires t: AnyType, conformsTo u: TraitType,
+    dueToConstraintAt constraintSite: SourceRange
+  ) -> Diagnostic {
+    .error(
+      "reference to '\(d.value)' requires that '\(t)' be conforming to '\(u)'",
+      at: d.site,
+      notes: [.note("constraint declared here", at: constraintSite)])
+  }
+
+  static func error(
+    referenceTo d: SourceRepresentable<Name>, requires t: AnyType, equals u: AnyType,
+    dueToConstraintAt constraintSite: SourceRange
+  ) -> Diagnostic {
+    .error(
+      "reference to '\(d.value)' requires that '\(t)' be equal to '\(u)'",
+      at: d.site,
+      notes: [.note("constraint declared here", at: constraintSite)])
+  }
+
+  static func error(
     invalidReferenceToAssociatedType a: AssociatedTypeDecl.ID, at site: SourceRange, in ast: AST
   ) -> Diagnostic {
     .error(

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -4190,12 +4190,11 @@ struct TypeChecker {
 
     // TODO: Report invalid uses of mutation markers
 
-    // The specialization of the entity includes that of context in which it was looked up.
-    //
-    // The resolution context may contain information necessary to determine the specialization of
+    // The specialization of the entity includes that of the context in which it was looked up. In
+    // particular, the context may contain information necessary to determine the specialization of
     // a qualified name. For example, given an instance of `type S<T> { let foo: Array<T> }`, the
     // type of the member `foo` depends on the specialization of its qualification.
-    var specialization = genericArguments(inScopeIntroducing: d, resolvedIn: context)
+    var specialization = genericQualificationArguments(inScopeIntroducing: d, resolvedIn: context)
     entityType = specialize(entityType, for: specialization, in: scopeOfUse)
 
     // Keep track of generic arguments that should be captured later on.
@@ -4469,12 +4468,13 @@ struct TypeChecker {
     }
   }
 
-  /// Returns the generic arguments passed to symbols occurring in `d` and looked up in `context`.
+  /// Returns the generic arguments passed to the qualification of symbols introduced in `d` that
+  /// that have been looked up in `context`.
   ///
   /// The arguments of `context` are returned if the latter isn't `nil`. Otherwise, the arguments
-  /// captured in the scope introducing `d` are returned in the form of a table mapping accumulated
-  /// generic parameters to a skolem.
-  private mutating func genericArguments(
+  /// captured in the scope introducing `d` are returned as a table mapping accumulated generic
+  /// parameters to a skolem.
+  private mutating func genericQualificationArguments(
     inScopeIntroducing d: AnyDeclID, resolvedIn context: NameResolutionContext?
   ) -> GenericArguments {
     if let c = context {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -272,10 +272,15 @@ struct TypeChecker {
   private mutating func conformedTraits(
     of t: GenericTypeParameterType, in scopeOfUse: AnyScopeID
   ) -> Set<TraitType> {
+    let scopeOfDeclaration = program[t.decl].scope
+
     // Trait receivers conform to their traits.
     var result: Set<TraitType>
-    if let d = TraitDecl.ID(program[t.decl].scope) {
+    if let d = TraitDecl.ID(scopeOfDeclaration) {
       result = refinements(of: TraitType(d, ast: program.ast)).unordered
+    } else if !isNotionallyContained(scopeOfUse, in: scopeOfDeclaration) {
+      let e = possiblyPartiallyFormedEnvironment(of: AnyDeclID(scopeOfDeclaration)!)!
+      result = e.conformedTraits(of: ^t)
     } else {
       result = []
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3913,7 +3913,12 @@ struct TypeChecker {
       if let c = candidates.elements.uniqueElement {
         report(c.diagnostics.elements)
       } else {
-        report(.error(noViableCandidateToResolve: name, notes: []))
+        let notes = candidates.elements.map { (c) -> Diagnostic in
+          let s = c.reference.decl.map(program.ast.siteForDiagnostics(about:))
+          let m = c.diagnostics.elements.min(by: Diagnostic.isLoggedBefore)?.message
+          return .note(m ?? "candidate not viable", at: s ?? name.site)
+        }
+        report(.error(noViableCandidateToResolve: name, notes: notes))
       }
       return []
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -165,7 +165,7 @@ struct TypeChecker {
   }
 
   /// Returns the traits to which `t` is declared conforming in `scopeOfUse`.
-  private mutating func conformedTraits(
+  mutating func conformedTraits(
     of t: AnyType, in scopeOfUse: AnyScopeID
   ) -> Set<TraitType> {
     // Computation is not memoized for generic type parameters because queries might come from
@@ -339,7 +339,7 @@ struct TypeChecker {
   /// `t` is a generic type parameter or an associated type introduced by a generic environment
   /// notionally containing `scopeOfUse`. The return value is the set of traits used as bounds of
   /// `t` in that environment.
-  mutating func conformedTraits(
+  private mutating func conformedTraits(
     declaredByConstraintsOn t: AnyType, exposedTo scopeOfUse: AnyScopeID
   ) -> Set<TraitType> {
     if let s = program.scopes(from: scopeOfUse).first(where: \.isGenericScope) {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -352,7 +352,7 @@ struct TypeChecker {
   /// synthesized in `scopeOfUse`.
   ///
   /// A conformance *M: T* is synthesizable iff *M* structurally conforms to *T*.
-  private mutating func conforms(
+  private mutating func canSynthesizeConformance(
     _ model: AnyType, to trait: TraitType, in scopeOfUse: AnyScopeID
   ) -> Bool {
     conformedTraits(of: model, in: scopeOfUse).contains(trait)
@@ -375,21 +375,21 @@ struct TypeChecker {
       return structurallyConforms(m, to: trait, in: scopeOfUse)
     case let m as BufferType:
       // FIXME: To remove once conditional conformance is implemented
-      return conforms(m.element, to: trait, in: scopeOfUse)
+      return canSynthesizeConformance(m.element, to: trait, in: scopeOfUse)
     case let m as ArrowType:
-      return conforms(m.environment, to: trait, in: scopeOfUse)
+      return canSynthesizeConformance(m.environment, to: trait, in: scopeOfUse)
     case is MetatypeType:
       return true
     case let m as ProductType:
       return structurallyConforms(m, to: trait, in: scopeOfUse)
     case let m as RemoteType:
-      return conforms(m.bareType, to: trait, in: scopeOfUse)
+      return canSynthesizeConformance(m.bareType, to: trait, in: scopeOfUse)
     case let m as TupleType:
-      return m.elements.allSatisfy({ conforms($0.type, to: trait, in: scopeOfUse) })
+      return m.elements.allSatisfy({ canSynthesizeConformance($0.type, to: trait, in: scopeOfUse) })
     case let m as TypeAliasType:
       return structurallyConforms(m.aliasee.value, to: trait, in: scopeOfUse)
     case let m as UnionType:
-      return m.elements.allSatisfy({ conforms($0, to: trait, in: scopeOfUse) })
+      return m.elements.allSatisfy({ canSynthesizeConformance($0, to: trait, in: scopeOfUse) })
     default:
       return false
     }
@@ -408,7 +408,7 @@ struct TypeChecker {
       let s = AnyScopeID(b.decl)
       return program.storedParts(of: b.decl).allSatisfy { (p) in
         let t = specialize(uncheckedType(of: p), for: z, in: s)
-        return conforms(t, to: trait, in: s)
+        return canSynthesizeConformance(t, to: trait, in: s)
       }
     } else {
       let t = specialize(base, for: z, in: scopeOfUse)
@@ -421,7 +421,7 @@ struct TypeChecker {
     _ model: ProductType, to trait: TraitType, in scopeOfUse: AnyScopeID
   ) -> Bool {
     program.storedParts(of: model.decl).allSatisfy { (p) in
-      conforms(uncheckedType(of: p), to: trait, in: scopeOfUse)
+      canSynthesizeConformance(uncheckedType(of: p), to: trait, in: scopeOfUse)
     }
   }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -165,7 +165,9 @@ struct TypeChecker {
   }
 
   /// Returns the traits to which `t` is declared conforming in `scopeOfUse`.
-  mutating func conformedTraits(of t: AnyType, in scopeOfUse: AnyScopeID) -> Set<TraitType> {
+  private mutating func conformedTraits(
+    of t: AnyType, in scopeOfUse: AnyScopeID
+  ) -> Set<TraitType> {
     // Computation is not memoized for generic type parameters because queries might come from
     // generic arguments under construction.
     if let u = GenericTypeParameterType(t) {
@@ -349,7 +351,7 @@ struct TypeChecker {
   }
 
   /// Returns `true` if `model` conforms to `trait` explicitly or structurally in `scopeOfUse`.
-  private mutating func conforms(
+  mutating func conforms(
     _ model: AnyType, to trait: TraitType, in scopeOfUse: AnyScopeID
   ) -> Bool {
     conformedTraits(of: model, in: scopeOfUse).contains(trait)

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -273,7 +273,8 @@ public struct TypedProgram {
   /// Returns the names and types of `t`'s stored properties.
   public func storage(of t: BoundGenericType) -> [TupleType.Element] {
     storage(of: t.base).map { (p) in
-      let t = specialize(p.type, for: t.arguments, in: AnyScopeID(base.ast.coreLibrary!))
+      let z = GenericArguments(t)
+      let t = specialize(p.type, for: z, in: AnyScopeID(base.ast.coreLibrary!))
       return .init(label: p.label, type: t)
     }
   }

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -417,7 +417,7 @@ public struct TypedProgram {
     }
 
     return .init(
-      model: model, concept: concept, arguments: [:], conditions: [], scope: scopeOfUse,
+      model: model, concept: concept, arguments: .empty, conditions: [], scope: scopeOfUse,
       implementations: implementations, isStructural: false, origin: nil)
   }
 
@@ -455,7 +455,9 @@ public struct TypedProgram {
     for requirement in ast.requirements(of: concept.decl) {
       guard let k = ast.synthesizedKind(of: requirement) else { return nil }
 
-      let a: GenericArguments = [ast[concept.decl].receiver: .type(model)]
+      var a = GenericArguments.empty
+      a[ast[concept.decl].receiver] = .type(model)
+
       let t = ArrowType(specialize(declType[requirement]!, for: a, in: scopeOfUse))!
       let d = SynthesizedFunctionDecl(k, typed: t, parameterizedBy: h, in: scopeOfUse)
       implementations[requirement] = .synthetic(d)

--- a/Sources/FrontEnd/Types/AnyType.swift
+++ b/Sources/FrontEnd/Types/AnyType.swift
@@ -174,12 +174,19 @@ public struct AnyType {
     }
   }
 
-  /// Indicates whether `self` is Hylo's `Void` or `Never` type.
-  ///
-  /// - Requires: `self` is canonical.
+  /// `true` iff `self` is syntactically equal to Hylo's `Void` or `Never` type.
   public var isVoidOrNever: Bool {
-    precondition(self[.isCanonical])
-    return (self == .void) || (self == .never)
+    isVoid || isNever
+  }
+
+  /// `true` iff `self` is syntactically equal to Hylo's `Void` type.
+  public var isVoid: Bool {
+    self == .void
+  }
+
+  /// `true` iff `self` is syntactically equal to Hylo's `Never` type.
+  public var isNever: Bool {
+    self == .never
   }
 
   /// Indicates whether `self` is a generic type parameter or associated type.

--- a/Sources/FrontEnd/Types/AnyType.swift
+++ b/Sources/FrontEnd/Types/AnyType.swift
@@ -115,7 +115,7 @@ public struct AnyType {
     case let u as TypeAliasType:
       return u.resolved.specialization
     default:
-      return [:]
+      return .empty
     }
   }
 

--- a/Sources/FrontEnd/Types/AnyType.swift
+++ b/Sources/FrontEnd/Types/AnyType.swift
@@ -111,7 +111,7 @@ public struct AnyType {
   public var specialization: GenericArguments {
     switch base {
     case let u as BoundGenericType:
-      return u.arguments
+      return .init(u)
     case let u as TypeAliasType:
       return u.resolved.specialization
     default:

--- a/Sources/FrontEnd/Types/BoundGenericType.swift
+++ b/Sources/FrontEnd/Types/BoundGenericType.swift
@@ -1,20 +1,23 @@
+import OrderedCollections
 import Utils
 
 /// A generic type bound to arguments.
 public struct BoundGenericType: TypeProtocol {
 
+  public typealias Arguments = OrderedDictionary<GenericParameterDecl.ID, CompileTimeValue>
+
   /// The underlying generic type.
   public let base: AnyType
 
   /// The type and value arguments of the base type.
-  public let arguments: GenericArguments
+  public let arguments: Arguments
 
   public let flags: TypeFlags
 
   /// Creates a bound generic type binding `base` to the given `arguments`.
   ///
   /// - Requires: `arguments` is not empty.
-  public init<T: TypeProtocol>(_ base: T, arguments: GenericArguments) {
+  public init<T: TypeProtocol>(_ base: T, arguments: Arguments) {
     precondition(!arguments.isEmpty)
     self.base = ^base
     self.arguments = arguments

--- a/Sources/FrontEnd/Types/MethodType.swift
+++ b/Sources/FrontEnd/Types/MethodType.swift
@@ -54,7 +54,7 @@ public struct MethodType: TypeProtocol {
 
     /// Returns the output type of a `let` or `sink` variant.
     func makeFunctionalOutput() -> AnyType {
-      if output == .void {
+      if output.isVoid {
         return receiver
       } else {
         return ^TupleType([.init(label: "self", type: receiver), .init(label: nil, type: output)])

--- a/Sources/FrontEnd/Types/SubscriptImplType.swift
+++ b/Sources/FrontEnd/Types/SubscriptImplType.swift
@@ -39,7 +39,7 @@ public struct SubscriptImplType: TypeProtocol {
   }
 
   /// Indicates whether `self` has an empty environment.
-  public var isThin: Bool { environment == .void }
+  public var isThin: Bool { environment.isVoid }
 
   /// Accesses the individual elements of the arrow's environment.
   public var captures: [TupleType.Element] { TupleType(environment)?.elements ?? [] }

--- a/Sources/FrontEnd/Types/UnionType.swift
+++ b/Sources/FrontEnd/Types/UnionType.swift
@@ -28,6 +28,11 @@ public struct UnionType: TypeProtocol {
     self.flags = fs
   }
 
+  /// `true` if `self` is Hylo's `Never` type.
+  public var isNever: Bool {
+    elements.isEmpty
+  }
+
   public func transformParts<M>(
     mutating m: inout M, _ transformer: (inout M, AnyType) -> TypeTransformAction
   ) -> Self {

--- a/Sources/IR/Analysis/Module+DeadCodeElimination.swift
+++ b/Sources/IR/Analysis/Module+DeadCodeElimination.swift
@@ -73,9 +73,9 @@ extension Module {
   private func returnsNever(_ i: InstructionID) -> Bool {
     switch self[i] {
     case is Call:
-      return type(of: (self[i] as! Call).output).ast == .never
+      return type(of: (self[i] as! Call).output).ast.isNever
     case is CallFFI:
-      return (self[i] as! CallFFI).returnType.ast == .never
+      return (self[i] as! CallFFI).returnType.ast.isNever
     default:
       return false
     }

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -81,7 +81,7 @@ extension IR.Program {
 
     let g = monomorphize(s.callee, for: s.specialization, usedIn: modules[m]!.scope(containing: i))
     let new = modules[m]!.makeProject(
-      s.projection, applying: g, specializedBy: [:], to: s.operands, at: s.site)
+      s.projection, applying: g, specializedBy: .empty, to: s.operands, at: s.site)
     modules[m]!.replace(i, with: new)
   }
 

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2145,7 +2145,7 @@ struct Emitter {
     switch program[callee].referredDecl {
     case .direct(let d, let a) where d.isCallable:
       // Callee is a direct reference to a lambda declaration.
-      guard ArrowType(canonical(program[callee].type))!.environment == .void else {
+      guard ArrowType(canonical(program[callee].type))!.environment.isVoid else {
         UNIMPLEMENTED("Generate IR for calls to local functions with captures #1088")
       }
       let f = FunctionReference(to: d, in: &module, specializedBy: a, in: insertionScope!)
@@ -2252,7 +2252,7 @@ struct Emitter {
     switch program[callee].referredDecl {
     case .direct(let d, let a) where d.kind == SubscriptDecl.self:
       // Callee is a direct reference to a subscript declaration.
-      guard SubscriptType(canonical(program[d].type))!.environment == .void else {
+      guard SubscriptType(canonical(program[d].type))!.environment.isVoid else {
         UNIMPLEMENTED("subscript with non-empty environment")
       }
 

--- a/Sources/IR/Mangling/Mangler.swift
+++ b/Sources/IR/Mangling/Mangler.swift
@@ -341,9 +341,14 @@ struct Mangler {
   ) {
     write(operator: .monomorphizedFunctionDecl, to: &output)
     mangle(function: symbol, to: &output)
-    write(integer: arguments.count, to: &output)
-    for u in arguments.values {
-      mangle(value: u, to: &output)
+    write(specialization: arguments, to: &output)
+  }
+
+  /// Writes the mangled representation of `specialization` to `output`.
+  private mutating func write(specialization: GenericArguments, to output: inout Output) {
+    write(integer: specialization.count, to: &output)
+    for (_, v) in specialization.sorted(by: \.key.rawValue) {
+      mangle(value: v, to: &output)
     }
   }
 
@@ -387,13 +392,10 @@ struct Mangler {
   /// Writes the mangled representation of `r` to `output`.
   mutating func mangle(reference r: DeclReference, to output: inout Output) {
     switch r {
-    case .direct(let d, let parameterization):
+    case .direct(let d, let z):
       write(operator: .directDeclReference, to: &output)
       mangle(decl: d, to: &output)
-      write(integer: parameterization.count, to: &output)
-      for u in parameterization.values {
-        mangle(value: u, to: &output)
-      }
+      write(specialization: z, to: &output)
 
     default:
       UNIMPLEMENTED()

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -479,7 +479,9 @@ public struct Module {
   ) -> FunctionReference {
     var a = witness.arguments
     if let m = program.traitMember(referredBy: d) {
-      a = a.merging([program[m.trait.decl].receiver: .type(witness.model)])
+      let r = program[m.trait.decl].receiver.id
+      assert(a[r] == nil)
+      a[r] = .type(witness.model)
     }
     return FunctionReference(to: d, in: self, specializedBy: a, in: witness.scope)
   }

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -25,7 +25,7 @@ public struct FunctionReference: Constant, Hashable {
 
     self.function = f
     self.type = .address(t)
-    self.specialization = [:]
+    self.specialization = .empty
   }
 
   /// Creates a reference to `f`, which is in `module`, specialized by `specialization` in

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension.hylo
@@ -18,6 +18,6 @@ extension B where X: T {
 }
 
 public fun main() {
-  //! @+1 diagnostic type 'Bool' does not conform to trait 'T'
+  //! @+1 diagnostic reference to 'foo' requires that 'Bool' be conforming to 'T'
   B<Bool>().foo()
 }

--- a/Tests/HyloTests/TestCases/TypeChecking/WhereClause.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/WhereClause.hylo
@@ -10,5 +10,5 @@ extension A where X == Bool {
 
 public fun main() {
   A<Bool>().koala()
-  A<Int8>().koala() //! diagnostic unsatisfied where clause
+  A<Int8>().koala() //! diagnostic reference to 'koala' requires that 'Int8' be equal to 'Bool'
 }


### PR DESCRIPTION
This PR makes two changes to specialization:
- The ordering of generic parameters in `GenericArguments` is removed and stored in `BoundGenericType`, which is the only place where it actually makes sense.
- The collection of constraints on generic parameters associated with the resolution of a name is refactored to reduce pressure on constraint solving and produce better diagnostics.
