### PR TITLE
Implement consuming for loops

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1592,9 +1592,10 @@ struct TypeChecker {
     /// Checks whether the constraints on the requirements of `trait` are satisfied by `model` in
     /// `scopeOfuse`, reporting diagnostics in `conformanceDiagnostics`.
     func checkRequirementConstraints() -> Bool {
-      var obligations = ProofObligations(scope: scopeOfDefinition)
-
       let e = environment(of: trait.decl)
+      var obligations = ProofObligations(
+        scope: AnyScopeID(origin.source) ?? program[origin.source].scope)
+
       for g in e.constraints {
         let c = specialize(
           g, for: traitReceiverToModel, in: scopeOfDefinition,

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -492,7 +492,8 @@ public struct TypedProgram {
   /// - Requires: `n` is declared by the trait for which `c` has been established.
   public func associatedType(_ n: AssociatedTypeDecl.ID, for c: Conformance) -> AnyType {
     let d = c.implementations[n]!.decl!
-    let t = specialize(MetatypeType(declType[d]!)!.instance, for: c.arguments, in: c.scope)
+    let s: AnyScopeID = c.origin.flatMap({ (o) in AnyScopeID(o.source) }) ?? c.scope
+    let t = specialize(MetatypeType(declType[d]!)!.instance, for: c.arguments, in: s)
     return canonical(t, in: c.scope)
   }
 

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2406,7 +2406,7 @@ struct Emitter {
   /// a rreference to that storage. Otherwise, returns `nil`.
   private mutating func emitAllocation(binding d: BindingDecl.ID) -> Operand? {
     if program[d].pattern.introducer.value.isConsuming {
-      return insert(module.makeAllocStack(program[d].type, at: ast[d].site))
+      return emitAllocStack(for: program[d].type, at: ast[d].site)
     } else {
       return nil
     }

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1208,16 +1208,63 @@ struct Emitter {
   /// Inserts the IR for loop `s`, returning its effect on control flow.
   private mutating func emit(forStmt s: ForStmt.ID) -> ControlFlow {
     if program.ast.isConsuming(s) {
-      UNIMPLEMENTED("consuming for loops")
+      return emit(consumingForStmt: s)
     } else {
       return emit(nonConsumingForStmt: s)
     }
   }
 
+  /// Inserts the IR for consuming loop `s`, returning its effect on control flow.
+  private mutating func emit(consumingForStmt s: ForStmt.ID) -> ControlFlow {
+    let d = program[program[s].domain.value].type
+    let c = program.conformance(
+      of: d, to: ast.core.iterator.type, exposedTo: program[s].scope)!
+    let witness = IteratorWitness(c, in: &module)
+    let introducer = program[s].introducerSite
+
+    // The collection on which the loop iterates.
+    let domain = emitLValue(program[s].domain.value)
+    // The element extracted before each iteration.
+    let element = emitAllocStack(for: ^ast.optional(witness.element), at: introducer)
+    // The storage containing the result of binding each element.
+    let storage = emitAllocation(binding: ast[s].binding)
+
+    // The "head" of the loop; extracts the next element.
+    let head = appendBlock(in: s)
+    // The remainder of the program, after the loop.
+    let exit = appendBlock()
+
+    loops.append(LoopID(depth: frames.depth, exit: exit))
+    defer { loops.removeLast() }
+
+    insert(module.makeBranch(to: head, at: introducer))
+    insertionPoint = .end(of: head)
+
+    let x0 = insert(module.makeAccess(.inout, from: domain, at: introducer))!
+    emitApply(witness.next, to: [x0], writingResultTo: element, at: introducer)
+    insert(module.makeEndAccess(x0, at: introducer))
+
+    let next = emitUnionNarrowing(
+      from: element, to: ast[ast[s].binding].pattern, typed: witness.element,
+      movingConsumedValuesTo: storage, branchingOnFailureTo: exit,
+      in: insertionScope!)
+
+    // TODO: Filter
+    precondition(ast[s].filter == nil, "loop filters are not implemented")
+
+    insertionPoint = .end(of: next)
+    let flow = emit(braceStmt: ast[s].body)
+    emitControlFlow(flow) { (me) in
+      me.insert(me.module.makeBranch(to: head, at: .empty(at: me.program[s].body.site.end)))
+    }
+
+    insertionPoint = .end(of: exit)
+    return .next
+  }
+
   /// Inserts the IR for non-consuming loop `s`, returning its effect on control flow.
   private mutating func emit(nonConsumingForStmt s: ForStmt.ID) -> ControlFlow {
     let domainType = program[program[s].domain.value].type
-
     let collection = ast.core.collection
     let collectionConformance = program.conformance(
       of: domainType, to: collection.type, exposedTo: program[s].scope)!
@@ -1277,6 +1324,7 @@ struct Emitter {
       introducedBy: program[s].binding.pattern, referringTo: [], relativeTo: x8)
 
     // TODO: Filter
+    precondition(ast[s].filter == nil, "loop filters are not implemented")
 
     let flow = emit(braceStmt: ast[s].body)
     emitControlFlow(flow) { (me) in
@@ -2391,38 +2439,57 @@ struct Emitter {
 
     assert(program[lhs].introducer.value.isConsuming || (storage == nil))
 
-    if let rhsType = UnionType(module.type(of: rhs).ast) {
-      guard rhsType.elements.contains(lhsType) else { UNIMPLEMENTED("recursive narrowing") }
-
-      let next = appendBlock(in: scope)
-      let site = program[lhs].site
-
-      var targets = UnionSwitch.Targets(
-        rhsType.elements.map({ (e) in (key: e, value: failure) }),
-        uniquingKeysWith: { (a, _) in a })
-      targets[lhsType] = next
-      emitUnionSwitch(on: rhs, toOneOf: targets, at: site)
-
-      insertionPoint = .end(of: next)
-
-      if let target = storage {
-        let x0 = insert(module.makeAccess(.sink, from: rhs, at: site))!
-        let x1 = insert(module.makeOpenUnion(x0, as: lhsType, at: site))!
-        emitMove([.set], x1, to: target, at: site)
-        emitLocalDeclarations(introducedBy: lhs, referringTo: [], relativeTo: target)
-        insert(module.makeCloseUnion(x1, at: site))
-        insert(module.makeEndAccess(x0, at: site))
-      } else {
-        let k = AccessEffect(program[lhs].introducer.value)
-        let x0 = insert(module.makeAccess(k, from: rhs, at: site))!
-        let x1 = insert(module.makeOpenUnion(x0, as: lhsType, at: site))!
-        assignProjections(of: x1, to: program[d].pattern)
-      }
-
-      return next
+    if module.type(of: rhs).ast.base is UnionType {
+      return emitUnionNarrowing(
+        from: rhs, to: lhs, typed: lhsType,
+        movingConsumedValuesTo: storage, branchingOnFailureTo: failure,
+        in: scope)
     } else {
       UNIMPLEMENTED()
     }
+  }
+
+  /// Returns a basic block in which the names in `lhs` have been declared and initialized.
+  ///
+  /// - Parameters:
+  ///   - rhs: A union container of a type that includes `lhsType`.
+  ///   - storage: For a consuming narrowing, the storage of the bindings declared in `lhs`.
+  ///   - failure: The basic block to which control flow jumps if the narrowing fails.
+  ///   - scope: The scope in which the new basic block is introducked.
+  private mutating func emitUnionNarrowing(
+    from rhs: Operand, to lhs: BindingPattern.ID, typed lhsType: AnyType,
+    movingConsumedValuesTo storage: Operand?,
+    branchingOnFailureTo failure: Block.ID,
+    in scope: AnyScopeID
+  ) -> Block.ID {
+    let rhsType = UnionType(module.type(of: rhs).ast)!
+    precondition(rhsType.elements.contains(lhsType), "recursive narrowing is unimplemented")
+
+    let next = appendBlock(in: scope)
+    let site = program[lhs].site
+    var targets = UnionSwitch.Targets(
+      rhsType.elements.map({ (e) in (key: e, value: failure) }),
+      uniquingKeysWith: { (a, _) in a })
+    targets[lhsType] = next
+    emitUnionSwitch(on: rhs, toOneOf: targets, at: site)
+
+    insertionPoint = .end(of: next)
+
+    if let target = storage {
+      let x0 = insert(module.makeAccess(.sink, from: rhs, at: site))!
+      let x1 = insert(module.makeOpenUnion(x0, as: lhsType, at: site))!
+      emitMove([.set], x1, to: target, at: site)
+      emitLocalDeclarations(introducedBy: lhs, referringTo: [], relativeTo: target)
+      insert(module.makeCloseUnion(x1, at: site))
+      insert(module.makeEndAccess(x0, at: site))
+    } else {
+      let k = AccessEffect(program[lhs].introducer.value)
+      let x0 = insert(module.makeAccess(k, from: rhs, at: site))!
+      let x1 = insert(module.makeOpenUnion(x0, as: lhsType, at: site))!
+      assignProjections(of: x1, to: lhs)
+    }
+
+    return next
   }
 
   /// Inserts the IR for branch condition `e`.

--- a/Sources/IR/IteratorWitness.swift
+++ b/Sources/IR/IteratorWitness.swift
@@ -1,0 +1,19 @@
+import FrontEnd
+
+/// The witness of a type's conformance to the `Iterator` trait from the standard library.
+struct IteratorWitness {
+
+  /// The implementation of the `Iterator.Element`.
+  let element: AnyType
+
+  /// The implementation of `Iterator.next`.
+  let next: Operand
+
+  /// Creates the lowered witness of the conformance `c` for use in `module`.
+  init(_ c: FrontEnd.Conformance, in module: inout Module) {
+    let iterator = module.program.ast.core.iterator
+    self.element = module.program.associatedType(iterator.element, for: c)
+    self.next = .constant(module.reference(toImplementationOf: iterator.next, for: c))
+  }
+
+}

--- a/Tests/EndToEndTests/TestCases/For.hylo
+++ b/Tests/EndToEndTests/TestCases/For.hylo
@@ -1,0 +1,7 @@
+//- compileAndRun expecting: .success
+
+public fun main() {
+  var x = 0
+  for sink let i in 0 ..< 3 { &x = i }
+  precondition(x == 2)
+}


### PR DESCRIPTION
This PR implements support for loops like the following:
```
for sink let n in 0 ..< 10 { print(n) }
```