### PR TITLE
Implement conditional binding statements

### DIFF
--- a/Sources/FrontEnd/AST/AST+Walk.swift
+++ b/Sources/FrontEnd/AST/AST+Walk.swift
@@ -173,8 +173,8 @@ extension AST {
       traverse(self[n] as! BraceStmt, notifying: &o)
     case BreakStmt.self:
       traverse(self[n] as! BreakStmt, notifying: &o)
-    case CondBindingStmt.self:
-      traverse(self[n] as! CondBindingStmt, notifying: &o)
+    case ConditionalBindingStmt.self:
+      traverse(self[n] as! ConditionalBindingStmt, notifying: &o)
     case ConditionalCompilationStmt.self:
       traverse(self[n] as! ConditionalCompilationStmt, notifying: &o)
     case ConditionalStmt.self:
@@ -682,7 +682,7 @@ extension AST {
 
   /// Visits the children of `n` in pre-order, notifying `o` when a node is entered or left.
   public func traverse<O: ASTWalkObserver>(
-    _ n: CondBindingStmt, notifying o: inout O
+    _ n: ConditionalBindingStmt, notifying o: inout O
   ) {
     walk(n.binding, notifying: &o)
   }

--- a/Sources/FrontEnd/AST/AST+Walk.swift
+++ b/Sources/FrontEnd/AST/AST+Walk.swift
@@ -685,6 +685,7 @@ extension AST {
     _ n: ConditionalBindingStmt, notifying o: inout O
   ) {
     walk(n.binding, notifying: &o)
+    walk(n.fallback, notifying: &o)
   }
 
   /// Visits the children of `n` in pre-order, notifying `o` when a node is entered or left.

--- a/Sources/FrontEnd/AST/NodeIDs/NodeKind.swift
+++ b/Sources/FrontEnd/AST/NodeIDs/NodeKind.swift
@@ -139,7 +139,7 @@ extension NodeKind {
     AssignStmt.self,
     BraceStmt.self,
     BreakStmt.self,
-    CondBindingStmt.self,
+    ConditionalBindingStmt.self,
     ConditionalCompilationStmt.self,
     ConditionalStmt.self,
     ContinueStmt.self,

--- a/Sources/FrontEnd/AST/Stmt/ConditionalBindingStmt.swift
+++ b/Sources/FrontEnd/AST/Stmt/ConditionalBindingStmt.swift
@@ -1,23 +1,16 @@
 /// A binding to a pattern that breaks control flow if the scrutinee doesn't match.
 public struct ConditionalBindingStmt: Stmt {
 
-  public enum Fallback: Codable {
-
-    case expr(AnyExprID)
-
-    case exit(AnyStmtID)
-
-  }
-
   public let site: SourceRange
 
   /// The conditional binding.
   public let binding: BindingDecl.ID
 
-  /// The fallback expression or statement.
-  public let fallback: Fallback
+  /// The branch that to which control flow jumps if the binding fails.
+  public let fallback: BraceStmt.ID
 
-  public init(binding: BindingDecl.ID, fallback: Fallback, site: SourceRange) {
+  /// Creates an instance with the given properties.
+  public init(binding: BindingDecl.ID, fallback: BraceStmt.ID, site: SourceRange) {
     self.site = site
     self.binding = binding
     self.fallback = fallback

--- a/Sources/FrontEnd/AST/Stmt/ConditionalBindingStmt.swift
+++ b/Sources/FrontEnd/AST/Stmt/ConditionalBindingStmt.swift
@@ -1,5 +1,5 @@
-/// A break statement.
-public struct CondBindingStmt: Stmt {
+/// A binding to a pattern that breaks control flow if the scrutinee doesn't match.
+public struct ConditionalBindingStmt: Stmt {
 
   public enum Fallback: Codable {
 

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2958,7 +2958,7 @@ public enum Parser {
       try fail(.error("conditional binding requires an initializer", at: state.ast[d].site))
     }
 
-    let fallback = try state.expect("fallback", using: conditionalBindingFallback)
+    let fallback = try state.expect("fallback", using: braceStmt.parse)
     let s = state.insert(
       ConditionalBindingStmt(
         binding: d,
@@ -2966,21 +2966,6 @@ public enum Parser {
         site: state.ast[d].site.extended(upTo: state.currentIndex)))
     return AnyStmtID(s)
   }
-
-  static let conditionalBindingFallback =
-    (conditionalBindingFallbackStmt.or(conditionalBindingFallbackExpr))
-
-  static let conditionalBindingFallbackExpr =
-    (expr.map({ (_, id) -> ConditionalBindingStmt.Fallback in .expr(id) }))
-
-  static let conditionalBindingFallbackStmt =
-    (oneOf([
-      anyStmt(breakStmt),
-      anyStmt(continueStmt),
-      anyStmt(returnStmt),
-      anyStmt(braceStmt),
-    ])
-    .map({ (_, id) -> ConditionalBindingStmt.Fallback in .exit(id) }))
 
   static let declStmt =
     (Apply(parseDecl)

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2960,7 +2960,7 @@ public enum Parser {
 
     let fallback = try state.expect("fallback", using: conditionalBindingFallback)
     let s = state.insert(
-      CondBindingStmt(
+      ConditionalBindingStmt(
         binding: d,
         fallback: fallback,
         site: state.ast[d].site.extended(upTo: state.currentIndex)))
@@ -2971,7 +2971,7 @@ public enum Parser {
     (conditionalBindingFallbackStmt.or(conditionalBindingFallbackExpr))
 
   static let conditionalBindingFallbackExpr =
-    (expr.map({ (_, id) -> CondBindingStmt.Fallback in .expr(id) }))
+    (expr.map({ (_, id) -> ConditionalBindingStmt.Fallback in .expr(id) }))
 
   static let conditionalBindingFallbackStmt =
     (oneOf([
@@ -2980,7 +2980,7 @@ public enum Parser {
       anyStmt(returnStmt),
       anyStmt(braceStmt),
     ])
-    .map({ (_, id) -> CondBindingStmt.Fallback in .exit(id) }))
+    .map({ (_, id) -> ConditionalBindingStmt.Fallback in .exit(id) }))
 
   static let declStmt =
     (Apply(parseDecl)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -369,6 +369,10 @@ extension Diagnostic {
     }
   }
 
+  static func error(fallbackBranchCannotFallThroughAt site: SourceRange) -> Diagnostic {
+    .error("fallback branch of conditional binding cannot fall through", at: site)
+  }
+
   static func error(
     referenceTo d: SourceRepresentable<Name>, requires t: AnyType, conformsTo u: TraitType,
     dueToConstraintAt constraintSite: SourceRange

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1228,7 +1228,6 @@ struct TypeChecker {
       break
     case ConditionalCompilationStmt.self:
       check(ConditionalCompilationStmt.ID(s)!)
-    // case ConditionalBindingStmt.self:
     case ConditionalStmt.self:
       check(ConditionalStmt.ID(s)!)
     case ContinueStmt.self:

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1228,6 +1228,7 @@ struct TypeChecker {
       break
     case ConditionalCompilationStmt.self:
       check(ConditionalCompilationStmt.ID(s)!)
+    // case ConditionalBindingStmt.self:
     case ConditionalStmt.self:
       check(ConditionalStmt.ID(s)!)
     case ContinueStmt.self:

--- a/Tests/EndToEndTests/TestCases/ConditionalBinding.hylo
+++ b/Tests/EndToEndTests/TestCases/ConditionalBinding.hylo
@@ -1,0 +1,11 @@
+//- compileAndRun expecting: .success
+
+public fun main() {
+  var x: Union<Int, Bool> = true as _
+
+  let y: Bool = x else { fatal_error() }
+  precondition(y)
+
+  let _: Int = x else { return }
+  fatal_error()
+}

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1646,7 +1646,7 @@ final class ParserTests: XCTestCase {
   func testConditionalBinding() throws {
     let input: SourceFile = "var x = foo() else return"
     let (s, ast) = try apply(Parser.bindingStmt, on: input, context: .functionBody)
-    let stmt = try XCTUnwrap(ast[s.flatMap(CondBindingStmt.ID.init)])
+    let stmt = try XCTUnwrap(ast[s.flatMap(ConditionalBindingStmt.ID.init)])
     if case .exit = stmt.fallback {
     } else {
       XCTFail()
@@ -1656,7 +1656,7 @@ final class ParserTests: XCTestCase {
   func testConditionalBindingBlock() throws {
     let input: SourceFile = "var x = foo() else { bar(); return }"
     let (s, ast) = try apply(Parser.bindingStmt, on: input, context: .functionBody)
-    let stmt = try XCTUnwrap(ast[s.flatMap(CondBindingStmt.ID.init)])
+    let stmt = try XCTUnwrap(ast[s.flatMap(ConditionalBindingStmt.ID.init)])
     if case .exit = stmt.fallback {
     } else {
       XCTFail()
@@ -1666,7 +1666,7 @@ final class ParserTests: XCTestCase {
   func testConditionalBindingExpr() throws {
     let input: SourceFile = "var x = foo() else fatal_error()"
     let (s, ast) = try apply(Parser.bindingStmt, on: input, context: .functionBody)
-    let stmt = try XCTUnwrap(ast[s.flatMap(CondBindingStmt.ID.init)])
+    let stmt = try XCTUnwrap(ast[s.flatMap(ConditionalBindingStmt.ID.init)])
     if case .expr = stmt.fallback {
     } else {
       XCTFail()

--- a/Tests/HyloTests/ParserTests.swift
+++ b/Tests/HyloTests/ParserTests.swift
@@ -1644,39 +1644,11 @@ final class ParserTests: XCTestCase {
   }
 
   func testConditionalBinding() throws {
-    let input: SourceFile = "var x = foo() else return"
-    let (s, ast) = try apply(Parser.bindingStmt, on: input, context: .functionBody)
-    let stmt = try XCTUnwrap(ast[s.flatMap(ConditionalBindingStmt.ID.init)])
-    if case .exit = stmt.fallback {
-    } else {
-      XCTFail()
-    }
-  }
-
-  func testConditionalBindingBlock() throws {
-    let input: SourceFile = "var x = foo() else { bar(); return }"
-    let (s, ast) = try apply(Parser.bindingStmt, on: input, context: .functionBody)
-    let stmt = try XCTUnwrap(ast[s.flatMap(ConditionalBindingStmt.ID.init)])
-    if case .exit = stmt.fallback {
-    } else {
-      XCTFail()
-    }
-  }
-
-  func testConditionalBindingExpr() throws {
-    let input: SourceFile = "var x = foo() else fatal_error()"
-    let (s, ast) = try apply(Parser.bindingStmt, on: input, context: .functionBody)
-    let stmt = try XCTUnwrap(ast[s.flatMap(ConditionalBindingStmt.ID.init)])
-    if case .expr = stmt.fallback {
-    } else {
-      XCTFail()
-    }
-  }
-
-  func testConditionalBindingFallback() throws {
-    let input: SourceFile = "return"
-    XCTAssertNotNil(
-      try apply(Parser.conditionalBindingFallbackStmt, on: input, context: .functionBody))
+    let input: SourceFile = "var x = foo() else { return }"
+    let (s, a) = try apply(Parser.bindingStmt, on: input, context: .functionBody)
+    let n = try XCTUnwrap(a[s.flatMap(ConditionalBindingStmt.ID.init(_:))])
+    let m = try XCTUnwrap(a[n.fallback].stmts.first)
+    XCTAssert(m.kind == ReturnStmt.self)
   }
 
   func testDeclStmt() throws {

--- a/Tests/HyloTests/TestCases/TypeChecking/ConditionalBinding.hylo
+++ b/Tests/HyloTests/TestCases/TypeChecking/ConditionalBinding.hylo
@@ -1,0 +1,13 @@
+//- typeCheck expecting: .failure
+
+public fun main() {
+  //! @+1 diagnostic fallback branch of conditional binding cannot fall through
+  let x? = Optional<Int>.none() else {}
+  print(x)
+
+  let y? = Optional<Int>.none() else {
+    let z = 0
+    //! @+1 diagnostic fallback branch of conditional binding cannot fall through
+    print(z)
+  }
+}


### PR DESCRIPTION
This PR implements full support for conditional binding statements, e.g:
```
fun print_int_or_trap(_ x: Union<Int, Bool>) {
  let y: Int = x else { fatal_error() }
  print(y)
}
```