### PR TITLE
Make sure `sink` parameter are deinitialized when a function returns

### DIFF
--- a/Sources/FrontEnd/AST/Decl/FunctionDecl.swift
+++ b/Sources/FrontEnd/AST/Decl/FunctionDecl.swift
@@ -104,6 +104,9 @@ public struct FunctionDecl: CapturingDecl, ExposableDecl, GenericDecl {
   /// `true` iff `self` denotes a `sink` member function.
   public var isSink: Bool { receiverEffect?.value == .sink }
 
+  /// `true` iff `self` denotes a deinitializer.
+  public var isDeinit: Bool { (identifier?.value == "deinit") && isSink && parameters.isEmpty }
+
   /// `true` iff `self` is a foreign function interface.
   public var isForeignInterface: Bool {
     api.contains(.isForeignInterface)

--- a/Sources/FrontEnd/BuiltinFunction.swift
+++ b/Sources/FrontEnd/BuiltinFunction.swift
@@ -14,6 +14,10 @@ public struct BuiltinFunction: Hashable {
       let p = ParameterType(.let, ^freshVariable())
       return .init(inputs: [.init(label: "of", type: ^p)], output: .builtin(.ptr))
 
+    case .markUninitialized:
+      let p = ParameterType(.let, ^freshVariable())
+      return .init(inputs: [.init(label: nil, type: ^p)], output: .void)
+
     case .llvm(let s):
       return s.type
     }
@@ -37,6 +41,11 @@ extension BuiltinFunction {
     /// measures may be needed to keep the argument alive during the pointer's use.
     case addressOf
 
+    /// `Builtin.mark_uninitialized<T>(_ v: sink T) -> Void`
+    ///
+    /// Marks `v` as being uninitialized.
+    case markUninitialized
+
   }
 
 }
@@ -49,6 +58,8 @@ extension BuiltinFunction.Name: CustomStringConvertible {
       return n.description
     case .addressOf:
       return "address(of:)"
+    case .markUninitialized:
+      return "mark_uninitialized(_:)"
     }
   }
 
@@ -63,6 +74,8 @@ extension BuiltinFunction {
     switch n {
     case "address":
       self.init(name: .addressOf)
+    case "mark_uninitialized":
+      self.init(name: .markUninitialized)
     default:
       self.init(native: n)
     }

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2112,6 +2112,11 @@ struct Emitter {
     case .addressOf:
       let source = emitLValue(arguments[0].value)
       return insert(module.makeAddressToPointer(source, at: site))!
+
+    case .markUninitialized:
+      let source = emitLValue(arguments[0].value)
+      insert(module.makeMarkState(source, initialized: false, at: site))
+      return .void
     }
   }
 

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2999,7 +2999,7 @@ struct Emitter {
 
   /// If `storage` is deinitializable in `self.insertionScope`, inserts the IR for deinitializing
   /// it; reports a diagnostic for each part that isn't deinitializable otherwise.
-  private mutating func emitDeinitParts(of storage: Operand, at site: SourceRange) {
+  mutating func emitDeinitParts(of storage: Operand, at site: SourceRange) {
     let t = module.type(of: storage).ast
 
     if program.isTriviallyDeinitializable(t, in: insertionScope!) {

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -179,6 +179,20 @@ public struct Module {
     return d.dominates(lhs.block, rhs.block)
   }
 
+  /// Returns `true` if `i` is a deinitializer.
+  public func isDeinit(_ i: Function.ID) -> Bool {
+    switch i.value {
+    case .lowered(let d):
+      return FunctionDecl.ID(d).map({ (n) in program.ast[n].isDeinit }) ?? false
+    case .existentialized(let j):
+      return isDeinit(j)
+    case .monomorphized(let j, arguments: _):
+      return isDeinit(j)
+    case .synthesized(let d):
+      return d.kind == .deinitialize
+    }
+  }
+
   /// Returns whether the IR in `self` is well-formed.
   ///
   /// Use this method as a sanity check to verify the module's invariants.

--- a/Sources/IR/Parameter.swift
+++ b/Sources/IR/Parameter.swift
@@ -25,7 +25,7 @@ public struct Parameter {
     case let u as RemoteType:
       self.init(decl: d, type: ParameterType(u))
     default:
-      self.init(decl: d, type: ParameterType(.sink, t))
+      self.init(decl: d, type: ParameterType(.inout, t))
     }
   }
 

--- a/StandardLibrary/Sources/Concurrency/Future.hylo
+++ b/StandardLibrary/Sources/Concurrency/Future.hylo
@@ -1,5 +1,5 @@
 /// A future that cannot escape the local scope.
-public type Future<E: Movable & Deinitializable> {
+public type Future<E: Movable & Deinitializable>: Deinitializable {
 
   // TODO
   public typealias Result = Int

--- a/StandardLibrary/Sources/Core/Bitcast.hylo
+++ b/StandardLibrary/Sources/Core/Bitcast.hylo
@@ -14,5 +14,6 @@ public subscript unsafe_bitcast<T, U>(_ value: T): U {
 /// Returns `value` with its memory representation reinterpreted as a value of type `U`.
 public fun unsafe_bitcast<T, U: Movable>(consuming value: sink T) -> U {
   sink let p: PointerToMutable<U> = PointerToMutable(type_punning: mutable_pointer[to: &value])
+  Builtin.mark_uninitialized(value)
   return p.unsafe_pointee()
 }

--- a/StandardLibrary/Sources/Core/String/UTF8Array.hylo
+++ b/StandardLibrary/Sources/Core/String/UTF8Array.hylo
@@ -168,7 +168,9 @@ public type UTF8Array: Regular {
     &self = with_extended_lifetime(
       nullterminated,
       do: fun[sink let c = count(), sink let k = new_capacity.copy()] (_ source) {
-        UTF8Array(unsafely_copying: PointerToBuffer(start: source.copy(), count: c), reserving: k)
+        UTF8Array(
+          unsafely_copying: PointerToBuffer(start: source.copy(), count: c.copy()),
+          reserving: k)
       })
   }
 

--- a/Tests/HyloTests/TestCases/Lowering/DI.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/DI.hylo
@@ -4,7 +4,7 @@ fun read<T>(_ x: T) {}
 
 fun modify<T>(_ x: inout T) {}
 
-fun consume<T>(_ x: sink T) {}
+fun consume<T: Deinitializable>(_ x: sink T) {}
 
 // fun assign<T>(_ x: set T, to y: sink T) { &x = y }
 

--- a/Tests/HyloTests/TestCases/Lowering/MissingDeinit.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/MissingDeinit.hylo
@@ -1,0 +1,10 @@
+//- lowerToFinishedIR expecting: failure
+
+type A {
+  public memberwise init
+}
+
+//! @+1 diagnostic type 'A' does not conform to trait 'Deinitializable'
+fun f(_ a: sink A) {}
+
+public fun main() { f(A()) }


### PR DESCRIPTION
Fixes #1500 and one of the bugs reported by #1499.