### PR TITLE
Add support for parsing arbitrary test runner arguments

### DIFF
--- a/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
+++ b/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
@@ -2,8 +2,8 @@ import ArgumentParser
 import Foundation
 import Utils
 
-/// A command-line tool that generates XCTest cases for a list of annotated ".hylo"
-/// files as part of our build process.
+/// A command-line tool that generates XCTest cases for a list of annotated ".hylo" files as part
+/// of our build process.
 @main
 struct GenerateHyloFileTests: ParsableCommand {
 

--- a/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
+++ b/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
@@ -29,14 +29,14 @@ struct GenerateHyloFileTests: ParsableCommand {
     let parsed = try firstLine.parsedAsFirstLineOfAnnotatedHyloFileTest()
     let testID = source.deletingPathExtension().lastPathComponent.asSwiftIdentifier
 
-    return parsed.reduce(into: "") { (o, p) in
-      o += """
+    return parsed.reduce(into: "") { (swiftCode, test) in
+      let trailing = test.arguments.reduce(into: "", { (s, a) in s.write(", \(a)") })
+      swiftCode += """
 
-        func test_\(p.methodName)_\(testID)() throws {
-          try \(p.methodName)(
+        func test_\(test.methodName)_\(testID)() throws {
+          try \(test.methodName)(
             \(String(reflecting: source.fileSystemPath)),
-            extending: programToExtend!,
-            expectingSuccess: \(p.expectSuccess))
+            extending: programToExtend!\(trailing))
         }
 
       """
@@ -88,39 +88,105 @@ extension StringProtocol where Self.SubSequence == Substring {
   fileprivate func parsedAsFirstLineOfAnnotatedHyloFileTest() throws -> [TestDescription] {
     var text = self[...]
     if !text.removeLeading("//- ") {
-      throw FirstLineError("first line of annotated test file must begin with “//-”.")
+      throw FirstLineError("first line of annotated test file must begin with '//-'")
     }
 
-    let methodName = text.removeFirstUntil(it: \.isWhitespace)
-    if methodName.isEmpty {
-      throw FirstLineError("missing test method name.")
-    }
-    text.removeFirstWhile(it: \.isWhitespace)
-
-    if !text.removeLeading("expecting:") {
-      throw FirstLineError("missing “expecting:” after test method name.")
-    }
-    text.removeFirstWhile(it: \.isWhitespace)
-
-    let expectation = text.removeFirstUntil(it: \.isWhitespace)
-    if expectation != "success" && expectation != "failure" {
-      throw FirstLineError(
-        "illegal expectation “\(expectation)” must be “success” or “failure”."
-      )
-    }
-    let expectSuccess = expectation == "success"
-
-    if !text.drop(while: \.isWhitespace).isEmpty {
-      throw FirstLineError("illegal trailing text “\(text)”.")
+    let m = text.removeFirstUntil(it: \.isWhitespace)
+    guard let methodName = TestMethod(rawValue: String(m)) else {
+      let s = m.isEmpty ? "missing test method name" : "unknown test method '\(m)'"
+      throw FirstLineError(s)
     }
 
-    var tests = [TestDescription(methodName: methodName, expectSuccess: expectSuccess)]
-    if methodName == "compileAndRun" {
-      tests.append(
-        .init(methodName: "compileAndRunWithOptimizations", expectSuccess: expectSuccess))
+    var arguments: [TestArgument] = []
+    while !text.isEmpty {
+      // Parse a label.
+      text.removeFirstWhile(it: \.isWhitespace)
+      let l = text.removeFirstUntil(it: { $0 == ":" })
+      if l.isEmpty {
+        break
+      } else if !text.removeLeading(":") {
+        throw FirstLineError("missing colon after argument label")
+      }
+
+      // Parse a value.
+      text.removeFirstWhile(it: \.isWhitespace)
+      let v = text.removeFirstUntil(it: \.isWhitespace)
+      if v.isEmpty { throw FirstLineError("missing value after '\(l):'") }
+
+      if let a = TestArgument(l, v) {
+        arguments.append(a)
+      } else {
+        throw FirstLineError("invalid argument '\(l): \(v)'")
+      }
+    }
+
+    var tests = [TestDescription(methodName: methodName, arguments: arguments)]
+    if methodName == .compileAndRun {
+      tests.append(TestDescription(methodName: .compileAndRunOptimized, arguments: arguments))
     }
     return tests
   }
+
+}
+
+/// The name of a method implementing the logic of a test runner.
+fileprivate enum TestMethod: String {
+
+  /// Compiles and runs the program.
+  case compileAndRun
+
+  /// Compiles and runs the program with optimizations.
+  case compileAndRunOptimized
+
+  /// Compiles the program down to LLVM IR.
+  case compileToLLVM
+
+  /// Compiles the program down to Hylo IR.
+  case lowerToFinishedIR
+
+  /// Parses the program.
+  case parse
+
+  /// Type checks the program.
+  case typeCheck
+
+}
+
+/// An argument of a test runner.
+fileprivate struct TestArgument: CustomStringConvertible {
+
+  /// The label of an argument.
+  enum Label: String {
+
+    /// The label of an argument specifying the expected outcome of the test.
+    case expecting
+
+  }
+
+  /// The label of the argument.
+  let label: Label
+
+  /// The value of the argument.
+  let value: String
+
+  /// Creates an instance with the given properties or returns `nil` if the argument is invalid.
+  init?(_ label: Substring, _ value: Substring) {
+    // Validate the label.
+    guard let l = Label(rawValue: String(label)) else {
+      return nil
+    }
+
+    // Validate the value.
+    switch l {
+    case .expecting:
+      if (value != ".success") && (value != ".failure") { return nil }
+    }
+
+    self.label = l
+    self.value = String(value)
+  }
+
+  var description: String { "\(label): \(value)" }
 
 }
 
@@ -128,10 +194,10 @@ extension StringProtocol where Self.SubSequence == Substring {
 fileprivate struct TestDescription {
 
   /// The name of the method implementing the logic of the test runner.
-  let methodName: Substring
+  let methodName: TestMethod
 
-  /// `true` iff the invoked compilation is expected to succeed.
-  let expectSuccess: Bool
+  /// The arguments of the method.
+  let arguments: [TestArgument]
 
 }
 

--- a/Sources/TestUtils/LoweringTests.swift
+++ b/Sources/TestUtils/LoweringTests.swift
@@ -10,11 +10,11 @@ extension XCTestCase {
   /// that diagnostics and thrown errors match annotated expectations.
   @nonobjc
   public func lowerToFinishedIR(
-    _ hyloFilePath: String, extending p: TypedProgram, expectingSuccess expectSuccess: Bool
+    _ hyloFilePath: String, extending p: TypedProgram, expecting expectation: ExpectedTestOutcome
   ) throws {
 
     try checkAnnotatedHyloFileDiagnostics(
-      inFileAt: hyloFilePath, expectingSuccess: expectSuccess
+      inFileAt: hyloFilePath, expecting: expectation
     ) { (hyloSource, log) in
 
       let (p, m) = try p.loadModule(reportingDiagnosticsTo: &log) { (ast, log, space) in

--- a/Sources/TestUtils/ParseTest.swift
+++ b/Sources/TestUtils/ParseTest.swift
@@ -7,11 +7,11 @@ extension XCTestCase {
   /// errors match annotated expectations.
   @nonobjc
   public func parse(
-    _ hyloFilePath: String, extending p: TypedProgram, expectingSuccess expectSuccess: Bool
+    _ hyloFilePath: String, extending p: TypedProgram, expecting expectation: ExpectedTestOutcome
   ) throws {
 
     try checkAnnotatedHyloFileDiagnostics(
-      inFileAt: hyloFilePath, expectingSuccess: expectSuccess
+      inFileAt: hyloFilePath, expecting: expectation
     ) { (hyloSource, log) in
       var ast = AST()
       _ = try ast.loadModule(

--- a/Sources/TestUtils/TypeCheckerTests.swift
+++ b/Sources/TestUtils/TypeCheckerTests.swift
@@ -9,11 +9,11 @@ extension XCTestCase {
   /// errors match annotated expectations.
   @nonobjc
   public func typeCheck(
-    _ hyloFilePath: String, extending p: TypedProgram, expectingSuccess expectSuccess: Bool
+    _ hyloFilePath: String, extending p: TypedProgram, expecting expectation: ExpectedTestOutcome
   ) throws {
 
     try checkAnnotatedHyloFileDiagnostics(
-      inFileAt: hyloFilePath, expectingSuccess: expectSuccess
+      inFileAt: hyloFilePath, expecting: expectation
     ) { (hyloSource, log) in
       _ = try p.loadModule(reportingDiagnosticsTo: &log) { (ast, log, space) in
         try ast.loadModule(

--- a/Tests/EndToEndTests/TestCases/AddressOf.hylo
+++ b/Tests/EndToEndTests/TestCases/AddressOf.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   let x = 42

--- a/Tests/EndToEndTests/TestCases/Autoclosure.hylo
+++ b/Tests/EndToEndTests/TestCases/Autoclosure.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 let counter: Int = 0
 

--- a/Tests/EndToEndTests/TestCases/BoundParameter.hylo
+++ b/Tests/EndToEndTests/TestCases/BoundParameter.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 trait P { fun foo() -> Int }
 

--- a/Tests/EndToEndTests/TestCases/Break.hylo
+++ b/Tests/EndToEndTests/TestCases/Break.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   // Break from a do-while loop.

--- a/Tests/EndToEndTests/TestCases/BufferInitialization.hylo
+++ b/Tests/EndToEndTests/TestCases/BufferInitialization.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun use(_ x: Bool[2]) {}
 

--- a/Tests/EndToEndTests/TestCases/Concurrency/concurrent_greeting.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/concurrent_greeting.hylo
@@ -1,4 +1,4 @@
-//- compileToLLVM expecting: success
+//- compileToLLVM expecting: .success
 
 fun do_greet() -> Int {
   print("Hello, concurrent world!")

--- a/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 let size_threshold = 16
 

--- a/Tests/EndToEndTests/TestCases/Concurrency/escaping_spawn.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/escaping_spawn.hylo
@@ -1,4 +1,4 @@
-//- compileToLLVM expecting: success
+//- compileToLLVM expecting: .success
 
 // TODO: type-erasure for the future type
 fun do_spawn() -> EscapingFuture<{}> {

--- a/Tests/EndToEndTests/TestCases/Concurrency/mutating_spawn.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/mutating_spawn.hylo
@@ -1,4 +1,4 @@
-//- compileToLLVM expecting: success
+//- compileToLLVM expecting: .success
 
 
 fun test_mutating_spawn() -> Int {

--- a/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
+++ b/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun use<T>(_ x: T) {}
 

--- a/Tests/EndToEndTests/TestCases/CustomMove.hylo
+++ b/Tests/EndToEndTests/TestCases/CustomMove.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 type A: Deinitializable {
   public var witness: Int

--- a/Tests/EndToEndTests/TestCases/DefaultImplementation.hylo
+++ b/Tests/EndToEndTests/TestCases/DefaultImplementation.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public trait Eq {
   fun infix== (_ other: Self) -> Bool

--- a/Tests/EndToEndTests/TestCases/Destroy.hylo
+++ b/Tests/EndToEndTests/TestCases/Destroy.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   _ = 42

--- a/Tests/EndToEndTests/TestCases/Destructure.hylo
+++ b/Tests/EndToEndTests/TestCases/Destructure.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun triplet() -> {Int, Int, Int} {
   (1, 2, 3)

--- a/Tests/EndToEndTests/TestCases/ExhaustiveBranchReturns.hylo
+++ b/Tests/EndToEndTests/TestCases/ExhaustiveBranchReturns.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   _ = f()

--- a/Tests/EndToEndTests/TestCases/Existential.hylo
+++ b/Tests/EndToEndTests/TestCases/Existential.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun use<T>(_ x: T) {}
 

--- a/Tests/EndToEndTests/TestCases/ExplicitCaptures.hylo
+++ b/Tests/EndToEndTests/TestCases/ExplicitCaptures.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun apply<E>(_ f: [E]() -> Int) -> Int {
   f()

--- a/Tests/EndToEndTests/TestCases/Factorial.hylo
+++ b/Tests/EndToEndTests/TestCases/Factorial.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun factorial(_ n: Int) -> Int {
   if n < 2 { 1 } else { n * factorial(n - 1) }

--- a/Tests/EndToEndTests/TestCases/Fibonacci.hylo
+++ b/Tests/EndToEndTests/TestCases/Fibonacci.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun fibonacci(_ n: Int) -> Int {
   precondition(n >= 0, "domain error")

--- a/Tests/EndToEndTests/TestCases/GenericValueParameter.hylo
+++ b/Tests/EndToEndTests/TestCases/GenericValueParameter.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun foo<n: Int>() -> Int {
   n.copy()

--- a/Tests/EndToEndTests/TestCases/Geometry.hylo
+++ b/Tests/EndToEndTests/TestCases/Geometry.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 /// The space between two intersecting lines.
 public type Angle: Deinitializable {

--- a/Tests/EndToEndTests/TestCases/GlobalBinding.hylo
+++ b/Tests/EndToEndTests/TestCases/GlobalBinding.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   precondition((x + y) == 42)

--- a/Tests/EndToEndTests/TestCases/ImperativeSum.hylo
+++ b/Tests/EndToEndTests/TestCases/ImperativeSum.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   var a = Array<Int>()

--- a/Tests/EndToEndTests/TestCases/Implicits.hylo
+++ b/Tests/EndToEndTests/TestCases/Implicits.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun foo(x?: let Int) -> Int { bar() }
 

--- a/Tests/EndToEndTests/TestCases/Lambda.hylo
+++ b/Tests/EndToEndTests/TestCases/Lambda.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun apply<E>(_ f: inout ([E]() inout -> Int)) -> Int {
   &f()

--- a/Tests/EndToEndTests/TestCases/LocalInout.hylo
+++ b/Tests/EndToEndTests/TestCases/LocalInout.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 extension Int {
 

--- a/Tests/EndToEndTests/TestCases/MemoryLayout.hylo
+++ b/Tests/EndToEndTests/TestCases/MemoryLayout.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 type Vector2 {
 

--- a/Tests/EndToEndTests/TestCases/MethodBundle.hylo
+++ b/Tests/EndToEndTests/TestCases/MethodBundle.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 type A: Deinitializable {
 

--- a/Tests/EndToEndTests/TestCases/Monomorphize.hylo
+++ b/Tests/EndToEndTests/TestCases/Monomorphize.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun poly<T>(_ x: T) -> Int { 0 }
 

--- a/Tests/EndToEndTests/TestCases/MonomorphizeRequirements.hylo
+++ b/Tests/EndToEndTests/TestCases/MonomorphizeRequirements.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 trait P {
   fun f() -> Int

--- a/Tests/EndToEndTests/TestCases/MonomorphizeSynthesizedImplementation.hylo
+++ b/Tests/EndToEndTests/TestCases/MonomorphizeSynthesizedImplementation.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 trait A {
   type P: Regular

--- a/Tests/EndToEndTests/TestCases/NestedGeneric.hylo
+++ b/Tests/EndToEndTests/TestCases/NestedGeneric.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 type A<T>: Deinitializable {
   public let x: Int

--- a/Tests/EndToEndTests/TestCases/Pointer.hylo
+++ b/Tests/EndToEndTests/TestCases/Pointer.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   let q = PointerToMutable<Int>.allocate(count: 1)

--- a/Tests/EndToEndTests/TestCases/Pragma.hylo
+++ b/Tests/EndToEndTests/TestCases/Pragma.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun f(_ f: sink Int = #line) -> Int { f }
 

--- a/Tests/EndToEndTests/TestCases/Puning.hylo
+++ b/Tests/EndToEndTests/TestCases/Puning.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   let x = 42

--- a/Tests/EndToEndTests/TestCases/RemotePart.hylo
+++ b/Tests/EndToEndTests/TestCases/RemotePart.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun inefficient_eq(_ x: Int, _ y: Int) {
   precondition(x - y == 0)

--- a/Tests/EndToEndTests/TestCases/Subscript.hylo
+++ b/Tests/EndToEndTests/TestCases/Subscript.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 type A: Deinitializable {
 

--- a/Tests/EndToEndTests/TestCases/SubscriptFree.hylo
+++ b/Tests/EndToEndTests/TestCases/SubscriptFree.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 subscript foo(): Int { 42 }
 

--- a/Tests/EndToEndTests/TestCases/SubscriptRvalue.hylo
+++ b/Tests/EndToEndTests/TestCases/SubscriptRvalue.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 type A: Deinitializable {
 

--- a/Tests/EndToEndTests/TestCases/SubscriptWithArgument.hylo
+++ b/Tests/EndToEndTests/TestCases/SubscriptWithArgument.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public type A: Deinitializable {
 

--- a/Tests/EndToEndTests/TestCases/SyntheticCopy.hylo
+++ b/Tests/EndToEndTests/TestCases/SyntheticCopy.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 type A: Regular {
   public var x: Optional<Int>

--- a/Tests/EndToEndTests/TestCases/TraitExtension.hylo
+++ b/Tests/EndToEndTests/TestCases/TraitExtension.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 trait Copier {
   type Original: Copyable

--- a/Tests/EndToEndTests/TestCases/TraitMemberDispatch.hylo
+++ b/Tests/EndToEndTests/TestCases/TraitMemberDispatch.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 // This program tests the dispatch behavior of calls to trait members. `P` declares a single
 // requirement `f` that is given a default implementation. Two conformances to `P` are defined:

--- a/Tests/EndToEndTests/TestCases/TupleKeyPath.hylo
+++ b/Tests/EndToEndTests/TestCases/TupleKeyPath.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public type A: Deinitializable, Movable {
   public memberwise init

--- a/Tests/EndToEndTests/TestCases/UnionNarrowing.hylo
+++ b/Tests/EndToEndTests/TestCases/UnionNarrowing.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   var x: Union<{a: Bool}, {b: Int}> = (b: 42)

--- a/Tests/EndToEndTests/TestCases/UnionOperations.hylo
+++ b/Tests/EndToEndTests/TestCases/UnionOperations.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun modify<T>(_ x: inout T) {}
 

--- a/Tests/HyloTests/TestCases/Lowering/Assignment.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Assignment.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 public fun main() {
   var x = 0

--- a/Tests/HyloTests/TestCases/Lowering/BindingEscape.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/BindingEscape.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 fun f() -> Int {
   let x = 0

--- a/Tests/HyloTests/TestCases/Lowering/BuiltinFunction.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/BuiltinFunction.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 public fun main() {
   _ = Builtin.zeroinitializer_i64()

--- a/Tests/HyloTests/TestCases/Lowering/Cast.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Cast.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 type A: Deinitializable {
   public memberwise init

--- a/Tests/HyloTests/TestCases/Lowering/DI.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/DI.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 fun read<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/Lowering/DefaultArgument.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/DefaultArgument.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 fun f0(x: Int, y: Bool = true) {}
 

--- a/Tests/HyloTests/TestCases/Lowering/Deinit.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Deinit.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 fun use<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/Lowering/EmptyStruct.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/EmptyStruct.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 public type Foo {
   public init() { }

--- a/Tests/HyloTests/TestCases/Lowering/Factorial.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Factorial.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 fun factorial(_ n: Int) -> Int {
   if n < 2 { 1 } else { n * factorial(n - 1) }

--- a/Tests/HyloTests/TestCases/Lowering/Identity.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Identity.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 fun identity<T: Movable>(_ x: sink T) -> T {
   x

--- a/Tests/HyloTests/TestCases/Lowering/IllegalMove.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/IllegalMove.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 // Note that some missing conformances to `Movable` can't be caught before we've emitted refined IR
 // because must determine whether values can be constructed in place, which typically can't be done

--- a/Tests/HyloTests/TestCases/Lowering/IllegalMutation.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/IllegalMutation.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 fun inc(_ x: Int) {
   //! @+1 diagnostic illegal mutable access

--- a/Tests/HyloTests/TestCases/Lowering/ImplicitReturn.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/ImplicitReturn.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 fun f0() -> Int {
   if true { 42 } else { 1337 }

--- a/Tests/HyloTests/TestCases/Lowering/Init.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Init.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 type A {
   var value: Float64

--- a/Tests/HyloTests/TestCases/Lowering/InvalidRvalue.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/InvalidRvalue.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 subscript s(_ x: Int): Int {
   let { yield x }

--- a/Tests/HyloTests/TestCases/Lowering/Loops.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Loops.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 fun foo() {}
 

--- a/Tests/HyloTests/TestCases/Lowering/MemberLambda.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/MemberLambda.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 // This test ensures that the emitter is capable of dstinguishing a call to a member method from a
 // call to a member property with a lambda type.

--- a/Tests/HyloTests/TestCases/Lowering/Methods.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Methods.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 extension Int {
   public fun foo() let -> Int { copy() }

--- a/Tests/HyloTests/TestCases/Lowering/MissingDeinit.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/MissingDeinit.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 type A {
   public memberwise init

--- a/Tests/HyloTests/TestCases/Lowering/NeverReturning.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/NeverReturning.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 public fun f() -> Int {
   _ = 1

--- a/Tests/HyloTests/TestCases/Lowering/NumericLiteral.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/NumericLiteral.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 public fun main() {
   let _: Int = 1

--- a/Tests/HyloTests/TestCases/Lowering/Ownership.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Ownership.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 fun read<T>(_ x: T) {}
 fun modify<T>(_ x: inout T) {}

--- a/Tests/HyloTests/TestCases/Lowering/Ownership2.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Ownership2.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 type A: Deinitializable {
   public var x: Int

--- a/Tests/HyloTests/TestCases/Lowering/ParameterEscape.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/ParameterEscape.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 fun f0(_ x: sink Int) -> Int { x }
 

--- a/Tests/HyloTests/TestCases/Lowering/ParameterSet.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/ParameterSet.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 fun f0(_ x: set Int) { &x = 0 }
 

--- a/Tests/HyloTests/TestCases/Lowering/ProjectionEscape.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/ProjectionEscape.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 public type A: Deinitializable {
   public var guts: Int

--- a/Tests/HyloTests/TestCases/Lowering/ReturnInSubscript.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/ReturnInSubscript.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: failure
+//- lowerToFinishedIR expecting: .failure
 
 public subscript s(x: Int): Int {
   //! @+1 diagnostic return statement in subscript

--- a/Tests/HyloTests/TestCases/Lowering/Sink.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Sink.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 fun eat<T: Movable & Deinitializable>(_ x: sink T) {
   _ = x

--- a/Tests/HyloTests/TestCases/Lowering/StructuralConformance.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/StructuralConformance.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 public type A: Deinitializable, Movable {
   public memberwise init

--- a/Tests/HyloTests/TestCases/Lowering/Tuple.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Tuple.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 fun use<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/Lowering/Unused.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Unused.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 fun use<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/Lowering/Upcast.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Upcast.hylo
@@ -1,4 +1,4 @@
-//- lowerToFinishedIR expecting: success
+//- lowerToFinishedIR expecting: .success
 
 public fun main() {
   var x: Optional<Int> = None()

--- a/Tests/HyloTests/TestCases/Parsing/ArgumentLists.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/ArgumentLists.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 public fun main() {
   ; foo(1 1)  //! diagnostic expected ',' separator

--- a/Tests/HyloTests/TestCases/Parsing/BindingDecl.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/BindingDecl.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 let x0: Int
 

--- a/Tests/HyloTests/TestCases/Parsing/ConditionalExpr.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/ConditionalExpr.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: success
+//- parse expecting: .success
 
 public fun main() {
   _ = if a { () } else { () }

--- a/Tests/HyloTests/TestCases/Parsing/ConditionalStmt.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/ConditionalStmt.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: success
+//- parse expecting: .success
 
 public fun main() {
   if a {}

--- a/Tests/HyloTests/TestCases/Parsing/DeclModifiers.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/DeclModifiers.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 type A0 {
 

--- a/Tests/HyloTests/TestCases/Parsing/IllegalImplicit.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/IllegalImplicit.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 //! @+1 diagnostic 'inout'-parameter cannot be implicit
 fun bar(x?: inout Int) -> Int { x.copy() }

--- a/Tests/HyloTests/TestCases/Parsing/IllegalTypealias.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/IllegalTypealias.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 //! @+1 diagnostic declaration requires definition
 typealias X: Y = Z

--- a/Tests/HyloTests/TestCases/Parsing/MatchExpr.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/MatchExpr.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 public fun main() {
   match true {

--- a/Tests/HyloTests/TestCases/Parsing/MemberwiseInit.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/MemberwiseInit.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 type A {
   var x: Int

--- a/Tests/HyloTests/TestCases/Parsing/MethodDecl.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/MethodDecl.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 type A0 {
 

--- a/Tests/HyloTests/TestCases/Parsing/NumberFollowedByEBlockCommentInBetween.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/NumberFollowedByEBlockCommentInBetween.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: success
+//- parse expecting: .success
 
 public fun main() {
   var x = 0 /*hello*/

--- a/Tests/HyloTests/TestCases/Parsing/NumberFollowedByELineCommentInBetween.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/NumberFollowedByELineCommentInBetween.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: success
+//- parse expecting: .success
 
 public fun main() {
   var x = 0 //hello

--- a/Tests/HyloTests/TestCases/Parsing/NumberFollowedByEOnNewLine.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/NumberFollowedByEOnNewLine.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: success
+//- parse expecting: .success
 
 public fun main() {
   var x = 0

--- a/Tests/HyloTests/TestCases/Parsing/NumberFollowedByESemiInBetween.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/NumberFollowedByESemiInBetween.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: success
+//- parse expecting: .success
 
 public fun main() {
   var x = 0; eat(x)

--- a/Tests/HyloTests/TestCases/Parsing/NumberWithEInvalid.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/NumberWithEInvalid.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 let x0 = 1e1
 

--- a/Tests/HyloTests/TestCases/Parsing/ParameterDecl.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/ParameterDecl.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 fun f1(x) -> U {}       //! diagnostic missing type annotation
 

--- a/Tests/HyloTests/TestCases/Parsing/Pragma.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/Pragma.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 //! @+1 diagnostic unknown pragma 'unknown'
 let x: Int = #unknown

--- a/Tests/HyloTests/TestCases/Parsing/Semicolons.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/Semicolons.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: success
+//- parse expecting: .success
 
 ;;
 import Foo;

--- a/Tests/HyloTests/TestCases/Parsing/StructDecl.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/StructDecl.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 // Empty struct.
 type A0 {}

--- a/Tests/HyloTests/TestCases/Parsing/SubscriptDecl.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/SubscriptDecl.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 type A0 {
 

--- a/Tests/HyloTests/TestCases/Parsing/UnterminatedComment.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/UnterminatedComment.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 //! @+1 diagnostic unterminated comment
 /* This block never ends

--- a/Tests/HyloTests/TestCases/Parsing/UnterminatedNestedComment.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/UnterminatedNestedComment.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 //! @+1 diagnostic unterminated comment
 /* This block never ends

--- a/Tests/HyloTests/TestCases/Parsing/UnterminatedString.hylo
+++ b/Tests/HyloTests/TestCases/Parsing/UnterminatedString.hylo
@@ -1,4 +1,4 @@
-//- parse expecting: failure
+//- parse expecting: .failure
 
 //! @+1 diagnostic unterminated string
 "This string never ends

--- a/Tests/HyloTests/TestCases/TypeChecking/AccessModifiers.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/AccessModifiers.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A: Deinitializable {
   public memberwise init

--- a/Tests/HyloTests/TestCases/TypeChecking/ArgumentLabels.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ArgumentLabels.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 // This test case ensures that arguments labels are used to disambiguate overloaded symbols in call
 // expressions, in order to get more precise diagnostics.

--- a/Tests/HyloTests/TestCases/TypeChecking/Assignment.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Assignment.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 public fun main() {
   var x = 0

--- a/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypeLookup.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypeLookup.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 trait T { type X }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypesWithConformances.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/AssociatedTypesWithConformances.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait P { type Z }
 trait Q { type Y }

--- a/Tests/HyloTests/TestCases/TypeChecking/BindingTypeInference.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/BindingTypeInference.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 let x0 = ()
 let (y0, y1) = ((), ())

--- a/Tests/HyloTests/TestCases/TypeChecking/BindingTypeInferenceWithHints.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/BindingTypeInferenceWithHints.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/BodylessDecl.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/BodylessDecl.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 //! @+1 diagnostic declaration requires a body
 fun f()

--- a/Tests/HyloTests/TestCases/TypeChecking/CallFunction.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallFunction.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun f(_ x: sink {}) -> {} { x }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/CallGenericFunction.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallGenericFunction.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 trait P { fun foo() }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/CallGenericUnnamedSubscript.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallGenericUnnamedSubscript.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A {
 

--- a/Tests/HyloTests/TestCases/TypeChecking/CallInit.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallInit.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A: Movable {
 

--- a/Tests/HyloTests/TestCases/TypeChecking/CallMemberwiseInit.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallMemberwiseInit.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A {
   var foo: Int

--- a/Tests/HyloTests/TestCases/TypeChecking/CallNonCallable.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallNonCallable.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 public fun main() {
   let forty_two = 42

--- a/Tests/HyloTests/TestCases/TypeChecking/CallOperator.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallOperator.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 public fun main() {
   let a = 42

--- a/Tests/HyloTests/TestCases/TypeChecking/CallStaticFunction.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CallStaticFunction.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A {
 

--- a/Tests/HyloTests/TestCases/TypeChecking/CastDown.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CastDown.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 public fun main() {
   let a: Any = ()

--- a/Tests/HyloTests/TestCases/TypeChecking/CastUp.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CastUp.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/CircularRefinement.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/CircularRefinement.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 //! @+1 diagnostic circular trait refinement
 trait T: U {}

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalExpr.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalExpr.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 trait T {
   fun foo()

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension2.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalExtension2.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait P { type X }
 trait Q { type Y }

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalStmt.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalStmt.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun use(_ x: Bool) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/Conformance.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Conformance.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 trait P {
   fun f()

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceGeneric.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceGeneric.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait T {
   fun foo()

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceStructural.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceStructural.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 //! @+1 diagnostic type 'A<T>' does not conform to trait 'Deinitializable'
 type A<T>: Deinitializable {

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithAssociatedType.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithAssociatedType.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait P {
   type X

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithGenericRequirement.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithGenericRequirement.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait P {
   fun red<T>(_ x: T) -> Int

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithPrivateImpl.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithPrivateImpl.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 // Implementations of the requirements of a trait `P` in a type `A` must be exposed to the same
 // scopes as the conformance `A : P`.

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithRefinement.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithRefinement.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait P: Regular {
   property n: Int { let }

--- a/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithSubscript.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConformanceWithSubscript.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait P {
   type X

--- a/Tests/HyloTests/TestCases/TypeChecking/Constructor.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Constructor.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type Message {
 

--- a/Tests/HyloTests/TestCases/TypeChecking/DefaultArgument.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/DefaultArgument.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A { public memberwise init }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/DefaultAssociatedType.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/DefaultAssociatedType.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait T {
   type U = Int

--- a/Tests/HyloTests/TestCases/TypeChecking/Destructuring.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Destructuring.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/DoWhile.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/DoWhile.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 public fun main() {
   do {

--- a/Tests/HyloTests/TestCases/TypeChecking/DuplicateCapture.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/DuplicateCapture.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 public fun main() {
   let x = 0

--- a/Tests/HyloTests/TestCases/TypeChecking/DuplicateFunctionParameter.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/DuplicateFunctionParameter.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 //! @+1 diagnostic duplicate parameter name 'a'
 fun f0(_ a: {}, _ a: {}) {}

--- a/Tests/HyloTests/TestCases/TypeChecking/DuplicateOperatorDecl.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/DuplicateOperatorDecl.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 operator prefix-*
 operator infix-* : addition

--- a/Tests/HyloTests/TestCases/TypeChecking/Existential.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Existential.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 trait P1 {}
 trait P2 {}

--- a/Tests/HyloTests/TestCases/TypeChecking/ExistentialGenericAPI.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ExistentialGenericAPI.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type A<X> {
   public memberwise init

--- a/Tests/HyloTests/TestCases/TypeChecking/ExistentialTraitAPI.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ExistentialTraitAPI.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 trait T {
   fun foo() -> Int

--- a/Tests/HyloTests/TestCases/TypeChecking/ExplicitCapture.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ExplicitCapture.hylo
@@ -1,3 +1,3 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun f0[sink let x = ()]() {}

--- a/Tests/HyloTests/TestCases/TypeChecking/ExtensionIllegal.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ExtensionIllegal.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 trait T {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/ExtensionOfImport.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ExtensionOfImport.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 extension Float64 {
   public static fun gravity() -> Float64 { 9.81 }

--- a/Tests/HyloTests/TestCases/TypeChecking/FloatLiteralExpr.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/FloatLiteralExpr.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/For.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/For.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type Counter: Iterator, Deinitializable {
   public var n: Int

--- a/Tests/HyloTests/TestCases/TypeChecking/FunctionIdentity.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/FunctionIdentity.hylo
@@ -1,3 +1,3 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 public fun identity<T>(_ x: sink T) -> T { x }

--- a/Tests/HyloTests/TestCases/TypeChecking/FunctionTrivial.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/FunctionTrivial.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun f0() {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/GenericArguments.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/GenericArguments.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type Box<X> {
   public var contents: X

--- a/Tests/HyloTests/TestCases/TypeChecking/GenericEnvironment.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/GenericEnvironment.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait P {
   type Element

--- a/Tests/HyloTests/TestCases/TypeChecking/GenericParameters.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/GenericParameters.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 //! @+1 diagnostic expected type but 'v' denotes a value
 fun f0<X, v: Int>(_ x: X, _ y: v) {}

--- a/Tests/HyloTests/TestCases/TypeChecking/GenericTypeAlias.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/GenericTypeAlias.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 typealias Pair<X, Y> = { first: X, second: Y }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/IllegalExtension.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/IllegalExtension.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 //! @+1 diagnostic expected type but expression denotes a value
 extension true {}

--- a/Tests/HyloTests/TestCases/TypeChecking/ImplicitImmutableCapture.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ImplicitImmutableCapture.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun main() {
   let foo = ()

--- a/Tests/HyloTests/TestCases/TypeChecking/ImplicitMutableCapture.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ImplicitMutableCapture.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun main() {
   var foo = ()

--- a/Tests/HyloTests/TestCases/TypeChecking/ImplicitQualification.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ImplicitQualification.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type A: Deinitializable {
 

--- a/Tests/HyloTests/TestCases/TypeChecking/Import.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Import.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 import Hylo
 import Import   //! diagnostic needless import: source file is part of 'Import'

--- a/Tests/HyloTests/TestCases/TypeChecking/InoutExpr.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/InoutExpr.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type A {
   public memberwise init

--- a/Tests/HyloTests/TestCases/TypeChecking/IntegerLiteralExpr.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/IntegerLiteralExpr.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/InvalidAnnotation.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/InvalidAnnotation.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A<T> {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/LambdaCoercion.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/LambdaCoercion.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun apply_immutable<E>(_ f: ([E]() -> Void)) { f() }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/LambdaTypeInference.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/LambdaTypeInference.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/LocalBindings.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/LocalBindings.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 public fun main() {
   sink let x: Int

--- a/Tests/HyloTests/TestCases/TypeChecking/MatchExpr.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/MatchExpr.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 public fun main() {
   let a = 42 as Any

--- a/Tests/HyloTests/TestCases/TypeChecking/MetatypeType.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/MetatypeType.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A {}
 type B {}

--- a/Tests/HyloTests/TestCases/TypeChecking/MethodBundle.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/MethodBundle.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookup.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookup.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type A<X>: Movable, Deinitializable {
   public memberwise init

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric2.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric2.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait DefaultConstructible {
   init()

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric3.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric3.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 // This test ensures that the type checker is able to determine the kind of a generic parameter
 // introduced in a member of a trait extension. Name lookup is a little tricky in this situation

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupLabels.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupLabels.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun add(x: Int, y: Int) -> Int {
   x + y

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupViaTraitExtension.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupViaTraitExtension.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait P { fun foo() }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupWithAlias.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupWithAlias.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 public type X {
   public let a: Int = 32

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupWithDottedPath.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupWithDottedPath.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type Item: SemiRegular {
 

--- a/Tests/HyloTests/TestCases/TypeChecking/NestedGenerics.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NestedGenerics.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type M<T: Deinitializable> {
   public var x: T

--- a/Tests/HyloTests/TestCases/TypeChecking/Overloading.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Overloading.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/Property.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Property.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type A: Deinitializable {
   public memberwise init

--- a/Tests/HyloTests/TestCases/TypeChecking/RecursiveConstraints.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/RecursiveConstraints.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun use<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/RecursiveParameter.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/RecursiveParameter.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 //! @+3 diagnostic definition recursively depends on itself
 //! @+2 diagnostic undefined name 'x' in this scope

--- a/Tests/HyloTests/TestCases/TypeChecking/RemoteExpr.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/RemoteExpr.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/Return.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Return.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun forty_two() -> Int { return 42 }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/Shadowing.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Shadowing.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun foo(_ x: Int) -> Bool { true }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/Skolemization.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/Skolemization.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 type A<X> {
   public memberwise init

--- a/Tests/HyloTests/TestCases/TypeChecking/StoredPropertyDecl.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/StoredPropertyDecl.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A {
 

--- a/Tests/HyloTests/TestCases/TypeChecking/StringLiteralExpr.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/StringLiteralExpr.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/TraitDecl.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/TraitDecl.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 trait T {
 

--- a/Tests/HyloTests/TestCases/TypeChecking/TraitExtension.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/TraitExtension.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 trait T {
   fun foo() -> Int

--- a/Tests/HyloTests/TestCases/TypeChecking/TupleMembers.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/TupleMembers.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 fun check<T>(_ x: T) {}
 

--- a/Tests/HyloTests/TestCases/TypeChecking/UndefinedOperator.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/UndefinedOperator.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 public fun main() {
   //! @+1 diagnostic undefined operator '&&&'

--- a/Tests/HyloTests/TestCases/TypeChecking/UnionType.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/UnionType.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 public fun main() {
   // Standard cases.

--- a/Tests/HyloTests/TestCases/TypeChecking/UnionTypeGeneric.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/UnionTypeGeneric.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 typealias MysteryBox<T> = Union<A<T>, B<T>>
 

--- a/Tests/HyloTests/TestCases/TypeChecking/UnresolvedUnnamedSubscript.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/UnresolvedUnnamedSubscript.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A { public memberwise init }
 

--- a/Tests/HyloTests/TestCases/TypeChecking/UnusedResult.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/UnusedResult.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: success
+//- typeCheck expecting: .success
 
 fun f() -> Int {
   1 + 1         //! diagnostic unused result of type 'Int'

--- a/Tests/HyloTests/TestCases/TypeChecking/WhereClause.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/WhereClause.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 type A<X>: Deinitializable {
   public memberwise init

--- a/Tests/HyloTests/TestCases/TypeChecking/While.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/While.hylo
@@ -1,4 +1,4 @@
-//- typeCheck expecting: failure
+//- typeCheck expecting: .failure
 
 public fun main() {
   var x = true

--- a/Tests/LibraryTests/TestCases/ArrayTests.hylo
+++ b/Tests/LibraryTests/TestCases/ArrayTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun test_init_empty() {
   var d = Array<Int>()

--- a/Tests/LibraryTests/TestCases/BitArrayTests.hylo
+++ b/Tests/LibraryTests/TestCases/BitArrayTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun test_modify() {
   var b = BitArray()

--- a/Tests/LibraryTests/TestCases/BoolTests.hylo
+++ b/Tests/LibraryTests/TestCases/BoolTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   // Bool.init(), infix==, infix!=

--- a/Tests/LibraryTests/TestCases/CollectionOfOneTests.hylo
+++ b/Tests/LibraryTests/TestCases/CollectionOfOneTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   let c = CollectionOfOne(42)

--- a/Tests/LibraryTests/TestCases/CollectionTests.hylo
+++ b/Tests/LibraryTests/TestCases/CollectionTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun test_reduce() {
   var a = Array<Int>()

--- a/Tests/LibraryTests/TestCases/DynamicBufferTests.hylo
+++ b/Tests/LibraryTests/TestCases/DynamicBufferTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun test_init_empty() {
   var d = DynamicBuffer<Int, Int>()

--- a/Tests/LibraryTests/TestCases/HeapTests.hylo
+++ b/Tests/LibraryTests/TestCases/HeapTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   let p = hylo_aligned_alloc(16, 8)

--- a/Tests/LibraryTests/TestCases/IntTests.hylo
+++ b/Tests/LibraryTests/TestCases/IntTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun test_min() {
   precondition(min[1, 2] == 1)

--- a/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
+++ b/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 /// Appends `0 ..< limit` to `a`
 fun append_count(up_to limit: Int, to a: inout Array<Int>) {

--- a/Tests/LibraryTests/TestCases/OptionalTests.hylo
+++ b/Tests/LibraryTests/TestCases/OptionalTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun main() {
   var x = 42 as Optional<Int>

--- a/Tests/LibraryTests/TestCases/PointerToMutableTests.hylo
+++ b/Tests/LibraryTests/TestCases/PointerToMutableTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 fun test_advance() {
   var c = PointerToMutable<Never>.allocate_bytes(

--- a/Tests/LibraryTests/TestCases/RangeTests.hylo
+++ b/Tests/LibraryTests/TestCases/RangeTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public fun test_conformance_to_iterator() {
   var r = 1 ..< 3

--- a/Tests/LibraryTests/TestCases/StrideableTests.hylo
+++ b/Tests/LibraryTests/TestCases/StrideableTests.hylo
@@ -1,4 +1,4 @@
-//- compileAndRun expecting: success
+//- compileAndRun expecting: .success
 
 public type A: Deinitializable, Strideable {
 


### PR DESCRIPTION
This PR is in preparation for future changes in the test generation framework.