### PR TITLE
Update meeting times in README, make contributing section more apparent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,15 @@ Once everything looks good, squash those additional commits before merging.
 
 Do not hesitate to reach out if you are lost in the process.
 
+
+## Join the community
+You can also get in touch with the community by joining our [Slack][join-slack] or one of our [Zoom Meetings][join-zoom]
+(ID: 633 2146 3694, Passcode: 409180) on Tuesdays and Thursdays, 13:00-13:30 Pacific time or 22:00-22:30 Central
+European time.
+
+[join-slack]: https://join.slack.com/t/val-qs97696/shared_invite/zt-1z3dsblrq-y4qXfEE6wr6uMEJSN9uFyg
+[join-zoom]: https://unige.zoom.us/j/63321463694?pwd=L0VuY3QwUEx5K3BaRWIyMjArdkhEQT09
+
 [typos-action]: https://github.com/marketplace/actions/typos-action
 [install typos]: https://github.com/crate-ci/typos#install
 [typos false positives documentation]: https://github.com/crate-ci/typos#false-positives

--- a/README.md
+++ b/README.md
@@ -238,7 +238,12 @@ A more detailed description of the current implementation status is available on
 We welcome contributions to Hylo.
 Please read through [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get started.
 
-You can also get in touch with the community by joining our [Slack](https://join.slack.com/t/val-qs97696/shared_invite/zt-1z3dsblrq-y4qXfEE6wr6uMEJSN9uFyg) or one of our [Zoom Meetings](https://unige.zoom.us/j/63321463694?pwd=L0VuY3QwUEx5K3BaRWIyMjArdkhEQT09) (ID: 633 2146 3694, Passcode: 409180) on Tuesdays and Thursdays, 12:30-1:00 Pacific time.
+You can also get in touch with the community by joining our [Slack][join-slack] or one of our [Zoom Meetings][join-zoom]
+(ID: 633 2146 3694, Passcode: 409180) on Tuesdays and Thursdays, 13:00-13:30 Pacific time or 22:00-22:30 Central
+European time.
+
+[join-slack]: https://join.slack.com/t/val-qs97696/shared_invite/zt-1z3dsblrq-y4qXfEE6wr6uMEJSN9uFyg
+[join-zoom]: https://unige.zoom.us/j/63321463694?pwd=L0VuY3QwUEx5K3BaRWIyMjArdkhEQT09
 
 ## License
 


### PR DESCRIPTION
I moved the contributing section to the beginning of our readme, so that it's not hidden below pages of setup guides. I also updated the meeting times, and added a time converter, so that people all around the world can quickly see when exactly the meetings happen.

I also added the slack and zoom links to CONTRIBUTING.md, which might be helpful on that page too, though I'm not entirely sure whether the redundancy is worth it, so I can remove that if needed.