### PR TITLE
Better ambiguity diagnostics

### DIFF
--- a/Sources/FrontEnd/DiagnosticSet.swift
+++ b/Sources/FrontEnd/DiagnosticSet.swift
@@ -33,6 +33,11 @@ public struct DiagnosticSet: Error {
     containsError = containsError || other.containsError
   }
 
+  /// Removes from `self` the elements that are not also contained in `other`.
+  public mutating func formIntersection(_ other: Self) {
+    self = .init(elements.filter(other.elements.contains(_:)))
+  }
+
   /// Throws `self` if any errors were reported.
   public func throwOnError() throws {
     if containsError { throw self }

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -192,11 +192,17 @@ struct ConstraintSystem {
       penalties: penalties, diagnostics: d, stale: stale.map({ goals[$0] }))
   }
 
-  /// Creates an ambiguous solution.
+  /// Creates an ambiguous solution, reporting the ambiguity with `d`.
+  ///
+  /// The return value is the intersection of the choices and diagnostics that are identical in
+  /// each result along with an additional diagnostic describing the ambiguity.
+  ///
+  /// - Requires: `result` contains at least two elements.
   private func formAmbiguousSolution<T>(
     _ results: Explorations<T>, diagnosedBy d: Diagnostic
   ) -> Solution {
-    var s = results.elements.reduce(into: Solution(), { (s, r) in s.formIntersection(r.solution) })
+    let (first, others) = results.elements.headAndTail!
+    var s = others.reduce(into: first.solution, { (s, r) in s.formIntersection(r.solution) })
     s.incorporate(d)
     return s
   }

--- a/Sources/FrontEnd/TypeChecking/Solution.swift
+++ b/Sources/FrontEnd/TypeChecking/Solution.swift
@@ -83,6 +83,7 @@ struct Solution {
   mutating func formIntersection(_ other: Self) {
     typeAssumptions.formIntersection(other.typeAssumptions)
     bindingAssumptions.formIntersection(other.bindingAssumptions)
+    diagnostics.formIntersection(other.diagnostics)
     penalties = max(penalties, other.penalties)
   }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/Overloading.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Overloading.hylo
@@ -39,5 +39,5 @@ public fun main() {
   check<Any>(x6)
 
   let a = 1
-  fn(a, a)    //! diagnostic ambiguous use of 'fn'
+  _ = fn(a, a) //! diagnostic ambiguous use of 'fn'
 }


### PR DESCRIPTION
Keep diagnostics that are common to all solutions when an ambiguity is detected during constraint solving.