### PR TITLE
Fix canonicalization of associated types

### DIFF
--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -87,11 +87,7 @@ extension IR.Program {
   ) -> SwiftyLLVM.IRType {
     precondition(val[.isCanonical])
 
-    let fields = base.storage(of: val.base).map { (part) in
-      let z = GenericArguments(val)
-      let u = base.specialize(part.type, for: z, in: AnyScopeID(base.ast.coreLibrary!))
-      return llvm(u, in: &module)
-    }
+    let fields = base.storage(of: val).map({ (p) in llvm(p.type, in: &module) })
 
     switch val.base.base {
     case let u as ProductType:

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -450,6 +450,8 @@ struct ConstraintSystem {
       if !goal.left[.isCanonical] || !goal.right[.isCanonical] {
         let l = checker.canonical(goal.left, in: scope)
         let r = checker.canonical(goal.right, in: scope)
+        assert(l[.isCanonical] && r[.isCanonical])
+
         let s = schedule(
           SubtypingConstraint(l, r, strictly: goal.isStrict, origin: goal.origin.subordinate()))
         return delegate(to: [s])

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -446,6 +446,14 @@ struct ConstraintSystem {
         return delegate(to: [s])
       }
 
+    case (let l as AssociatedTypeType, _) where l.root.base is TypeVariable:
+      postpone(g)
+      return nil
+
+    case (_, let r as AssociatedTypeType) where r.root.base is TypeVariable:
+      postpone(g)
+      return nil
+
     default:
       if !goal.left[.isCanonical] || !goal.right[.isCanonical] {
         let l = checker.canonical(goal.left, in: scope)

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -106,7 +106,10 @@ struct ConstraintSystem {
         return nil
       }
 
-      goals[g].modifyTypes({ typeAssumptions[$0] })
+      goals[g].modifyTypes { (t) in
+        typeAssumptions.reify(t, withVariables: .kept)
+      }
+
       log("- solve: \"\(goals[g])\"")
       indentation += 1
       log("actions:")

--- a/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
+++ b/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
@@ -90,11 +90,9 @@ struct SubstitutionMap {
   func reify(
     _ type: AnyType, withVariables substitutionPolicy: SubstitutionPolicy = .substitutedByError
   ) -> AnyType {
-    return type.transform(transform(type:))
-
-    func transform(type: AnyType) -> TypeTransformAction {
-      if type.base is TypeVariable {
-        let walked = self[type]
+    type.transform { (t: AnyType) -> TypeTransformAction in
+      if t.base is TypeVariable {
+        let walked = self[t]
 
         // Substitute `walked` for `type`.
         if walked.base is TypeVariable {
@@ -102,17 +100,17 @@ struct SubstitutionMap {
           case .substitutedByError:
             return .stepOver(.error)
           case .kept:
-            return .stepOver(type)
+            return .stepOver(walked)
           }
         } else {
           return .stepInto(walked)
         }
-      } else if !type[.hasVariable] {
+      } else if !t[.hasVariable] {
         // Nothing to do if the type doesn't contain any variable.
-        return .stepOver(type)
+        return .stepOver(t)
       } else {
         // Recursively visit other types.
-        return .stepInto(type)
+        return .stepInto(t)
       }
     }
   }

--- a/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
+++ b/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
@@ -81,8 +81,8 @@ struct SubstitutionMap {
     return occurs
   }
 
-  /// Substitutes each type variable occurring in `type` by its corresponding substitution in `self`,
-  /// apply `substitutionPolicy` to deal with free variables.
+  /// Returns a copy of `type` where type variable occurring in is replaced by its corresponding
+  /// substitution in `self`, applying `substitutionPolicy` to deal with free variables.
   ///
   /// The default substitution policy is `substituteByError` because we typically use `reify` after
   /// having built a complete solution and therefore don't expect its result to still contain open
@@ -115,8 +115,8 @@ struct SubstitutionMap {
     }
   }
 
-  /// Returns `r` where each type variable occurring in its generic arguments of `r` are replaced by
-  /// their corresponding value in `self`, applying `substitutionPolicy` to handle free variables.
+  /// Returns a copy of `r` where each generic argument is replaced by the result of applying
+  /// `reify(withVariables:)` on it.
   func reify(
     _ r: DeclReference, withVariables substitutionPolicy: SubstitutionPolicy
   ) -> DeclReference {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -606,15 +606,18 @@ struct TypeChecker {
     return result
   }
 
-  /// Returns the type implementing requirement `r` for the model `m` in `scopeOfUse`, or `nil` if
-  /// `m` does not implement `r`.
+  /// Returns the type implementing `requirement` for `model` in `scopeOfUse`, or `nil` if `model`
+  /// does not implement `requirement`.
   private mutating func demandImplementation(
-    of r: AssociatedTypeDecl.ID, for m: AnyType, in scopeOfUse: AnyScopeID
+    of requirement: AssociatedTypeDecl.ID, for model: AnyType, in scopeOfUse: AnyScopeID
   ) -> AnyType? {
-    if let c = demandConformance(of: m, to: traitDeclaring(r)!, exposedTo: scopeOfUse) {
-      return demandImplementation(of: r, in: c)
+    let p = traitDeclaring(requirement)!
+    let m = canonical(model, in: scopeOfUse)
+
+    if let c = demandConformance(of: m, to: p, exposedTo: scopeOfUse) {
+      return demandImplementation(of: requirement, in: c)
     } else if m.base is GenericTypeParameterType {
-      return ^AssociatedTypeType(r, domain: m, ast: program.ast)
+      return ^AssociatedTypeType(requirement, domain: m, ast: program.ast)
     } else {
       return nil
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -79,6 +79,8 @@ struct TypeChecker {
     if t[.isCanonical] { return t }
 
     switch t.base {
+    case let u as AssociatedTypeType:
+      return canonical(u, in: scopeOfUse)
     case let u as BoundGenericType:
       return canonical(u, in: scopeOfUse)
     case let u as TypeAliasType:
@@ -87,6 +89,15 @@ struct TypeChecker {
       return canonical(u, in: scopeOfUse)
     default:
       return t.transformParts(mutating: &self, { .stepOver($0.canonical($1, in: scopeOfUse)) })
+    }
+  }
+
+  /// Returns the canonical form of `t` in `scopeOfUse`.
+  private mutating func canonical(_ t: AssociatedTypeType, in scopeOfUse: AnyScopeID) -> AnyType {
+    if let u = demandImplementation(of: t.decl, for: t.domain, in: scopeOfUse) {
+      return canonical(u, in: scopeOfUse)
+    } else {
+      return .error
     }
   }
 

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -296,9 +296,12 @@ public struct TypedProgram {
   /// Returns the names and types of `t`'s stored properties.
   public func storage(of t: BoundGenericType) -> [TupleType.Element] {
     storage(of: t.base).map { (p) in
+      // FIXME: Probably wrong to specialize/canonicalize in any random scope.
+      let s = AnyScopeID(base.ast.coreLibrary!)
       let z = GenericArguments(t)
-      let t = specialize(p.type, for: z, in: AnyScopeID(base.ast.coreLibrary!))
-      return .init(label: p.label, type: t)
+      let t = specialize(p.type, for: z, in: s)
+      let u = canonical(t, in: s)
+      return .init(label: p.label, type: u)
     }
   }
 

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -297,11 +297,11 @@ public struct TypedProgram {
   public func storage(of t: BoundGenericType) -> [TupleType.Element] {
     storage(of: t.base).map { (p) in
       // FIXME: Probably wrong to specialize/canonicalize in any random scope.
-      let s = AnyScopeID(base.ast.coreLibrary!)
+      let arbitraryScope = AnyScopeID(base.ast.coreLibrary!)
       let z = GenericArguments(t)
-      let t = specialize(p.type, for: z, in: s)
-      let u = canonical(t, in: s)
-      return .init(label: p.label, type: u)
+      let u = specialize(p.type, for: z, in: arbitraryScope)
+      let v = canonical(u, in: arbitraryScope)
+      return .init(label: p.label, type: v)
     }
   }
 

--- a/Sources/FrontEnd/Types/AssociatedTypeType.swift
+++ b/Sources/FrontEnd/Types/AssociatedTypeType.swift
@@ -25,7 +25,9 @@ public struct AssociatedTypeType: TypeProtocol {
   /// Creates an instance with the given properties.
   init(decl: AssociatedTypeDecl.ID, domain: AnyType, name: String) {
     var fs = domain.flags
-    if !domain.isSkolem && !(domain.base is TypeVariable) {
+
+    let d = AssociatedTypeType(domain)?.root ?? domain
+    if !(d.isSkolem || d.base is TypeVariable) {
       fs.remove(.isCanonical)
     }
 
@@ -33,6 +35,11 @@ public struct AssociatedTypeType: TypeProtocol {
     self.domain = domain
     self.name = Incidental(name)
     self.flags = fs
+  }
+
+  /// Returns the root of `self`'s qualification.
+  public var root: AnyType {
+    AssociatedTypeType(domain)?.root ?? domain
   }
 
   public func transformParts<M>(

--- a/Tests/HyloTests/TestCases/TypeChecking/AbstractType.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/AbstractType.hylo
@@ -1,0 +1,48 @@
+//- typeCheck expecting: .success
+
+trait P: SemiRegular {
+  type T: SemiRegular
+  type U: SemiRegular
+
+  fun t(_ x: T)
+  fun u(_ x: U)
+}
+
+trait Q: SemiRegular {
+  type V: P
+  property v: V { let }
+}
+
+type A<V: P>: Q {
+  public let _v: V
+  public init (v: sink V) { &self._v = v }
+  public property v: V { yield _v }
+  public fun infix== (_ other: Self) -> Bool { self.v == other.v }
+}
+
+type B<W: Q>: Deinitializable {
+  public let w: W
+  public memberwise init
+
+  public fun t(_ x: W.V.T) { w.v.t(x) }
+  public fun u(_ x: W.V.U) { w.v.u(x) }
+}
+
+conformance Array: P {
+  public typealias T = Element
+  public typealias U = Self.Position
+
+  public fun t(_ x: Element) {}
+  public fun u(_ x: Self.Position) {}
+}
+
+fun foo<X: P>(p: sink X, t: sink X.T, u: sink X.U) {
+  let a = A(v: p)
+  let b = B(w: a)
+  b.t(t)
+  b.u(u)
+}
+
+public fun main() {
+  foo(p: Array<Bool>(), t: true, u: 1)
+}


### PR DESCRIPTION
This PR lets the type checker handle abstract associated types of the form `Array<X>.T.U`, where `X` is a generic parameter.