### PR TITLE
Use an introducer to determine the kind of a generic parameter

### DIFF
--- a/Sources/FrontEnd/AST/Decl/GenericParameterDecl.swift
+++ b/Sources/FrontEnd/AST/Decl/GenericParameterDecl.swift
@@ -3,7 +3,21 @@ public struct GenericParameterDecl: SingleEntityDecl, ConstrainedGenericTypeDecl
 
   public static let constructDescription = "generic parameter declaration"
 
+  /// The introducer of a generic parameter declaration.
+  public enum Introducer: Codable {
+
+    /// The type introducer, `type`.
+    case type
+
+    /// The value introducer, `value`
+    case value
+
+  }
+
   public let site: SourceRange
+
+  /// The parameter's introducer, if any.
+  public let introducer: SourceRepresentable<Introducer>?
 
   /// The identifier of the parameter.
   public let identifier: SourceRepresentable<Identifier>
@@ -19,12 +33,14 @@ public struct GenericParameterDecl: SingleEntityDecl, ConstrainedGenericTypeDecl
   public let defaultValue: AnyExprID?
 
   public init(
+    introducer: SourceRepresentable<Introducer>?,
     identifier: SourceRepresentable<Identifier>,
     conformances: [NameExpr.ID] = [],
     defaultValue: AnyExprID? = nil,
     site: SourceRange
   ) {
     self.site = site
+    self.introducer = introducer
     self.identifier = identifier
     self.conformances = conformances
     self.defaultValue = defaultValue

--- a/Sources/FrontEnd/AST/Decl/GenericParameterDecl.swift
+++ b/Sources/FrontEnd/AST/Decl/GenericParameterDecl.swift
@@ -48,4 +48,9 @@ public struct GenericParameterDecl: SingleEntityDecl, ConstrainedGenericTypeDecl
 
   public var baseName: String { identifier.value }
 
+  /// `true` iff `self` is denotes a variable that ranges over types.
+  public var isTypeKinded: Bool {
+    introducer?.value != .value
+  }
+
 }

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -973,6 +973,7 @@ public enum Parser {
     // Synthesize the `Self` parameter of the trait.
     let selfParameterDecl = state.insert(
       GenericParameterDecl(
+        introducer: SourceRepresentable(value: .type, range: introducer.site),
         identifier: SourceRepresentable(value: "Self", range: name.site),
         site: name.site))
     members.append(AnyDeclID(selfParameterDecl))
@@ -1223,13 +1224,7 @@ public enum Parser {
   static func parseParameterDecl(in state: inout ParserState) throws -> ParameterDecl.ID? {
     guard let interface = try parseParameterInterface(in: &state) else { return nil }
 
-    let annotation: ParameterTypeExpr.ID?
-    if state.take(.colon) != nil {
-      annotation = try state.expect("type expression", using: parseParameterTypeExpr(in:))
-    } else {
-      annotation = nil
-    }
-
+    let annotation = try parseAscription(in: &state, parseParameterTypeExpr(in:))
     let defaultValue = try parseDefaultValue(in: &state)
 
     let isImplicit = interface.implicitMarker != nil
@@ -1331,19 +1326,54 @@ public enum Parser {
     (genericParameter.and(zeroOrMany(take(.comma).and(genericParameter).second))
       .map({ (_, tree) -> [GenericParameterDecl.ID] in [tree.0] + tree.1 }))
 
-  static let genericParameter =
-    (maybe(typeAttribute).andCollapsingSoftFailures(take(.name))
-      .and(maybe(take(.colon).and(boundComposition)))
-      .and(maybe(take(.assign).and(expr)))
-      .map({ (state, tree) -> GenericParameterDecl.ID in
-        state.insert(
-          GenericParameterDecl(
-            identifier: state.token(tree.0.0.1),
-            conformances: tree.0.1?.1 ?? [],
-            defaultValue: tree.1?.1,
-            site: state.range(
-              from: tree.0.0.0?.site.startIndex ?? tree.0.0.1.site.startIndex)))
-      }))
+  static let genericParameter = Apply(parseGenericParameterDecl(in:))
+
+  private static func parseGenericParameterDecl(
+    in state: inout ParserState
+  ) throws -> GenericParameterDecl.ID? {
+    let i = parseGenericParameterIntroducer(in: &state)
+
+    guard let n = state.take(.name) else {
+      if i == nil {
+        return nil
+      } else {
+        try fail(.error(expected: "identifier", at: state.currentLocation))
+      }
+    }
+
+    let a = try parseAscription(in: &state, boundComposition.parse(_:))
+    let v = try parseDefaultValue(in: &state)
+
+    return state.insert(
+      GenericParameterDecl(
+        introducer: i,
+        identifier: state.token(n),
+        conformances: a ?? [],
+        defaultValue: v,
+        site: (i?.site ?? n.site).extended(upTo: state.currentIndex)))
+  }
+
+  private static func parseGenericParameterIntroducer(
+    in state: inout ParserState
+  ) -> SourceRepresentable<GenericParameterDecl.Introducer>? {
+    (state.take(.type) ?? state.take(nameTokenWithValue: "value")).map { (t) in
+      if t.kind == .type {
+        return .init(value: .type, range: t.site)
+      } else {
+        return .init(value: .value, range: t.site)
+      }
+    }
+  }
+
+  private static func parseGenericParameterAscription(
+    in state: inout ParserState
+  ) throws -> [NameExpr.ID]? {
+    if state.take(.colon) != nil {
+      return try state.expect("type expression", using: boundComposition)
+    } else {
+      return nil
+    }
+  }
 
   static let conformanceList =
     (take(.colon).and(nameTypeExpr).and(zeroOrMany(take(.comma).and(nameTypeExpr).second))
@@ -1353,6 +1383,17 @@ public enum Parser {
   private static func parseDefaultValue(in state: inout ParserState) throws -> AnyExprID? {
     if state.take(.assign) != nil {
       return try state.expect("expression", using: parseExpr(in:))
+    } else {
+      return nil
+    }
+  }
+
+  /// Parses a colon and returns the result of `ascription` applied on `state`.
+  private static func parseAscription<T>(
+    in state: inout ParserState, _ ascription: (inout ParserState) throws -> T?
+  ) throws -> T? {
+    if state.take(.colon) != nil {
+      return try state.expect("type expression", using: ascription)
     } else {
       return nil
     }
@@ -2609,16 +2650,9 @@ public enum Parser {
     state.contexts.append(.bindingPattern)
     defer { state.contexts.removeLast() }
 
-    // Parse the subpattern.
+    // Parse the subpattern and its optional ascription.
     let subpattern = try state.expect("pattern", using: parsePattern(in:))
-
-    // Parse the type annotation, if any.
-    let annotation: AnyExprID?
-    if state.take(.colon) != nil {
-      annotation = try state.expect("type expression", using: parseExpr(in:))
-    } else {
-      annotation = nil
-    }
+    let annotation = try parseAscription(in: &state, parseExpr(in:))
 
     return state.insert(
       BindingPattern(
@@ -3417,8 +3451,6 @@ public enum Parser {
 
     return nil
   }
-
-  static let typeAttribute = attribute("@type")
 
   static let valueAttribute = attribute("@value")
 

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1365,16 +1365,6 @@ public enum Parser {
     }
   }
 
-  private static func parseGenericParameterAscription(
-    in state: inout ParserState
-  ) throws -> [NameExpr.ID]? {
-    if state.take(.colon) != nil {
-      return try state.expect("type expression", using: boundComposition)
-    } else {
-      return nil
-    }
-  }
-
   static let conformanceList =
     (take(.colon).and(nameTypeExpr).and(zeroOrMany(take(.comma).and(nameTypeExpr).second))
       .map({ (state, tree) -> [NameExpr.ID] in [tree.0.1] + tree.1 }))

--- a/StandardLibrary/Sources/Array.hylo
+++ b/StandardLibrary/Sources/Array.hylo
@@ -12,7 +12,7 @@ public type Array<Element: SemiRegular>: SemiRegular {
   }
 
   /// Creates an array with the given `elements`.
-  public init<n: Int>(_ elements: sink Element[n]) {
+  public init<value n: Int>(_ elements: sink Element[n]) {
     &storage = .new()
     &reserve_capacity(n)
 

--- a/Tests/EndToEndTests/TestCases/GenericValueParameter.hylo
+++ b/Tests/EndToEndTests/TestCases/GenericValueParameter.hylo
@@ -1,6 +1,6 @@
 //- compileAndRun expecting: .success
 
-public fun foo<n: Int>() -> Int {
+public fun foo<value n: Int>() -> Int {
   n.copy()
 }
 

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -837,6 +837,22 @@ final class ParserTests: XCTestCase {
     XCTAssertEqual(decl.baseName, "T")
   }
 
+  func testGenericParameterWithTypeIntroducer() throws {
+    let input: SourceFile = "type T"
+    let (d, a) = try apply(Parser.genericParameter, on: input)
+    let n = try XCTUnwrap(a[d])
+    XCTAssertEqual(n.baseName, "T")
+    XCTAssertEqual(n.introducer?.value, .type)
+  }
+
+  func testGenericParameterWithValueIntroducer() throws {
+    let input: SourceFile = "value T"
+    let (d, a) = try apply(Parser.genericParameter, on: input)
+    let n = try XCTUnwrap(a[d])
+    XCTAssertEqual(n.baseName, "T")
+    XCTAssertEqual(n.introducer?.value, .value)
+  }
+
   func testGenericParameterWithConformances() throws {
     let input: SourceFile = "T: Foo & Bar"
     let (declID, ast) = try apply(Parser.genericParameter, on: input)

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1458,16 +1458,6 @@ final class ParserTests: XCTestCase {
     }
   }
 
-  // func testWhereClauseValueConstraintSansHint() throws {
-  //   let input: SourceFile = "x > 2"
-  //   let constraint = try XCTUnwrap(try apply(Parser.valueConstraint, on: input).element)
-  //   if case .value(let exprID) = constraint.value {
-  //     XCTAssertEqual(exprID.kind, .init(SequenceExpr.self))
-  //   } else {
-  //     XCTFail()
-  //   }
-  // }
-
   func testBoundComposition() throws {
     let input: SourceFile = "T & U & V"
     let list = try XCTUnwrap(try apply(Parser.boundComposition, on: input).element)

--- a/Tests/HyloTests/TestCases/TypeChecking/GenericParameters.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/GenericParameters.hylo
@@ -1,7 +1,7 @@
 //- typeCheck expecting: .failure
 
 //! @+1 diagnostic expected type but 'v' denotes a value
-fun f0<X, v: Int>(_ x: X, _ y: v) {}
+fun f0<X, value v: Int>(_ x: X, _ y: v) {}
 
 //! @+2 diagnostic conformance to non-trait type 'Float64'
 //! @+1 diagnostic conformance to non-trait type 'Int'

--- a/Tests/HyloTests/TestCases/TypeChecking/GenericTypeAlias.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/GenericTypeAlias.hylo
@@ -4,4 +4,4 @@ typealias Pair<X, Y> = { first: X, second: Y }
 
 typealias AnyPair = Pair<Any, Any>
 
-typealias AliasWithValue<X, v: Int> = { buffer: X }
+typealias AliasWithValue<X, value v: Int> = { buffer: X }

--- a/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric3.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/NameLookupGeneric3.hylo
@@ -11,5 +11,5 @@ trait Q {
 }
 
 extension P {
-  public fun f<T: Q, v: Int>(x: T.B) {}
+  public fun f<T: Q, value v: Int>(x: T.B) {}
 }


### PR DESCRIPTION
This PR adds a new introducer to distinguish between generic type and term parameters based on syntax, retiring the previous detection algorithm which was based on a handful of tricks.
