### PR TITLE
Add support for non-consuming projections of union payloads

### DIFF
--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -1211,14 +1211,13 @@ extension SwiftyLLVM.Module {
       if let (_, b) = s.targets.elements.uniqueElement {
         insertBr(to: block[b]!, at: insertionPoint)
       } else {
-        let d = discriminator(s.scrutinee)
-        let t = UnionType(m.type(of: s.scrutinee).ast)!
-        let e = m.program.discriminatorToElement(in: t)
+        let e = m.program.discriminatorToElement(in: s.union)
         let branches = s.targets.map { (t, b) in
           (word().constant(e.firstIndex(of: t)!), block[b]!)
         }
 
         // The last branch is the "default".
+        let d = llvm(s.discriminator)
         insertSwitch(
           on: d, cases: branches.dropLast(), default: branches.last!.1,
           at: insertionPoint)

--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -64,7 +64,7 @@ extension Module {
 
       forEachClient(of: i) { (u) in
         let rs = requests(u)
-        lower = max(rs.weakest!, lower)
+        if let w = rs.weakest { lower = max(w, lower) }
         upper = rs.strongest(including: upper)
       }
 

--- a/Sources/IR/Analysis/Module+CloseBorrows.swift
+++ b/Sources/IR/Analysis/Module+CloseBorrows.swift
@@ -43,6 +43,12 @@ extension Module {
         this.makeCloseCapture(.register(i), at: site)
       }
 
+    case is OpenUnion:
+      let region = extendedLiveRange(of: .register(i))
+      insertClose(i, atBoundariesOf: region) { (this, site) in
+        this.makeCloseUnion(.register(i), at: site)
+      }
+
     case is Project:
       let region = extendedLiveRange(of: .register(i))
       insertClose(i, atBoundariesOf: region) { (this, site) in

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -240,12 +240,13 @@ extension IR.Program {
       }
 
     case let s as UnionSwitch:
-      let x0 = t.transform(s.scrutinee, in: &self)
-      let x1 = s.targets.reduce(into: UnionSwitch.Targets()) { (d, kv) in
+      let x0 = t.transform(s.discriminator, in: &self)
+      let x1 = UnionType(t.transform(^s.union, in: &self))!
+      let x2 = s.targets.reduce(into: UnionSwitch.Targets()) { (d, kv) in
         _ = d[t.transform(kv.key, in: &self)].setIfNil(t.transform(kv.value, in: &self))
       }
       return insert(at: p, in:n) { (target) in
-        target.makeUnionSwitch(on: x0, toOneOf: x1, at: s.site)
+        target.makeUnionSwitch(over: x0, of: x1, toOneOf: x2, at: s.site)
       }
 
     case let s as Unreachable:

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int32.hylo
@@ -308,7 +308,7 @@ public conformance Int32: FixedWidthInteger {
 
   public fun infix&<< (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &<<= n
+    &lhs &<<= n
     return lhs
   }
 
@@ -318,7 +318,7 @@ public conformance Int32: FixedWidthInteger {
 
   public fun infix&>> (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &>>= n
+    &lhs &>>= n
     return lhs
   }
 

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int64.hylo
@@ -309,7 +309,7 @@ public conformance Int64: FixedWidthInteger {
 
   public fun infix&<< (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &<<= n
+    &lhs &<<= n
     return lhs
   }
 
@@ -319,7 +319,7 @@ public conformance Int64: FixedWidthInteger {
 
   public fun infix&>> (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &>>= n
+    &lhs &>>= n
     return lhs
   }
 

--- a/StandardLibrary/Sources/Core/Numbers/Integers/Int8.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/Int8.hylo
@@ -314,7 +314,7 @@ public conformance Int8: FixedWidthInteger {
 
   public fun infix&<< (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &<<= n
+    &lhs &<<= n
     return lhs
   }
 
@@ -324,7 +324,7 @@ public conformance Int8: FixedWidthInteger {
 
   public fun infix&>> (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &>>= n
+    &lhs &>>= n
     return lhs
   }
 

--- a/StandardLibrary/Sources/Core/Numbers/Integers/UInt32.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/UInt32.hylo
@@ -267,7 +267,7 @@ public conformance UInt32: FixedWidthInteger {
 
   public fun infix&<< (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &<<= n
+    &lhs &<<= n
     return lhs
   }
 
@@ -277,7 +277,7 @@ public conformance UInt32: FixedWidthInteger {
 
   public fun infix&>> (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &>>= n
+    &lhs &>>= n
     return lhs
   }
 

--- a/StandardLibrary/Sources/Core/Numbers/Integers/UInt64.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/UInt64.hylo
@@ -268,7 +268,7 @@ public conformance UInt64: FixedWidthInteger {
 
   public fun infix&<< (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &<<= n
+    &lhs &<<= n
     return lhs
   }
 
@@ -278,7 +278,7 @@ public conformance UInt64: FixedWidthInteger {
 
   public fun infix&>> (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &>>= n
+    &lhs &>>= n
     return lhs
   }
 

--- a/StandardLibrary/Sources/Core/Numbers/Integers/UInt8.hylo
+++ b/StandardLibrary/Sources/Core/Numbers/Integers/UInt8.hylo
@@ -273,7 +273,7 @@ public conformance UInt8: FixedWidthInteger {
 
   public fun infix&<< (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &<<= n
+    &lhs &<<= n
     return lhs
   }
 
@@ -283,7 +283,7 @@ public conformance UInt8: FixedWidthInteger {
 
   public fun infix&>> (_ n: Int) -> Self {
     var lhs = self.copy()
-    lhs &>>= n
+    &lhs &>>= n
     return lhs
   }
 

--- a/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
+++ b/Tests/EndToEndTests/TestCases/Concurrency/concurrent_sort.hylo
@@ -138,7 +138,7 @@ type ArraySlice<Element: Regular & Comparable> : Deinitializable, Movable {
           &elements.swap_at(i, i + 1)
           &swapped = true
         }
-        i += 1
+        &i += 1
       }
     } while swapped
   }

--- a/Tests/EndToEndTests/TestCases/SyntheticCopy.hylo
+++ b/Tests/EndToEndTests/TestCases/SyntheticCopy.hylo
@@ -12,11 +12,9 @@ public fun main() {
   var b = a.copy()
   &a.y = 1337
 
-  let ax = if let x: Int = a.x { x } else { 0 }
-  precondition(ax == 42)
+  precondition(a.x == (42 as _))
   precondition(a.y == 1337)
 
-  let bx = if let x: Int = b.x { x } else { 0 }
-  precondition(bx == 42)
+  precondition(b.x == (42 as _))
   precondition(b.y == 1)
 }

--- a/Tests/HyloTests/TestCases/Lowering/Narrowing.hylo
+++ b/Tests/HyloTests/TestCases/Lowering/Narrowing.hylo
@@ -1,0 +1,18 @@
+//- lowerToFinishedIR expecting: .success
+
+fun use<T>(_ x: T) {}
+
+public fun main() {
+  var x: Optional<Int> = 1 as _
+
+  if let y: Int = x {
+    // Additional access to `x` is legal.
+    use(x)
+    use(y)
+  }
+
+  if sink let y: Int = x {
+    // Mutation of `x` is legal since it has been consumed.
+    &x = .none()
+  }
+}

--- a/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
+++ b/Tests/LibraryTests/TestCases/MutableCollectionTests.hylo
@@ -5,7 +5,7 @@ fun append_count(up_to limit: Int, to a: inout Array<Int>) {
   var i = 0
   while i < limit {
     &a.append(i.copy())
-    i += 1
+    &i += 1
   }
 }
 
@@ -30,10 +30,10 @@ fun test_rotate(length N: Int) {
       if a[j] != (pivot + j) % N {
         &failed = true
       }
-      j += 1
+      &j += 1
     }
 
-    pivot += 1
+    &pivot += 1
   }
   precondition(!failed)
 }
@@ -44,7 +44,7 @@ fun test_rotate() {
   var n = 0
   while n < 17 {
     test_rotate(length: n)
-    n += 1
+    &n += 1
   }
 }
 

--- a/Tests/LibraryTests/TestCases/RangeTests.hylo
+++ b/Tests/LibraryTests/TestCases/RangeTests.hylo
@@ -4,11 +4,11 @@ public fun test_conformance_to_iterator() {
   var r = 1 ..< 3
   var x: Int
 
-  &x = if let y: Int = &r.next() { y } else { -1 }
+  &x = if sink let y: Int = &r.next() { y } else { -1 }
   precondition(x == 1)
-  &x = if let y: Int = &r.next() { y } else { -1 }
+  &x = if sink let y: Int = &r.next() { y } else { -1 }
   precondition(x == 2)
-  &x = if let y: Int = &r.next() { y } else { -1 }
+  &x = if sink let y: Int = &r.next() { y } else { -1 }
   precondition(x == -1)
 
   precondition(r.lower_bound == r.upper_bound)


### PR DESCRIPTION
The following program is now legal:
```
fun f(_ x: Optional<Int>) {
  if let y: Int = x { print(y) }
}
```
Previously, the compiler would complain that `x` can't be consumed because all narrowing conversions required a `sink` access on the source.