### PR TITLE
Add support for choosing between standard library sources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -135,7 +135,7 @@ let package = Package(
       name: "StandardLibrary",
       dependencies: ["FrontEnd", "Utils"],
       path: "StandardLibrary",
-      exclude: ["Sources"],
+      resources: [.copy("Sources")],
       swiftSettings: allTargetsSwiftSettings),
 
     .plugin(

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -2,20 +2,26 @@ import Foundation
 import FrontEnd
 import Utils
 
+private let standardLibrarySourceFolder = URL(fileURLWithPath: #filePath).deletingLastPathComponent().appendingPathComponent("Sources")
+#if canImport(SPMUtility) // Check if SPM is being used
+  /// The parent directory of the standard library sources directory.
+  private let useBuiltinStandardLibrary = ProcessInfo.processInfo.environment["HYLO_USE_BUILTIN_STDLIB"] == "true"
 
-/// The parent directory of the standard library sources directory.
-private let useBuiltinStandardLibrary = ProcessInfo.processInfo.environment["HYLO_USE_BUILTIN_STDLIB"] == "true"
+  private let libraryRoot = if useBuiltinStandardLibrary {
+    // This path points into the source tree rather than to some copy so that when diagnostics are
+    // issued for the standard library, they point to the original source files and edits to those
+    // source files actually fix the problems (see https://github.com/hylo-lang/hylo/issues/932).  If we
+    // ever change that, some other mechanism is needed to ensure that diagnostics refer to the original
+    // source files.
+    standardLibrarySourceFolder
+  } else {
+    Bundle.module.url(forResource: "Sources", withExtension: nil)!
+  }
+#else
+  // Default to source location on SPM. TODO make this able to use exported resources
+  private let libraryRoot = standardLibrarySourceFolder
+#endif
 
-private let libraryRoot = if useBuiltinStandardLibrary {
-  // This path points into the source tree rather than to some copy so that when diagnostics are
-  // issued for the standard library, they point to the original source files and edits to those
-  // source files actually fix the problems (see https://github.com/hylo-lang/hylo/issues/932).  If we
-  // ever change that, some other mechanism is needed to ensure that diagnostics refer to the original
-  // source files.
-  URL(fileURLWithPath: #filePath).appendingPathComponent("Sources")
-} else {
-  Bundle.module.url(forResource: "Sources", withExtension: nil)!
-}
 
 /// The root of a directory hierarchy containing all the standard library sources.
 private let hostedLibrarySourceRoot = libraryRoot

--- a/StandardLibrary/StandardLibrary.swift
+++ b/StandardLibrary/StandardLibrary.swift
@@ -2,17 +2,23 @@ import Foundation
 import FrontEnd
 import Utils
 
-// This path points into the source tree rather than to some copy so that when diagnostics are
-// issued for the standard library, they point to the original source files and edits to those
-// source files actually fix the problems (see https://github.com/hylo-lang/hylo/issues/932).  If we
-// ever change that, some other mechanism is needed to ensure that diagnostics refer to the original
-// source files.
-//
+
 /// The parent directory of the standard library sources directory.
-private let libraryRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+private let useBuiltinStandardLibrary = ProcessInfo.processInfo.environment["HYLO_USE_BUILTIN_STDLIB"] == "true"
+
+private let libraryRoot = if useBuiltinStandardLibrary {
+  // This path points into the source tree rather than to some copy so that when diagnostics are
+  // issued for the standard library, they point to the original source files and edits to those
+  // source files actually fix the problems (see https://github.com/hylo-lang/hylo/issues/932).  If we
+  // ever change that, some other mechanism is needed to ensure that diagnostics refer to the original
+  // source files.
+  URL(fileURLWithPath: #filePath).appendingPathComponent("Sources")
+} else {
+  Bundle.module.url(forResource: "Sources", withExtension: nil)!
+}
 
 /// The root of a directory hierarchy containing all the standard library sources.
-private let hostedLibrarySourceRoot = libraryRoot.appendingPathComponent("Sources")
+private let hostedLibrarySourceRoot = libraryRoot
 
 /// The root of a directory hierarchy containing the sources for the standard library's freestanding
 /// core.


### PR DESCRIPTION
Add support for choosing between standard library source taken from resources or the original sources.

Developers will need to set the HYLO_USE_BUILTIN_STDLIB environment variable to "true" if they want diagnostics to point to the original sources.