### PR TITLE
Simplify variant selection

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -5801,9 +5801,8 @@ struct TypeChecker {
   ) -> AnyType {
     switch callee.kind {
     case InoutExpr.self:
-      let e = InoutExpr.ID(callee)!
-      let t = inferredType(
-        ofCallee: program[e].subject, usedAs: purpose, implicitlyIn: q, updating: &obligations)
+      let e = program[InoutExpr.ID(callee)!].subject.id
+      let t = inferredType(ofCallee: e, usedAs: purpose, implicitlyIn: q, updating: &obligations)
       return constrain(callee, to: t, in: &obligations)
 
     case NameExpr.self:

--- a/Sources/IR/TypedProgram+Extensions.swift
+++ b/Sources/IR/TypedProgram+Extensions.swift
@@ -28,28 +28,12 @@ extension TypedProgram {
     }
   }
 
-  /// Returns a subscript bundle reference to `d`, which occurs specialized by `z` and is marked
-  /// for mutation iff `isMutating` is `true`.
+  /// Returns a subscript bundle reference to `d`, which occurs specialized by `z`.
   func subscriptBundleReference(
-    to d: SubscriptDecl.ID, specializedBy z: GenericArguments, markedForMutation isMutating: Bool
+    to d: SubscriptDecl.ID, specializedBy z: GenericArguments
   ) -> BundleReference<SubscriptDecl> {
-    let t = SubscriptType(canonical(self[d].type, in: self[d].scope))!
-    let r = requestedCapabilities(
-      onBundleProviding: t.capabilities, forInPlaceMutation: isMutating)
-    return BundleReference(to: d, specializedBy: z, requesting: r)
-  }
-
-  /// Returns the capabilities potentially requested by an access on a subscript or method bundle
-  /// defining `available`, used for mutation iff `m` is `true`.
-  func requestedCapabilities(
-    onBundleProviding available: AccessEffectSet, forInPlaceMutation m: Bool
-  ) -> AccessEffectSet {
-    let requested = available.intersection(
-      AccessEffectSet.forUseOfBundle(performingInPlaceMutation: m))
-
-    // TODO: requested is empty iff the program is ill-typed w.r.t. mutation markers
-    // assert(!requested.isEmpty)
-    return requested.isEmpty ? available : requested
+    let available = SubscriptType(canonical(self[d].type, in: self[d].scope))!.capabilities
+    return BundleReference(to: d, specializedBy: z, requesting: available)
   }
 
 }

--- a/Tests/EndToEndTests/TestCases/MethodBundle.hylo
+++ b/Tests/EndToEndTests/TestCases/MethodBundle.hylo
@@ -13,8 +13,27 @@ type A: Deinitializable {
 
 }
 
+public type B: Deinitializable {
+
+  public let x: Int
+
+  public memberwise init
+
+  public fun foo(_ n: sink Int) {
+    let   { B(x: n) }
+    inout { &self.x = n }
+  }
+
+}
+
 public fun main() {
   var a = A(x: 42)
   precondition(a.foo().1 == 42)
   precondition(a.foo().1 == 42)
+
+  var b0 = B(x: 1)
+  let b1 = b0.foo(2)
+  precondition(b1.x == 2)
+  &b0.foo(3)
+  precondition(b0.x == 3)
 }


### PR DESCRIPTION
It seems like keeping track of mutation markers to create ~method/~ subscript bundles isn't actually necessary for name resolution to pick the right candidates. Further access reification works better if we don't pre-filter the variants available on a free subscript bundle. For example:

```
subscript s(_ x: inout Int): Int {
  let { yield x }
  inout { yield &x }
}

public fun main() {
  var n = 0
  inout m = s[&n]
}
```

Here, name resolution should _not_ filter out the `inout` variant only because the callee is not marked for mutation.