### PR TITLE
Lock to a revision of Hylo-CMakeModules

### DIFF
--- a/cmake/TopLevelDefaults.cmake
+++ b/cmake/TopLevelDefaults.cmake
@@ -14,7 +14,7 @@ block()
   set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE NEVER)
   FetchContent_Declare(Hylo-CMakeModules
     GIT_REPOSITORY https://github.com/hylo-lang/CMakeModules.git
-    GIT_TAG        main
+    GIT_TAG        43ee6f5
     OVERRIDE_FIND_PACKAGE
   )
 


### PR DESCRIPTION
So we can update its main without breaking anything.