### PR TITLE
Fix GNU source location presentation

### DIFF
--- a/Sources/FrontEnd/SourceRange.swift
+++ b/Sources/FrontEnd/SourceRange.swift
@@ -104,7 +104,7 @@ extension SourceRange: CustomStringConvertible {
   /// [Gnu-standard](https://www.gnu.org/prep/standards/html_node/Errors.html).
   public var gnuStandardText: String {
     let start = self.start.lineAndColumn
-    let head = "\(file.url.relativePath):\(start.line).\(start.column)"
+    let head = "\(file.url.relativePath):\(start.line):\(start.column)"
     if regionOfFile.isEmpty { return head }
 
     let end = file.position(endIndex).lineAndColumn


### PR DESCRIPTION
The common syntax for referring to lines and columns is to write line:column instead of line.column. When I make this change, the link will become clickable in VSCode.