### PR TITLE
Fix the checking of synthesizable conformances under a where clause

### DIFF
--- a/StandardLibrary/Sources/Core/Optional.hylo
+++ b/StandardLibrary/Sources/Core/Optional.hylo
@@ -19,3 +19,10 @@ public extension Optional {
   }
 
 }
+
+// Note: We can't declare confitional conformance of `Optional` to "umbrella traits" yet without
+// causing ambiguities. See #1566
+
+public conformance Optional: Deinitializable where T: Deinitializable {}
+
+public conformance Optional: Equatable where T: Equatable {}

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalConformance.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalConformance.hylo
@@ -1,0 +1,8 @@
+//- typeCheck expecting: .success
+
+type Box<T> {
+  public let contents: T
+  public memberwise init
+}
+
+conformance Box: Equatable where T: Equatable {}

--- a/Tests/LibraryTests/TestCases/OptionalTests.hylo
+++ b/Tests/LibraryTests/TestCases/OptionalTests.hylo
@@ -4,6 +4,8 @@ public fun main() {
   precondition(None<Int>() == None<Int>())
 
   var x = 42 as Optional<Int>
+  precondition(x == x)
+
   let y = if let i: Int = x { i.copy() } else { 0 }
   precondition(y == 42)
 


### PR DESCRIPTION
Now we can write this:
```
type Box<T> {
  public let contents: T
  public memberwise init
}

conformance Box: Equatable where T: Equatable {}
```