### PR TITLE
Add && and || operators to compile-time compilation conditions

### DIFF
--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -55,7 +55,8 @@ public struct LLVMProgram {
   /// to `directory`, returning the URL of each written file.
   ///
   /// - Returns: The URL of each written product, one for each module in `self`.
-  public func write(_ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL) throws -> [URL] {
+  public func write(_ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL) throws -> [URL]
+  {
     precondition(directory.hasDirectoryPath)
     var result: [URL] = []
     for m in llvmModules.values {

--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -55,8 +55,9 @@ public struct LLVMProgram {
   /// to `directory`, returning the URL of each written file.
   ///
   /// - Returns: The URL of each written product, one for each module in `self`.
-  public func write(_ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL) throws -> [URL]
-  {
+  public func write(
+    _ type: SwiftyLLVM.CodeGenerationResultType, to directory: URL
+  ) throws -> [URL] {
     precondition(directory.hasDirectoryPath)
     var result: [URL] = []
     for m in llvmModules.values {

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -322,7 +322,8 @@ extension SwiftyLLVM.Module {
     if !implementations.isEmpty {
       tableContents.append(
         SwiftyLLVM.ArrayConstant(
-          of: SwiftyLLVM.StructType([word(), ptr], in: &self), containing: implementations, in: &self))
+          of: SwiftyLLVM.StructType([word(), ptr], in: &self), containing: implementations,
+          in: &self))
     }
 
     let table = SwiftyLLVM.StructConstant(aggregating: tableContents, in: &self)
@@ -927,42 +928,48 @@ extension SwiftyLLVM.Module {
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.sadd.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .unsignedAdditionWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.uadd.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .signedSubtractionWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.ssub.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .unsignedSubtractionWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.usub.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .signedMultiplicationWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.smul.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .unsignedMultiplicationWithOverflow(let t):
         let l = llvm(s.operands[0])
         let r = llvm(s.operands[1])
         let f = intrinsic(
           named: Intrinsic.llvm.umul.with.overflow, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [l, r], at: insertionPoint)
 
       case .icmp(let p, _):
         let l = llvm(s.operands[0])
@@ -1046,7 +1053,8 @@ extension SwiftyLLVM.Module {
       case .ctpop(let t):
         let source = llvm(s.operands[0])
         let f = intrinsic(named: Intrinsic.llvm.ctpop, for: [ir.llvm(builtinType: t, in: &self)])!
-        register[.register(i)] = insertCall(SwiftyLLVM.Function(f)!, on: [source], at: insertionPoint)
+        register[.register(i)] = insertCall(
+          SwiftyLLVM.Function(f)!, on: [source], at: insertionPoint)
 
       case .ctlz(let t):
         let source = llvm(s.operands[0])

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -82,9 +82,9 @@ extension IR.Program {
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module)
-    -> SwiftyLLVM.IRType
-  {
+  func llvm(
+    boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module
+  ) -> SwiftyLLVM.IRType {
     precondition(val[.isCanonical])
 
     let fields = base.storage(of: val.base).map { (part) in

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -82,7 +82,9 @@ extension IR.Program {
   /// Returns the LLVM form of `val` in `module`.
   ///
   /// - Requires: `val` is representable in LLVM.
-  func llvm(boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module) -> SwiftyLLVM.IRType {
+  func llvm(boundGenericType val: BoundGenericType, in module: inout SwiftyLLVM.Module)
+    -> SwiftyLLVM.IRType
+  {
     precondition(val[.isCanonical])
 
     let fields = base.storage(of: val.base).map { (part) in

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -3,8 +3,8 @@ import CodeGenLLVM
 import Foundation
 import FrontEnd
 import IR
-import SwiftyLLVM
 import StandardLibrary
+import SwiftyLLVM
 import Utils
 
 public struct Driver: ParsableCommand {

--- a/Sources/FrontEnd/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/FrontEnd/AST/Stmt/ConditionalCompilationStmt.swift
@@ -69,6 +69,10 @@ public struct ConditionalCompilationStmt: Stmt {
         return true
       case .not(let c):
         return c.mayNotNeedParsing
+      case .and(let l, let r):
+        return l.mayNotNeedParsing && r.mayNotNeedParsing
+      case .or(let l, let r):
+        return l.mayNotNeedParsing || r.mayNotNeedParsing
       default:
         return false
       }

--- a/Sources/FrontEnd/AST/Stmt/ConditionalCompilationStmt.swift
+++ b/Sources/FrontEnd/AST/Stmt/ConditionalCompilationStmt.swift
@@ -94,22 +94,29 @@ public struct ConditionalCompilationStmt: Stmt {
 
   }
 
-  /// Abstracts the whole condition structure and its sub-conditions.
+  /// A condition in a conditional compilation statement expressed as a composition of predicates.
   public indirect enum ConditionTree: Codable {
 
+    /// A proposition or the negation of a proposition.
     case operand(Condition)
 
+    /// A conjunction of conditions.
     case and(ConditionTree, ConditionTree)
 
+    /// A disjunction of conditions.
     case or(ConditionTree, ConditionTree)
 
     public enum ConditionKind: String {
+
       case holdOnly
+
       case skipMain
+
       case skipElse
+
     }
 
-    /// Visit the SequenceCondition tail to calculate the right case for executing the right branch.
+    /// Visits the SequenceCondition tail to calculate the right case for executing the right branch.
     private func unroll(
       for factors: ConditionalCompilationFactors, conditionCase: ConditionKind
     ) -> Bool {
@@ -131,17 +138,17 @@ public struct ConditionalCompilationStmt: Stmt {
       }
     }
 
-    /// Return `true` iff the the full condition is satisfied.
+    /// Returns `true` iff the condition is satisfied.
     public func mustSkipMainBranch(for factors: ConditionalCompilationFactors) -> Bool {
       self.unroll(for: factors, conditionCase: ConditionKind.skipMain)
     }
 
-    /// Return `true` iff the the full condition is unsatisfied.
+    /// Returns `true` iff the condition is not unsatisfied.
     public func mustSkipElseBranch(for factors: ConditionalCompilationFactors) -> Bool {
       self.unroll(for: factors, conditionCase: ConditionKind.skipElse)
     }
 
-    /// Return `true` iff the the full condition is satisfied.
+    /// Returns `true` iff the the condition is satisfied.
     fileprivate func holds(for factors: ConditionalCompilationFactors) -> Bool {
       self.unroll(for: factors, conditionCase: ConditionKind.holdOnly)
     }

--- a/Sources/FrontEnd/BuiltinFunction.swift
+++ b/Sources/FrontEnd/BuiltinFunction.swift
@@ -352,8 +352,9 @@ private func mathFlags(_ stream: inout ArraySlice<Substring>) -> NativeInstructi
 }
 
 /// Returns an overflow behavior parsed from `stream` or `.ignore` if none can be parsed.
-private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> SwiftyLLVM.OverflowBehavior
-{
+private func overflowBehavior(
+  _ stream: inout ArraySlice<Substring>
+) -> SwiftyLLVM.OverflowBehavior {
   switch stream.first {
   case "nuw":
     stream.removeFirst()

--- a/Sources/FrontEnd/BuiltinFunction.swift
+++ b/Sources/FrontEnd/BuiltinFunction.swift
@@ -352,7 +352,8 @@ private func mathFlags(_ stream: inout ArraySlice<Substring>) -> NativeInstructi
 }
 
 /// Returns an overflow behavior parsed from `stream` or `.ignore` if none can be parsed.
-private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> SwiftyLLVM.OverflowBehavior {
+private func overflowBehavior(_ stream: inout ArraySlice<Substring>) -> SwiftyLLVM.OverflowBehavior
+{
   switch stream.first {
   case "nuw":
     stream.removeFirst()

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2996,7 +2996,7 @@ public enum Parser {
     in state: inout ParserState
   ) throws -> ConditionalCompilationStmt.ConditionTree {
 
-    /// Calculates operator's precedence.
+    /// Returns the precedence of `tokenValue`, which is a either `||` or `&&`.
     func precedence(_ tokenValue: String) -> Int {
       switch tokenValue {
       case "||": 0

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2991,16 +2991,38 @@ public enum Parser {
     return head != nil ? try parseCompilerConditionTail(head: head!, in: &state) : nil
   }
 
+  /// Builds the sequence of compiler conditions for the present CompilerConditionTail
+  private static func buildSequenceCondition(
+    in state: inout ParserState
+  ) throws -> ConditionalCompilationStmt.SequenceCondition {
+    let condition = try parseCompilerCondition(in: &state)
+    let backup = state.backup()
+
+    // Look for the next `&&` or `||` operator if exists.
+    guard let firstOperHalf = state.take(), ["||", "&&"].contains(state.token(firstOperHalf).value)
+    else {
+      state.restore(from: backup)
+      return .operand(condition)
+    }
+
+    if state.token(firstOperHalf).value == "&&" {
+      return .and(condition, try buildSequenceCondition(in: &state))
+    } else {
+      return .or(condition, try buildSequenceCondition(in: &state))
+    }
+  }
+
   /// Parses a compiler condition structure, after the initial token (#if or #elseif).
   private static func parseCompilerConditionTail(
     head: Token, in state: inout ParserState
   ) throws -> AnyStmtID {
     // Parse the condition.
-    let condition = try parseCompilerCondition(in: &state)
+
+    let conditionSeq = try buildSequenceCondition(in: &state)
 
     // Parse the body of the compiler condition.
     let stmts: [AnyStmtID]
-    if condition.mayNotNeedParsing && !condition.holds(for: state.ast.compilationConditions) {
+    if conditionSeq.mustSkipMainBranch(for: state.ast.compilationConditions) {
       try skipConditionalCompilationBranch(in: &state, stoppingAtElse: true)
       stmts = []
     } else {
@@ -3012,7 +3034,7 @@ public enum Parser {
     if state.take(.poundEndif) != nil {
       fallback = []
     } else if state.take(.poundElse) != nil {
-      if condition.mayNotNeedParsing && condition.holds(for: state.ast.compilationConditions) {
+      if conditionSeq.mustSkipElseBranch(for: state.ast.compilationConditions) {
         try skipConditionalCompilationBranch(in: &state, stoppingAtElse: false)
         fallback = []
       } else {
@@ -3021,7 +3043,7 @@ public enum Parser {
       // Expect #endif.
       _ = try state.expect("'#endif'", using: { $0.take(.poundEndif) })
     } else if let head2 = state.take(.poundElseif) {
-      if condition.mayNotNeedParsing && condition.holds(for: state.ast.compilationConditions) {
+      if conditionSeq.mustSkipElseBranch(for: state.ast.compilationConditions) {
         try skipConditionalCompilationBranch(in: &state, stoppingAtElse: false)
         fallback = []
       } else {
@@ -3034,7 +3056,7 @@ public enum Parser {
 
     let r = state.insert(
       ConditionalCompilationStmt(
-        condition: condition,
+        condition: conditionSeq,
         stmts: stmts,
         fallback: fallback,
         site: head.site.extended(upTo: state.currentIndex)))

--- a/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
+++ b/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
@@ -192,7 +192,7 @@ fileprivate struct TestArgument: CustomStringConvertible {
 }
 
 /// Information necessary to generate a test case.
-fileprivate struct TestDescription {
+private struct TestDescription {
 
   /// The name of the method implementing the logic of the test runner.
   let methodName: TestMethod

--- a/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
+++ b/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
@@ -170,16 +170,20 @@ fun testNot() {
 }
 
 fun testMultipleOperandConditions() {
-  #if arch(arm64) && false
-    let a = 1
+  #if os(windows)
+    <something that would not be parsed>
+  #elseif !arch(arm64) && !true
+    <something that would not be parsed>
+  #elseif arch(arm64) && false || !true || false
+    <something that would not be parsed>
   #elseif os(windows) || os(linux)
-    let b = 2
-  #elseif arch(x86_64) || arch(arm64) && !false
-    let c = 3
+    <something that would not be parsed>
+  #elseif arch(x86_64) || arch(arm64) && true || false
+    let message = "arm64 or x86_64"
   #else
-    let d = 4
+    <something that would not be parsed>
   #endif
-  use(c)
+  use(message)
 }
 
 public fun main() {

--- a/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
+++ b/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
@@ -169,6 +169,19 @@ fun testNot() {
   use(b)
 }
 
+fun testMultipleOperandConditions() {
+  #if arch(arm64) && false
+    let a = 1
+  #elseif os(windows) || os(linux)
+    let b = 2
+  #elseif arch(x86_64) || arch(arm64) && !false
+    let c = 3
+  #else
+    let d = 4
+  #endif
+  use(c)
+}
+
 public fun main() {
   testTrue()
   testFalse()
@@ -180,4 +193,5 @@ public fun main() {
   testHyloVersion()
   testSkipParsingNested()
   testNot()
+  testMultipleOperandConditions()
 }

--- a/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
+++ b/Tests/EndToEndTests/TestCases/ConditionalCompilation.hylo
@@ -170,20 +170,27 @@ fun testNot() {
 }
 
 fun testMultipleOperandConditions() {
-  #if os(windows)
-    <something that would not be parsed>
-  #elseif !arch(arm64) && !true
-    <something that would not be parsed>
-  #elseif arch(arm64) && false || !true || false
-    <something that would not be parsed>
-  #elseif os(windows) || os(linux)
-    <something that would not be parsed>
-  #elseif arch(x86_64) || arch(arm64) && true || false
-    let message = "arm64 or x86_64"
-  #else
+  var n = 0
+
+  #if compiler_version(>= 0.0)
+    &n += 1
+  #else if true
     <something that would not be parsed>
   #endif
-  use(message)
+
+  #if os(macOS)
+    &n += 1
+  #elseif os(macOS) && !true
+    &n += 1
+  #elseif os(macOS) && false || !true || false
+    &n += 1
+  #elseif os(macOS) || compiler_version(< 1.0)
+    &n += 1
+  #else
+    &n += 1
+  #endif
+
+  use(n)
 }
 
 public fun main() {

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1679,7 +1679,11 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if os(macOs) foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .operatingSystem("macOs"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("macOs"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)
   }
@@ -1688,7 +1692,11 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if true foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .`true`)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .`true`)
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
   }
@@ -1697,7 +1705,11 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if false awgr() #else foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .`false`)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .`false`)
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
   }
@@ -1707,15 +1719,27 @@ final class ParserTests: XCTestCase {
       "#if os(macOs) foo() #elseif os(Linux) bar() #elseif os(Windows) bazz() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .operatingSystem("macOs"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("macOs"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt2.condition, .operatingSystem("Linux"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("Linux"))
     XCTAssertEqual(stmt2.stmts.count, 1)
     XCTAssertEqual(stmt2.fallback.count, 1)
     let stmt3 = try XCTUnwrap(ast[stmt2.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt3.condition, .operatingSystem("Windows"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("Windows"))
     XCTAssertEqual(stmt3.stmts.count, 1)
     XCTAssertEqual(stmt3.fallback.count, 1)
   }
@@ -1725,19 +1749,35 @@ final class ParserTests: XCTestCase {
       "#if arch(x86_64) foo() #elseif arch(i386) bar() #elseif arch(arm64) bazz() #elseif arch(arm) fizz() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .architecture("x86_64"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .architecture("x86_64"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt2.condition, .architecture("i386"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .architecture("i386"))
     XCTAssertEqual(stmt2.stmts.count, 1)
     XCTAssertEqual(stmt2.fallback.count, 1)
     let stmt3 = try XCTUnwrap(ast[stmt2.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt3.condition, .architecture("arm64"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .architecture("arm64"))
     XCTAssertEqual(stmt3.stmts.count, 1)
     XCTAssertEqual(stmt3.fallback.count, 1)
     let stmt4 = try XCTUnwrap(ast[stmt3.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt4.condition, .architecture("arm"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .architecture("arm"))
     XCTAssertEqual(stmt4.stmts.count, 1)
     XCTAssertEqual(stmt4.fallback.count, 1)
   }
@@ -1747,7 +1787,11 @@ final class ParserTests: XCTestCase {
       "#if feature(useLibC) foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .feature("useLibC"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .feature("useLibC"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)
   }
@@ -1756,7 +1800,11 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler(hc) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt.condition, .compiler("hc"))
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .compiler("hc"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)  // Body not parsed
   }
@@ -1765,8 +1813,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler_version(>= 0.1) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .compilerVersion(
         comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1777,8 +1829,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler_version(< 100.1.2) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .compilerVersion(
         comparison: .less(SemanticVersion(major: 100, minor: 1, patch: 2))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1789,8 +1845,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(>= 0.1) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)  // Body not parsed
@@ -1800,8 +1860,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(< 100.1.2) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(
         comparison: .less(SemanticVersion(major: 100, minor: 1, patch: 2))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1822,8 +1886,12 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(< 0.1) <don't show parse error here> #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1834,8 +1902,12 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(< 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1846,13 +1918,21 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(< 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #elseif os(bla) #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 1)
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    XCTAssertEqual(stmt2.condition, .operatingSystem("bla"))
+    guard case .operand(let condition) = stmt2.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
+    XCTAssertEqual(condition, .operatingSystem("bla"))
     XCTAssertEqual(stmt2.stmts.count, 0)
     XCTAssertEqual(stmt2.fallback.count, 0)
   }
@@ -1862,8 +1942,12 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(>= 0.1) #else <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1874,8 +1958,12 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(>= 0.1) #elseif compiler_version(>= 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    guard case .operand(let condition) = stmt.condition else {
+      XCTFail("Expected case .operand in SequenceCondition instance")
+      return
+    }
     XCTAssertEqual(
-      stmt.condition,
+      condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)
     XCTAssertEqual(stmt.fallback.count, 0)

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1679,11 +1679,7 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if os(macOs) foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .operatingSystem("macOs"))
+    XCTAssertEqual(stmt.condition, .operatingSystem("macOs"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)
   }
@@ -1692,11 +1688,7 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if true foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .`true`)
+    XCTAssertEqual(stmt.condition, .`true`)
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
   }
@@ -1705,11 +1697,7 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if false awgr() #else foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .`false`)
+    XCTAssertEqual(stmt.condition, .`false`)
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
   }
@@ -1719,27 +1707,17 @@ final class ParserTests: XCTestCase {
       "#if os(macOs) foo() #elseif os(Linux) bar() #elseif os(Windows) bazz() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .operatingSystem("macOs"))
+    XCTAssertEqual(stmt.condition, .operatingSystem("macOs"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
+    
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .operatingSystem("Linux"))
+    XCTAssertEqual(stmt2.condition, .operatingSystem("Linux"))
     XCTAssertEqual(stmt2.stmts.count, 1)
     XCTAssertEqual(stmt2.fallback.count, 1)
+    
     let stmt3 = try XCTUnwrap(ast[stmt2.fallback[0]] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .operatingSystem("Windows"))
+    XCTAssertEqual(stmt3.condition, .operatingSystem("Windows"))
     XCTAssertEqual(stmt3.stmts.count, 1)
     XCTAssertEqual(stmt3.fallback.count, 1)
   }
@@ -1749,35 +1727,22 @@ final class ParserTests: XCTestCase {
       "#if arch(x86_64) foo() #elseif arch(i386) bar() #elseif arch(arm64) bazz() #elseif arch(arm) fizz() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .architecture("x86_64"))
+    XCTAssertEqual(stmt.condition, .architecture("x86_64"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 1)
+    
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .architecture("i386"))
+    XCTAssertEqual(stmt2.condition, .architecture("i386"))
     XCTAssertEqual(stmt2.stmts.count, 1)
     XCTAssertEqual(stmt2.fallback.count, 1)
+    
     let stmt3 = try XCTUnwrap(ast[stmt2.fallback[0]] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .architecture("arm64"))
+    XCTAssertEqual(stmt3.condition, .architecture("arm64"))
     XCTAssertEqual(stmt3.stmts.count, 1)
     XCTAssertEqual(stmt3.fallback.count, 1)
+    
     let stmt4 = try XCTUnwrap(ast[stmt3.fallback[0]] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .architecture("arm"))
+    XCTAssertEqual(stmt4.condition, .architecture("arm"))
     XCTAssertEqual(stmt4.stmts.count, 1)
     XCTAssertEqual(stmt4.fallback.count, 1)
   }
@@ -1787,11 +1752,7 @@ final class ParserTests: XCTestCase {
       "#if feature(useLibC) foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .feature("useLibC"))
+    XCTAssertEqual(stmt.condition, .feature("useLibC"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)
   }
@@ -1800,11 +1761,7 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler(hc) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .compiler("hc"))
+    XCTAssertEqual(stmt.condition, .compiler("hc"))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)  // Body not parsed
   }
@@ -1813,12 +1770,8 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler_version(>= 0.1) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .compilerVersion(
         comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1829,12 +1782,8 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if compiler_version(< 100.1.2) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .compilerVersion(
         comparison: .less(SemanticVersion(major: 100, minor: 1, patch: 2))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1845,12 +1794,8 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(>= 0.1) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)  // Body not parsed
@@ -1860,12 +1805,8 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(< 100.1.2) foo() #else awgr() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .hyloVersion(
         comparison: .less(SemanticVersion(major: 100, minor: 1, patch: 2))))
     XCTAssertEqual(stmt.stmts.count, 1)
@@ -1886,12 +1827,8 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "#if hylo_version(< 0.1) <don't show parse error here> #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1902,12 +1839,8 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(< 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1918,21 +1851,14 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(< 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #elseif os(bla) #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .hyloVersion(comparison: .less(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 1)
+    
     let stmt2 = try XCTUnwrap(ast[stmt.fallback[0]] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt2.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
-    XCTAssertEqual(condition, .operatingSystem("bla"))
+    XCTAssertEqual(stmt2.condition, .operatingSystem("bla"))
     XCTAssertEqual(stmt2.stmts.count, 0)
     XCTAssertEqual(stmt2.fallback.count, 0)
   }
@@ -1942,12 +1868,8 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(>= 0.1) #else <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)  // Body not parsed
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1958,12 +1880,8 @@ final class ParserTests: XCTestCase {
       "#if hylo_version(>= 0.1) #elseif compiler_version(>= 0.1) <don't show parse error here> #if hylo_version(< 0.1) <don't show parse error here> #endif #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
-    guard case .operand(let condition) = stmt.condition else {
-      XCTFail("Expected case .operand in SequenceCondition instance")
-      return
-    }
     XCTAssertEqual(
-      condition,
+      stmt.condition,
       .hyloVersion(comparison: .greaterOrEqual(SemanticVersion(major: 0, minor: 1, patch: 0))))
     XCTAssertEqual(stmt.stmts.count, 0)
     XCTAssertEqual(stmt.fallback.count, 0)
@@ -1978,6 +1896,7 @@ final class ParserTests: XCTestCase {
       // all good
     }
   }
+
   func testConditionalControlNotOperatorOnFalse() throws {
     let input: SourceFile = "#if !os(abracadabra) foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
@@ -1993,6 +1912,7 @@ final class ParserTests: XCTestCase {
     // We should expand to nothing.
     XCTAssertEqual(stmt.expansion(for: ConditionalCompilationFactors()).count, 0)
   }
+
   func testConditionalControlNotNot() throws {
     let input: SourceFile = "#if ! !true foo() #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
@@ -2000,12 +1920,33 @@ final class ParserTests: XCTestCase {
     // We should expand to the body.
     XCTAssertEqual(stmt.expansion(for: ConditionalCompilationFactors()).count, 1)
   }
+
   func testConditionalControlSkipParsingAfterNot() throws {
     let input: SourceFile = "#if !compiler_version(< 0.1) foo() #else <won't parse> #endif"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
     XCTAssertEqual(stmt.stmts.count, 1)
     XCTAssertEqual(stmt.fallback.count, 0)  // don't parse the #else part
+  }
+
+  func testConditionalControlInfix() throws {
+    let input = SourceFile.diagnosableLiteral(
+      """
+      #if os(macOS) || os(Linux) && hylo_version(< 1.0.0) || os(Windows)
+      do_something()
+      #endif
+      """)
+    let (stmtID, ast) = try apply(Parser.stmt, on: input)
+    let stmt = try XCTUnwrap(ast[stmtID] as? ConditionalCompilationStmt)
+    XCTAssertEqual(
+      stmt.condition,
+      .or(
+        .or(
+          .operatingSystem("macOS"),
+          .and(
+            .operatingSystem("Linux"),
+            .hyloVersion(comparison: .less(SemanticVersion(major: 1, minor: 0, patch: 0))))),
+        .operatingSystem("Windows")))
   }
 
   // MARK: Operators


### PR DESCRIPTION
This PR is finishing the work started by @Metalymph on logic operators in compile-time conditions (see #1358). The original PR was #1410.