### PR TITLE
Document precondition of SourceFile's constructor

### DIFF
--- a/Sources/FrontEnd/SourceFile.swift
+++ b/Sources/FrontEnd/SourceFile.swift
@@ -61,9 +61,19 @@ public struct SourceFile {
   }
 
   /// Creates a synthetic source file with the specified contents and base name.
+  ///
+  /// If `baseName` is not provided, a unique name will be generated.
+  ///
+  /// - Precondition: the same baseName must not be used for different text, as
+  ///   synthesized files with the same `baseName` will share storage.
+  ///
   public init(synthesizedText text: String, named baseName: String = UUID().uuidString) {
     let storage = Storage(URL(string: "synthesized://\(baseName)")!) { text[...] }
     self.storage = storage
+
+    // The assertion is not evaluated in release builds.
+    assert(text == self.storage.text, "Precondition violated: synthesized files with the " +
+      "same baseName must have the same text globally.")
   }
 
   /// The name of the source file, sans path qualification or extension.

--- a/Sources/FrontEnd/SourceFile.swift
+++ b/Sources/FrontEnd/SourceFile.swift
@@ -64,16 +64,13 @@ public struct SourceFile {
   ///
   /// If `baseName` is not provided, a unique name will be generated.
   ///
-  /// - Precondition: the same baseName must not be used for different text, as
-  ///   synthesized files with the same `baseName` will share storage.
-  ///
+  /// - Precondition: No synthetic source file named `baseName` has been created yet.
   public init(synthesizedText text: String, named baseName: String = UUID().uuidString) {
     let storage = Storage(URL(string: "synthesized://\(baseName)")!) { text[...] }
     self.storage = storage
 
     // The assertion is not evaluated in release builds.
-    assert(text == self.storage.text, "Precondition violated: synthesized files with the " +
-      "same baseName must have the same text globally.")
+    assert(text == self.storage.text, "duplicate synthesized filename")
   }
 
   /// The name of the source file, sans path qualification or extension.


### PR DESCRIPTION
I added documentation for the precondition mentioned in: #1489 
When given the same `baseName` for a SourceFile's constructor as before, the provided file content must equal the one before for synthesized source files.

I added a runtime check that only runs in debug builds, so it shouldn't influence the performance of the compiler in release mode.