### PR TITLE
Add a Compiler option to profile the compilation time 

### DIFF
--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -13,6 +13,8 @@ public struct LLVMProgram {
   /// The LLVM modules in the program.
   public private(set) var llvmModules: [ModuleDecl.ID: SwiftyLLVM.Module] = [:]
 
+  let profiler : ProfilingMeasurements?
+
   /// Creates a transpiling `ir`, whose main module is `mainModule`, for `target`.
   ///
   /// - Parameters:
@@ -20,11 +22,14 @@ public struct LLVMProgram {
   public init(
     _ ir: IR.Program,
     mainModule: ModuleDecl.ID,
-    for target: SwiftyLLVM.TargetMachine? = nil
+    for target: SwiftyLLVM.TargetMachine? = nil,
+    profileWith profiler: ProfilingMeasurements?
   ) throws {
+    self.profiler = profiler
     self.target = try target ?? SwiftyLLVM.TargetMachine(for: .host())
     for m in ir.modules.keys {
       var context = CodeGenerationContext(forCompiling: m, of: ir)
+      let _convertProbe = profiler?.createTimeMeasurementProbe(MeasurementType.IRConversion)          
       let transpilation = SwiftyLLVM.Module(transpiling: m, in: &context)
       do {
         try transpilation.verify()
@@ -38,6 +43,7 @@ public struct LLVMProgram {
 
   /// Applies the mandatory IR simplification passes on each module in `self`.
   public mutating func applyMandatoryPasses() {
+    let _optimizeProbe = profiler?.createTimeMeasurementProbe(MeasurementType.MandatoryPass)    
     for k in llvmModules.keys {
       llvmModules[k]!.runDefaultModulePasses(optimization: .none, for: target)
     }
@@ -47,6 +53,7 @@ public struct LLVMProgram {
   ///
   /// Optimization applied are similar to clang's `-O3`.
   public mutating func optimize() {
+    let _mandatoryProbe = profiler?.createTimeMeasurementProbe(MeasurementType.Optimizations)
     for k in llvmModules.keys {
       llvmModules[k]!.runDefaultModulePasses(optimization: .aggressive, for: target)
     }
@@ -63,6 +70,7 @@ public struct LLVMProgram {
     var result: [URL] = []
     for m in llvmModules.values {
       let f = directory.appendingPathComponent(m.name).appendingPathExtension("o")
+      let _writeProbe = profiler?.createTimeMeasurementProbe(MeasurementType.EmitPhase)
       try m.write(type, for: target, to: f.fileSystemPath)
       result.append(f)
     }

--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -13,7 +13,7 @@ public struct LLVMProgram {
   /// The LLVM modules in the program.
   public private(set) var llvmModules: [ModuleDecl.ID: SwiftyLLVM.Module] = [:]
 
-  let profiler : ProfilingMeasurements?
+  let profiler: ProfilingMeasurements?
 
   /// Creates a transpiling `ir`, whose main module is `mainModule`, for `target`.
   ///
@@ -29,7 +29,7 @@ public struct LLVMProgram {
     self.target = try target ?? SwiftyLLVM.TargetMachine(for: .host())
     for m in ir.modules.keys {
       var context = CodeGenerationContext(forCompiling: m, of: ir)
-      let _convertProbe = profiler?.createTimeMeasurementProbe(MeasurementType.IRConversion)          
+      let _convertProbe = profiler?.createTimeMeasurementProbe(MeasurementType.IRConversion)
       let transpilation = SwiftyLLVM.Module(transpiling: m, in: &context)
       do {
         try transpilation.verify()
@@ -43,7 +43,7 @@ public struct LLVMProgram {
 
   /// Applies the mandatory IR simplification passes on each module in `self`.
   public mutating func applyMandatoryPasses() {
-    let _optimizeProbe = profiler?.createTimeMeasurementProbe(MeasurementType.MandatoryPass)    
+    let _optimizeProbe = profiler?.createTimeMeasurementProbe(MeasurementType.MandatoryPass)
     for k in llvmModules.keys {
       llvmModules[k]!.runDefaultModulePasses(optimization: .none, for: target)
     }

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -7,7 +7,6 @@ import StandardLibrary
 import SwiftyLLVM
 import Utils
 
-
 public struct Driver: ParsableCommand {
 
   /// A validation error that includes the command's full help message.
@@ -99,7 +98,7 @@ public struct Driver: ParsableCommand {
   @Flag(
     name: [.customLong("profile-compiler")],
     help: "Profile the compilation time")
-  private var profileCompiler: Bool = false  
+  private var profileCompiler: Bool = false
 
   @Option(
     name: [.customLong("trace-inference")],
@@ -248,7 +247,7 @@ public struct Driver: ParsableCommand {
     let productName = makeProductName(inputs)
 
     // Pool of measurements for time profiling
-    var profiler : ProfilingMeasurements? =  profileCompiler ? ProfilingMeasurements() : nil
+    var profiler: ProfilingMeasurements? = profileCompiler ? ProfilingMeasurements() : nil
     defer { profiler?.printProfilingReport() }
 
     // There's no need to load the standard library under `--emit raw-ast`.
@@ -304,7 +303,6 @@ public struct Driver: ParsableCommand {
       return
     }
 
-
     // LLVM
 
     logVerbose("begin depolymorphization pass.\n")
@@ -318,7 +316,8 @@ public struct Driver: ParsableCommand {
     #endif
 
     logVerbose("create LLVM program.\n")
-    var llvmProgram = try LLVMProgram(ir, mainModule: sourceModule, for: target, profileWith: profiler)
+    var llvmProgram = try LLVMProgram(
+      ir, mainModule: sourceModule, for: target, profileWith: profiler)
 
     logVerbose("LLVM mandatory passes.\n")
     llvmProgram.applyMandatoryPasses()
@@ -353,11 +352,14 @@ public struct Driver: ParsableCommand {
     let binaryPath = executableOutputPath(default: productName)
 
     #if os(macOS)
-      try makeMacOSExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
+      try makeMacOSExecutable(
+        at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
     #elseif os(Linux)
-      try makeLinuxExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
+      try makeLinuxExecutable(
+        at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
     #elseif os(Windows)
-      try makeWindowsExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
+      try makeWindowsExecutable(
+        at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
     #else
       _ = (objectFiles, binaryPath)
       UNIMPLEMENTED()
@@ -393,9 +395,9 @@ public struct Driver: ParsableCommand {
   /// Mandatory IR passes are applied unless `self.outputType` is `.rawIR`.
   private func lower(
     program: TypedProgram, reportingDiagnosticsTo log: inout DiagnosticSet,
-    profileWith profiler : ProfilingMeasurements?    
+    profileWith profiler: ProfilingMeasurements?
   ) throws -> IR.Program {
-    let _irProbe = profiler?.createTimeMeasurementProbe(MeasurementType.IRLowering)    
+    let _irProbe = profiler?.createTimeMeasurementProbe(MeasurementType.IRLowering)
     var loweredModules: [ModuleDecl.ID: IR.Module] = [:]
     for d in program.ast.modules {
       loweredModules[d] = try lower(d, in: program, reportingDiagnosticsTo: &log)
@@ -426,7 +428,7 @@ public struct Driver: ParsableCommand {
   /// logging diagnostics to `log`.
   private func makeMacOSExecutable(
     at binaryPath: String, linking objects: [URL], diagnostics: inout DiagnosticSet,
-    profileWith profiler: ProfilingMeasurements? 
+    profileWith profiler: ProfilingMeasurements?
   ) throws {
     let xcrun = try findExecutable(invokedAs: "xcrun").fileSystemPath
 
@@ -455,7 +457,7 @@ public struct Driver: ParsableCommand {
     at binaryPath: String,
     linking objects: [URL],
     diagnostics: inout DiagnosticSet,
-    profileWith profiler: ProfilingMeasurements?     
+    profileWith profiler: ProfilingMeasurements?
   ) throws {
     var arguments = [
       "-o", binaryPath,
@@ -479,7 +481,7 @@ public struct Driver: ParsableCommand {
     at binaryPath: String,
     linking objects: [URL],
     diagnostics: inout DiagnosticSet,
-    profileWith profiler: ProfilingMeasurements?     
+    profileWith profiler: ProfilingMeasurements?
   ) throws {
     // linking profiling probe
     let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.LinkPhase)

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -7,6 +7,7 @@ import StandardLibrary
 import SwiftyLLVM
 import Utils
 
+
 public struct Driver: ParsableCommand {
 
   /// A validation error that includes the command's full help message.
@@ -94,6 +95,11 @@ public struct Driver: ParsableCommand {
     name: [.customLong("typecheck")],
     help: "Type-check the input file(s).")
   private var typeCheckOnly: Bool = false
+
+  @Flag(
+    name: [.customLong("profile-compiler")],
+    help: "Profile the compilation time")
+  private var profileCompiler: Bool = false  
 
   @Option(
     name: [.customLong("trace-inference")],
@@ -241,13 +247,18 @@ public struct Driver: ParsableCommand {
 
     let productName = makeProductName(inputs)
 
+    // Pool of measurements for time profiling
+    var profiler : ProfilingMeasurements? =  profileCompiler ? ProfilingMeasurements() : nil
+    defer { profiler?.printProfilingReport() }
+
     // There's no need to load the standard library under `--emit raw-ast`.
     if outputType == .rawAST {
       var a = AST()
       _ = try a.loadModule(
         productName, parsing: sourceFiles(in: inputs),
         withBuiltinModuleAccess: importBuiltinModule,
-        reportingDiagnosticsTo: &log)
+        reportingDiagnosticsTo: &log,
+        profileWith: profiler)
       try write(a, to: astFile(productName))
       return
     }
@@ -266,7 +277,8 @@ public struct Driver: ParsableCommand {
         annotating: ScopedProgram(a), inParallel: experimentalParallelTypeChecking,
         reportingDiagnosticsTo: &log,
         tracingInferenceIf: shouldTraceInference,
-        loggingRequirementSystemIf: shouldLogRequirements)
+        loggingRequirementSystemIf: shouldLogRequirements,
+        profileWith: profiler)
     }
 
     let (program, sourceModule) = try dependencies.loadModule(
@@ -277,14 +289,14 @@ public struct Driver: ParsableCommand {
       try ast.loadModule(
         productName, parsing: sourceFiles(in: inputs), inNodeSpace: space,
         withBuiltinModuleAccess: importBuiltinModule,
-        reportingDiagnosticsTo: &log)
+        reportingDiagnosticsTo: &log,
+        profileWith: profiler)
     }
 
     if typeCheckOnly { return }
 
     // IR
-
-    var ir = try lower(program: program, reportingDiagnosticsTo: &log)
+    var ir = try lower(program: program, reportingDiagnosticsTo: &log, profileWith: profiler)
 
     if outputType == .ir || outputType == .rawIR {
       let m = ir.modules[sourceModule]!
@@ -292,10 +304,11 @@ public struct Driver: ParsableCommand {
       return
     }
 
+
     // LLVM
 
     logVerbose("begin depolymorphization pass.\n")
-    ir.depolymorphize()
+    ir.depolymorphize(profileWith: profiler)
 
     logVerbose("create LLVM target machine.\n")
     #if os(Windows)
@@ -305,7 +318,7 @@ public struct Driver: ParsableCommand {
     #endif
 
     logVerbose("create LLVM program.\n")
-    var llvmProgram = try LLVMProgram(ir, mainModule: sourceModule, for: target)
+    var llvmProgram = try LLVMProgram(ir, mainModule: sourceModule, for: target, profileWith: profiler)
 
     logVerbose("LLVM mandatory passes.\n")
     llvmProgram.applyMandatoryPasses()
@@ -340,11 +353,11 @@ public struct Driver: ParsableCommand {
     let binaryPath = executableOutputPath(default: productName)
 
     #if os(macOS)
-      try makeMacOSExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log)
+      try makeMacOSExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
     #elseif os(Linux)
-      try makeLinuxExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log)
+      try makeLinuxExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
     #elseif os(Windows)
-      try makeWindowsExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log)
+      try makeWindowsExecutable(at: binaryPath, linking: objectFiles, diagnostics: &log, profileWith: profiler)
     #else
       _ = (objectFiles, binaryPath)
       UNIMPLEMENTED()
@@ -379,8 +392,10 @@ public struct Driver: ParsableCommand {
   ///
   /// Mandatory IR passes are applied unless `self.outputType` is `.rawIR`.
   private func lower(
-    program: TypedProgram, reportingDiagnosticsTo log: inout DiagnosticSet
+    program: TypedProgram, reportingDiagnosticsTo log: inout DiagnosticSet,
+    profileWith profiler : ProfilingMeasurements?    
   ) throws -> IR.Program {
+    let _irProbe = profiler?.createTimeMeasurementProbe(MeasurementType.IRLowering)    
     var loweredModules: [ModuleDecl.ID: IR.Module] = [:]
     for d in program.ast.modules {
       loweredModules[d] = try lower(d, in: program, reportingDiagnosticsTo: &log)
@@ -410,9 +425,14 @@ public struct Driver: ParsableCommand {
   /// Combines the object files located at `objects` into an executable file at `binaryPath`,
   /// logging diagnostics to `log`.
   private func makeMacOSExecutable(
-    at binaryPath: String, linking objects: [URL], diagnostics: inout DiagnosticSet
+    at binaryPath: String, linking objects: [URL], diagnostics: inout DiagnosticSet,
+    profileWith profiler: ProfilingMeasurements? 
   ) throws {
     let xcrun = try findExecutable(invokedAs: "xcrun").fileSystemPath
+
+    // linking profiling probe
+    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.LinkPhase)
+
     let sdk =
       try runCommandLine(xcrun, ["--sdk", "macosx", "--show-sdk-path"], diagnostics: &diagnostics)
       ?? ""
@@ -434,7 +454,8 @@ public struct Driver: ParsableCommand {
   private func makeLinuxExecutable(
     at binaryPath: String,
     linking objects: [URL],
-    diagnostics: inout DiagnosticSet
+    diagnostics: inout DiagnosticSet,
+    profileWith profiler: ProfilingMeasurements?     
   ) throws {
     var arguments = [
       "-o", binaryPath,
@@ -442,6 +463,9 @@ public struct Driver: ParsableCommand {
     arguments.append(contentsOf: librarySearchPaths.map({ "-L\($0)" }))
     arguments.append(contentsOf: objects.map(\.fileSystemPath))
     arguments.append(contentsOf: libraries.map({ "-l\($0)" }))
+
+    // linking profiling probe
+    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.LinkPhase)
 
     // Note: We use "clang" rather than "ld" so that to deal with the entry point of the program.
     // See https://stackoverflow.com/questions/51677440
@@ -454,8 +478,12 @@ public struct Driver: ParsableCommand {
   private func makeWindowsExecutable(
     at binaryPath: String,
     linking objects: [URL],
-    diagnostics: inout DiagnosticSet
+    diagnostics: inout DiagnosticSet,
+    profileWith profiler: ProfilingMeasurements?     
   ) throws {
+    // linking profiling probe
+    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.LinkPhase)
+
     try runCommandLine(
       findExecutable(invokedAs: "lld-link").fileSystemPath,
       ["-defaultlib:HyloLibC", "-defaultlib:msvcrt", "-out:" + binaryPath]

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -397,7 +397,8 @@ public struct Driver: ParsableCommand {
     program: TypedProgram, reportingDiagnosticsTo log: inout DiagnosticSet,
     profileWith profiler: ProfilingMeasurements?
   ) throws -> IR.Program {
-    let _irProbe = profiler?.createTimeMeasurementProbe(MeasurementType.IRLowering)
+    let probe = profiler?.createAndStartProfilingProbe(MeasurementType.IRLowering)
+    defer { probe?.stop() }
     var loweredModules: [ModuleDecl.ID: IR.Module] = [:]
     for d in program.ast.modules {
       loweredModules[d] = try lower(d, in: program, reportingDiagnosticsTo: &log)
@@ -433,7 +434,8 @@ public struct Driver: ParsableCommand {
     let xcrun = try findExecutable(invokedAs: "xcrun").fileSystemPath
 
     // linking profiling probe
-    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.LinkPhase)
+    let probe = profiler?.createAndStartProfilingProbe(MeasurementType.LinkPhase)
+    defer { probe?.stop() }
 
     let sdk =
       try runCommandLine(xcrun, ["--sdk", "macosx", "--show-sdk-path"], diagnostics: &diagnostics)
@@ -467,7 +469,8 @@ public struct Driver: ParsableCommand {
     arguments.append(contentsOf: libraries.map({ "-l\($0)" }))
 
     // linking profiling probe
-    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.LinkPhase)
+    let probe = profiler?.createAndStartProfilingProbe(MeasurementType.LinkPhase)
+    defer { probe?.stop() }
 
     // Note: We use "clang" rather than "ld" so that to deal with the entry point of the program.
     // See https://stackoverflow.com/questions/51677440
@@ -484,7 +487,8 @@ public struct Driver: ParsableCommand {
     profileWith profiler: ProfilingMeasurements?
   ) throws {
     // linking profiling probe
-    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.LinkPhase)
+    let probe = profiler?.createAndStartProfilingProbe(MeasurementType.LinkPhase)
+    defer { probe?.stop() }
 
     try runCommandLine(
       findExecutable(invokedAs: "lld-link").fileSystemPath,

--- a/Sources/FrontEnd/AST/AST.swift
+++ b/Sources/FrontEnd/AST/AST.swift
@@ -447,7 +447,7 @@ public struct AST {
 
       case TuplePattern.self:
         let x = TuplePattern.ID(pattern)!
-        for i in 0 ..< self[x].elements.count {
+        for i in 0..<self[x].elements.count {
           visit(pattern: self[x].elements[i].pattern, subfield: subfield + [i], result: &result)
         }
 

--- a/Sources/FrontEnd/AST/AST.swift
+++ b/Sources/FrontEnd/AST/AST.swift
@@ -107,12 +107,13 @@ public struct AST {
   public mutating func loadModule<S: Sequence>(
     _ name: String, parsing sourceCode: S, inNodeSpace space: Int? = nil,
     withBuiltinModuleAccess builtinModuleAccess: Bool = false,
-    reportingDiagnosticsTo log: inout DiagnosticSet
+    reportingDiagnosticsTo log: inout DiagnosticSet,
+    profileWith profiler: ProfilingMeasurements? = nil
   ) throws -> ModuleDecl.ID where S.Element == SourceFile {
     try loadModule(reportingDiagnosticsTo: &log) { (me, log, k) in
       // Suppress thrown diagnostics until all files are parsed.
       let translations = sourceCode.compactMap { (f) in
-        try? Parser.parse(f, inNodeSpace: k, in: &me, diagnostics: &log)
+        try? Parser.parse(f, inNodeSpace: k, in: &me, diagnostics: &log, profileWith: profiler)
       }
 
       let m = me.insert(

--- a/Sources/FrontEnd/AST/NodeIDs/DeclIDs.swift
+++ b/Sources/FrontEnd/AST/NodeIDs/DeclIDs.swift
@@ -35,7 +35,7 @@ public struct DeclIDs {
 
   /// The identifiers in `self` denoting type extending declarations.
   public var extensions: ArraySlice<AnyDeclID> {
-    all[0 ..< extensionEndIndex]
+    all[0..<extensionEndIndex]
   }
 
   /// The identifiers in `self` _not_ denoting type extending declarations.

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -1,3 +1,5 @@
+import Utils
+
 /// A type that tokenize a source file.
 public struct Lexer: IteratorProtocol, Sequence {
 
@@ -7,10 +9,13 @@ public struct Lexer: IteratorProtocol, Sequence {
   /// The current position in the source file.
   private(set) var index: String.Index
 
+  private let profiler : ProfilingMeasurements?
+
   /// Creates a lexer generating tokens from the contents of `source`.
-  public init(tokenizing source: SourceFile) {
+  public init(tokenizing source: SourceFile, profileWith profiler: ProfilingMeasurements? = nil) {
     self.sourceCode = source
     self.index = source.text.startIndex
+    self.profiler = profiler
   }
 
   /// The current location of the lexer in `sourceCode`.
@@ -21,6 +26,9 @@ public struct Lexer: IteratorProtocol, Sequence {
 
   /// Advances to the next token and returns it, or returns `nil` if no next token exists.
   public mutating func next() -> Token? {
+    // Start measuring Lexer time
+     let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Lexer)
+
     // Skip whitespaces and comments.
     while true {
       if index == sourceCode.text.endIndex { return nil }

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -9,7 +9,7 @@ public struct Lexer: IteratorProtocol, Sequence {
   /// The current position in the source file.
   private(set) var index: String.Index
 
-  private let profiler : ProfilingMeasurements?
+  private let profiler: ProfilingMeasurements?
 
   /// Creates a lexer generating tokens from the contents of `source`.
   public init(tokenizing source: SourceFile, profileWith profiler: ProfilingMeasurements? = nil) {
@@ -27,7 +27,7 @@ public struct Lexer: IteratorProtocol, Sequence {
   /// Advances to the next token and returns it, or returns `nil` if no next token exists.
   public mutating func next() -> Token? {
     // Start measuring Lexer time
-     let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Lexer)
+    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Lexer)
 
     // Skip whitespaces and comments.
     while true {
@@ -62,7 +62,7 @@ public struct Lexer: IteratorProtocol, Sequence {
           } else {
             return Token(
               kind: .unterminatedBlockComment,
-              site: sourceCode.range(start ..< index))
+              site: sourceCode.range(start..<index))
           }
         }
 
@@ -76,12 +76,12 @@ public struct Lexer: IteratorProtocol, Sequence {
 
     // Scan a new token.
     let head = sourceCode.text[index]
-    var token = Token(kind: .invalid, site: location ..< location)
+    var token = Token(kind: .invalid, site: location..<location)
 
     // Try scan for exponent if previous token was .int
     if previousTokenWasInt, let next = peek(), next == "e" || next == "E" {
       discard()
-      if let _ = scanIntegralLiteral(allowingPlus: true) {
+      if scanIntegralLiteral(allowingPlus: true) != nil {
         token.kind = .exponent
       }
       token.site.extend(upTo: index)
@@ -168,7 +168,7 @@ public struct Lexer: IteratorProtocol, Sequence {
         if peek() == "`" {
           let start = sourceCode.position(sourceCode.text.index(after: token.site.startIndex))
           token.kind = .name
-          token.site = start ..< location
+          token.site = start..<location
           discard()
           return token
         } else {
@@ -250,7 +250,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       case "<", ">":
         // Leading angle brackets are tokenized individually, to parse generic clauses.
         discard()
-        oper = sourceCode.text[token.site.startIndex ..< index]
+        oper = sourceCode.text[token.site.startIndex..<index]
 
       default:
         oper = take(while: { $0.isOperator })
@@ -356,7 +356,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       index = sourceCode.text.index(after: index)
     }
 
-    return sourceCode.text[start ..< index]
+    return sourceCode.text[start..<index]
   }
 
   /// Consumes an integral literal and returns its kind, or returns `nil` if it fails to scan a valid integer.
@@ -413,23 +413,23 @@ extension Character {
   /// Indicates whether `self` character represents a decimal digit.
   fileprivate var isDecDigit: Bool {
     guard let ascii = asciiValue else { return false }
-    return (0x30 ... 0x39) ~= ascii  // 0 ... 9
+    return (0x30...0x39) ~= ascii  // 0 ... 9
       || 0x5f == ascii  // _
   }
 
   /// Indicates whether `self` represents an hexadecimal digit.
   fileprivate var isHexDigit: Bool {
     guard let ascii = asciiValue else { return false }
-    return (0x30 ... 0x39) ~= ascii  // 0 ... 9
-      || (0x41 ... 0x46) ~= ascii  // A ... F
-      || (0x61 ... 0x66) ~= ascii  // a ... f
+    return (0x30...0x39) ~= ascii  // 0 ... 9
+      || (0x41...0x46) ~= ascii  // A ... F
+      || (0x61...0x66) ~= ascii  // a ... f
       || 0x5f == ascii  // _
   }
 
   /// /// Indicates whether `self` represents an octal digit.
   fileprivate var isOctDigit: Bool {
     guard let ascii = asciiValue else { return false }
-    return (0x30 ... 0x37) ~= ascii  // 0 ... 7
+    return (0x30...0x37) ~= ascii  // 0 ... 7
       || 0x5f == ascii  // _
   }
 

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -27,7 +27,8 @@ public struct Lexer: IteratorProtocol, Sequence {
   /// Advances to the next token and returns it, or returns `nil` if no next token exists.
   public mutating func next() -> Token? {
     // Start measuring Lexer time
-    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Lexer)
+    let probe = profiler?.createAndStartProfilingProbe(MeasurementType.Lexer)
+    defer { probe?.stop() }
 
     // Skip whitespaces and comments.
     while true {

--- a/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
+++ b/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
@@ -11,7 +11,7 @@ extension Diagnostic {
   static func error(expected subject: String, at location: SourcePosition, notes: [Diagnostic] = [])
     -> Diagnostic
   {
-    .error("expected \(subject)", at: location ..< location, notes: notes)
+    .error("expected \(subject)", at: location..<location, notes: notes)
   }
 
   static func error(
@@ -41,11 +41,11 @@ extension Diagnostic {
   }
 
   static func error(unterminatedCommentStartingAt p: SourcePosition) -> Diagnostic {
-    .error("unterminated comment", at: p ..< p)
+    .error("unterminated comment", at: p..<p)
   }
 
   static func error(unterminatedStringStartingAt p: SourcePosition) -> Diagnostic {
-    .error("unterminated string", at: p ..< p)
+    .error("unterminated string", at: p..<p)
   }
 
   static func error(duplicateAccessModifier m: SourceRepresentable<AccessModifier>) -> Diagnostic {

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -28,17 +28,17 @@ public enum Parser {
     inNodeSpace k: Int,
     in ast: inout AST,
     diagnostics: inout DiagnosticSet,
-    profileWith profiler: ProfilingMeasurements?  
+    profileWith profiler: ProfilingMeasurements?
   ) throws -> TranslationUnit.ID {
     // Temporarily stash the AST and diagnostics in the parser state, avoiding CoW costs
     var state = ParserState(
-      ast: ast, space: k, lexer: Lexer(tokenizing: input, profileWith: profiler), reportingDiagnosticsTo: diagnostics)
+      ast: ast, space: k, lexer: Lexer(tokenizing: input, profileWith: profiler),
+      reportingDiagnosticsTo: diagnostics)
     defer { diagnostics = state.diagnostics }
     diagnostics = DiagnosticSet()
 
     // Parse the input.
     var members: [AnyDeclID] = []
-
 
     // start time measurement if needed
     let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Parser)
@@ -62,7 +62,7 @@ public enum Parser {
           Diagnostic(
             level: .error,
             message: "\(type(of: error)): \(error)",
-            site: state.lexer.sourceCode.range(startIndex ..< state.currentIndex)))
+            site: state.lexer.sourceCode.range(startIndex..<state.currentIndex)))
         continue
       }
 
@@ -98,7 +98,7 @@ public enum Parser {
     let translation = state.insert(
       TranslationUnit(
         decls: members,
-        site: input.range(input.text.startIndex ..< input.text.endIndex)))
+        site: input.range(input.text.startIndex..<input.text.endIndex)))
 
     try state.diagnostics.throwOnError()
     ast = state.ast
@@ -1466,7 +1466,7 @@ public enum Parser {
       if !state.hasLeadingWhitespace {
         // If there isn't any leading whitespace before the next expression but the operator is on
         // a different line, we may be looking at the start of a prefix expression.
-        let rangeBefore = state.ast[lhs].site.endIndex ..< operatorStem.site.startIndex
+        let rangeBefore = state.ast[lhs].site.endIndex..<operatorStem.site.startIndex
         if state.lexer.sourceCode.text[rangeBefore].contains(where: { $0.isNewline }) {
           state.restore(from: backup)
           break
@@ -3055,7 +3055,7 @@ public enum Parser {
         guard let c = parseConnective(in: &state) else { return lhs }
 
         // Backtrack if the connective we got hasn't strong enough precedence.
-        if (c.rawValue < p.rawValue) {
+        if c.rawValue < p.rawValue {
           state.restore(from: backup)
           return lhs
         }
@@ -3109,7 +3109,7 @@ public enum Parser {
       } else if h.kind == .poundElse {
         fallback = try parseConditionalCompilationBranch(in: &state)
         _ = try state.expect("'#endif'", using: { $0.take(.poundEndif) })
-      } else{
+      } else {
         fallback = [try parseCompilerConditionTail(head: h, in: &state)]
       }
 

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -27,16 +27,21 @@ public enum Parser {
     _ input: SourceFile,
     inNodeSpace k: Int,
     in ast: inout AST,
-    diagnostics: inout DiagnosticSet
+    diagnostics: inout DiagnosticSet,
+    profileWith profiler: ProfilingMeasurements?  
   ) throws -> TranslationUnit.ID {
     // Temporarily stash the AST and diagnostics in the parser state, avoiding CoW costs
     var state = ParserState(
-      ast: ast, space: k, lexer: Lexer(tokenizing: input), reportingDiagnosticsTo: diagnostics)
+      ast: ast, space: k, lexer: Lexer(tokenizing: input, profileWith: profiler), reportingDiagnosticsTo: diagnostics)
     defer { diagnostics = state.diagnostics }
     diagnostics = DiagnosticSet()
 
     // Parse the input.
     var members: [AnyDeclID] = []
+
+
+    // start time measurement if needed
+    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Parser)
 
     while let head = state.peek() {
       // Ignore semicolons.

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -41,7 +41,8 @@ public enum Parser {
     var members: [AnyDeclID] = []
 
     // start time measurement if needed
-    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Parser)
+    let probe = profiler?.createAndStartProfilingProbe(MeasurementType.Parser)
+    defer { probe?.stop() }
 
     while let head = state.peek() {
       // Ignore semicolons.

--- a/Sources/FrontEnd/Parse/ParserState.swift
+++ b/Sources/FrontEnd/Parse/ParserState.swift
@@ -112,13 +112,13 @@ struct ParserState {
 
   /// Returns whether there is a new line in the character stream before `bound`.
   mutating func hasNewline(before bound: Token) -> Bool {
-    lexer.sourceCode.text[currentIndex ..< bound.site.startIndex]
+    lexer.sourceCode.text[currentIndex..<bound.site.startIndex]
       .contains(where: { $0.isNewline })
   }
 
   /// Returns a site from `startIndex` to `self.currentIndex`.
   func range(from startIndex: String.Index) -> SourceRange {
-    lexer.sourceCode.range(startIndex ..< currentIndex)
+    lexer.sourceCode.range(startIndex..<currentIndex)
   }
 
   /// Returns whether `token` is a member index.
@@ -126,7 +126,7 @@ struct ParserState {
     (token.kind == .int)
       && lexer.sourceCode[token.site].allSatisfy({ ch in
         guard let ascii = ch.asciiValue else { return false }
-        return (0x30 ... 0x39) ~= ascii
+        return (0x30...0x39) ~= ascii
       })
   }
 
@@ -257,7 +257,7 @@ struct ParserState {
         upper = next.site.endIndex
       }
 
-      let range = head.site.file.range(head.site.startIndex ..< upper)
+      let range = head.site.file.range(head.site.startIndex..<upper)
       return SourceRepresentable(value: String(lexer.sourceCode[range]), range: range)
 
     default:

--- a/Sources/FrontEnd/Parse/Token.swift
+++ b/Sources/FrontEnd/Parse/Token.swift
@@ -111,7 +111,7 @@ public struct Token {
 
   /// Indicates whether `self` is a keyword.
   public var isKeyword: Bool {
-    (Kind.any.rawValue ..< Kind.any.rawValue + 999) ~= kind.rawValue
+    (Kind.any.rawValue..<Kind.any.rawValue + 999) ~= kind.rawValue
   }
 
   /// Indicates whether `self` is a suitable as a label.

--- a/Sources/FrontEnd/SourceFile.swift
+++ b/Sources/FrontEnd/SourceFile.swift
@@ -49,8 +49,7 @@ public struct SourceFile {
 
     let storage = Storage(fragment, lineStarts: wholeFile.lineStarts) {
       wholeFile.text[
-        wholeFile.index(line: startLine, column: 1)
-          ..< wholeFile.index(line: endLine + 1, column: 1)]
+        wholeFile.index(line: startLine, column: 1)..<wholeFile.index(line: endLine + 1, column: 1)]
     }
     self.storage = storage
   }
@@ -86,12 +85,12 @@ public struct SourceFile {
 
   /// A range covering the whole contents of this instance.
   public var wholeRange: SourceRange {
-    range(text.startIndex ..< text.endIndex)
+    range(text.startIndex..<text.endIndex)
   }
 
   /// Returns a range starting and ending at `index`.
   public func emptyRange(at index: String.Index) -> SourceRange {
-    range(index ..< index)
+    range(index..<index)
   }
 
   /// Returns the contents of the file in the specified range.
@@ -99,7 +98,7 @@ public struct SourceFile {
   /// - Requires: The bounds of `range` are valid positions in `self`.
   public subscript(_ range: SourceRange) -> Substring {
     precondition(range.file.url == url, "invalid range")
-    return text[range.startIndex ..< range.endIndex]
+    return text[range.startIndex..<range.endIndex]
   }
 
   /// Returns the position corresponding to `i` in `text`.
@@ -146,7 +145,7 @@ public struct SourceFile {
   /// The bounds of given `line`, including any trailing newline.
   public func bounds(of line: SourceLine) -> SourceRange {
     let end = line.number < lineStarts.count ? lineStarts[line.number] : text.endIndex
-    return range(lineStarts[line.number - 1] ..< end)
+    return range(lineStarts[line.number - 1]..<end)
   }
 
   /// Returns the 1-based line and column numbers corresponding to `i`.

--- a/Sources/FrontEnd/SourcePosition.swift
+++ b/Sources/FrontEnd/SourcePosition.swift
@@ -35,7 +35,7 @@ public struct SourcePosition: Hashable {
   /// - Requires: `l.file == r.file`
   public static func ..< (l: Self, r: Self) -> SourceRange {
     precondition(l.file == r.file, "incompatible locations")
-    return l.file.range(l.index ..< r.index)
+    return l.file.range(l.index..<r.index)
   }
 
 }

--- a/Sources/FrontEnd/SourceRange.swift
+++ b/Sources/FrontEnd/SourceRange.swift
@@ -37,14 +37,14 @@ public struct SourceRange: Hashable {
   /// Returns a copy of `self` with the end increased (if necessary) to `newEnd`.
   public func extended(upTo newEnd: SourceFile.Index) -> SourceRange {
     precondition(newEnd >= endIndex)
-    return file.range(startIndex ..< newEnd)
+    return file.range(startIndex..<newEnd)
   }
 
   /// Returns a copy of `self` extended to cover `other`.
   public func extended(toCover other: SourceRange) -> SourceRange {
     precondition(file == other.file, "incompatible ranges")
     return file.range(
-      Swift.min(startIndex, other.startIndex) ..< Swift.max(endIndex, other.endIndex))
+      Swift.min(startIndex, other.startIndex)..<Swift.max(endIndex, other.endIndex))
   }
 
   /// Increases (if necessary) the end of `self` so that it equals `newEnd`.
@@ -64,7 +64,7 @@ public struct SourceRange: Hashable {
 
   /// Creates an empty range that starts and end at `p`.
   public static func empty(at p: SourcePosition) -> Self {
-    SourceRange(p.index ..< p.index, in: p.file)
+    SourceRange(p.index..<p.index, in: p.file)
   }
 
 }
@@ -86,7 +86,7 @@ extension SourceRange: Codable {
     let end = String.Index(
       utf16Offset: try container.decode(Int.self, forKey: .end),
       in: file.text)
-    regionOfFile = start ..< end
+    regionOfFile = start..<end
   }
 
   public func encode(to encoder: Encoder) throws {

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -1040,7 +1040,7 @@ struct ConstraintSystem {
 
   /// Refresh stale constraints containing variables that have been assigned.
   private mutating func refresh() {
-    for i in (0 ..< stale.count).reversed() {
+    for i in (0..<stale.count).reversed() {
       var changed = false
       goals[stale[i]].modifyTypes { (t) in
         if t[.hasVariable] {

--- a/Sources/FrontEnd/TypeChecking/Constraints/CallConstraint.swift
+++ b/Sources/FrontEnd/TypeChecking/Constraints/CallConstraint.swift
@@ -86,7 +86,7 @@ struct CallConstraint: Constraint, Hashable {
   func collectOpenVariables(in s: inout Set<TypeVariable>) {
     callee.collectOpenVariables(in: &s)
     output.collectOpenVariables(in: &s)
-    for i in 0 ..< arguments.count {
+    for i in 0..<arguments.count {
       arguments[i].type.collectOpenVariables(in: &s)
     }
   }
@@ -94,7 +94,7 @@ struct CallConstraint: Constraint, Hashable {
   mutating func modifyTypes(_ transform: (AnyType) -> AnyType) {
     update(&callee, with: transform)
     update(&output, with: transform)
-    for i in 0 ..< arguments.count {
+    for i in 0..<arguments.count {
       update(&arguments[i].type, with: transform)
     }
   }

--- a/Sources/FrontEnd/TypeChecking/Constraints/DisjunctionConstraint.swift
+++ b/Sources/FrontEnd/TypeChecking/Constraints/DisjunctionConstraint.swift
@@ -18,7 +18,7 @@ struct DisjunctionConstraint: DisjunctiveConstraintProtocol, Hashable {
   }
 
   mutating func modifyTypes(_ transform: (AnyType) -> AnyType) {
-    for i in 0 ..< choices.count {
+    for i in 0..<choices.count {
       let modified = choices[i].constraints.reduce(into: ConstraintSet()) { (cs, c) in
         var newConstraint = c
         newConstraint.modifyTypes(transform)

--- a/Sources/FrontEnd/TypeChecking/Constraints/MergingConstraint.swift
+++ b/Sources/FrontEnd/TypeChecking/Constraints/MergingConstraint.swift
@@ -29,7 +29,7 @@ struct MergingConstraint: Constraint, Hashable {
 
   mutating func modifyTypes(_ transform: (AnyType) -> AnyType) {
     update(&supertype, with: transform)
-    for i in 0 ..< branches.count {
+    for i in 0..<branches.count {
       update(&branches[i], with: transform)
     }
   }

--- a/Sources/FrontEnd/TypeChecking/Constraints/OverloadConstraint.swift
+++ b/Sources/FrontEnd/TypeChecking/Constraints/OverloadConstraint.swift
@@ -41,7 +41,7 @@ struct OverloadConstraint: DisjunctiveConstraintProtocol, Hashable {
   mutating func modifyTypes(_ transform: (AnyType) -> AnyType) {
     update(&overloadedExprType, with: transform)
 
-    for i in 0 ..< choices.count {
+    for i in 0..<choices.count {
       let modified = choices[i].constraints.reduce(into: ConstraintSet()) { (cs, c) in
         var newConstraint = c
         newConstraint.modifyTypes(transform)

--- a/Sources/FrontEnd/TypeChecking/Rewriting/RewritingSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/Rewriting/RewritingSystem.swift
@@ -99,7 +99,7 @@ struct RewritingSystem<Term: RewritingTerm> {
   /// This method uses Knuth-Bendix completion algorithm to transform `self` into a terminating
   /// confluent system. The completion procedure is semi-decidable: it returns `true` if it
   /// succeeds or `false` if it suspects that it won't terminate.
-  mutating func complete(orderingTermsWith compareOrder: (Term, Term) -> StrictOrdering) -> Bool{
+  mutating func complete(orderingTermsWith compareOrder: (Term, Term) -> StrictOrdering) -> Bool {
     var visitedOverlaps = Set<OverlapIdentifier>()
     var pairs: [CriticalPair] = []
     var changed = true
@@ -128,7 +128,6 @@ struct RewritingSystem<Term: RewritingTerm> {
     leftSimplify()
     return true
   }
-
 
   /// Calls `action` on each overlap between two rules of the system.
   private func forEachOverlap(do action: (RuleID, RuleID, Term.Index) -> Void) {
@@ -232,7 +231,7 @@ struct RewritingSystem<Term: RewritingTerm> {
 
   /// Removes the rules in `self` whose left hand side can be reduced by a simpler rule.
   private mutating func leftSimplify() {
-    for i in 0 ..< rules.count where !rules[i].isSimplified {
+    for i in 0..<rules.count where !rules[i].isSimplified {
       for p in rules[i].lhs.indices {
         if simplify(i, lookingForTermsInSuffixFrom: p) { break }
       }
@@ -246,7 +245,7 @@ struct RewritingSystem<Term: RewritingTerm> {
     var n = termToRule[prefix: []]!
 
     for q in w[p...].indices {
-      if let m = n[prefix: w[q ..< w.index(after: q)]] {
+      if let m = n[prefix: w[q..<w.index(after: q)]] {
         if let j = m[[]], i != j {
           rules[i].raiseFlags(.isLeftSimplified)
           termToRule[rules[i].lhs] = nil

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -1,4 +1,3 @@
-
 extension Diagnostic {
 
   static func error(ambiguousDisjunctionAt site: SourceRange) -> Diagnostic {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1599,7 +1599,8 @@ struct TypeChecker {
       return (
         type: canonical(expectedType(of: m), in: scopeOfDefinition),
         name: program.name(of: m)!,
-        parameters: genericParameters(introducedBy: m))
+        parameters: genericParameters(introducedBy: m)
+      )
     }
 
     /// Returns the type of `m` viewed as a member of `model` through its conformance to `trait`.
@@ -1685,8 +1686,7 @@ struct TypeChecker {
       of requirement: AnyDeclID, withAPI expectedAPI: API
     ) -> SynthesizedFunctionDecl? {
       let scopeOfImplementation = AnyScopeID(origin.source)!
-      if
-        let k = program.ast.synthesizedKind(of: requirement),
+      if let k = program.ast.synthesizedKind(of: requirement),
         canSynthesizeConformance(model, to: trait, in: scopeOfImplementation)
       {
         let t = ArrowType(expectedAPI.type)!
@@ -4396,8 +4396,7 @@ struct TypeChecker {
     }
 
     // If the match is a trait member, specialize its receiver.
-    if
-      d.kind != AssociatedTypeDecl.self,
+    if d.kind != AssociatedTypeDecl.self,
       let t = traitDeclaring(d),
       let r = context?.type ?? resolveReceiverMetatype(in: scopeOfUse)?.instance
     {
@@ -4533,8 +4532,7 @@ struct TypeChecker {
     reportingDiagnosticsAt diagnosticSite: SourceRange
   ) -> AnyType {
     let lens = traitDeclaring(d)!
-    if
-      let c = demandConformance(of: domain, to: lens, exposedTo: scopeOfUse),
+    if let c = demandConformance(of: domain, to: lens, exposedTo: scopeOfUse),
       let i = c.implementations[d]?.decl
     {
       return uncheckedType(of: i)
@@ -5591,7 +5589,7 @@ struct TypeChecker {
     }
 
     // Create the necessary constraints to let the solver resolve the remaining components.
-    for i in (0 ..< unresolved.count).reversed() {
+    for i in (0..<unresolved.count).reversed() {
       let memberType = ^freshVariable()
       obligations.insert(
         MemberConstraint(
@@ -6589,7 +6587,7 @@ struct TypeChecker {
     let bb = bases(of: b)
 
     if ab.unordered.count > bb.unordered.count {
-      return .descending // !!! .ascending in Slava's work
+      return .descending  // !!! .ascending in Slava's work
     } else if ab.unordered.count == bb.unordered.count {
       return .init(between: a.decl.rawValue, and: b.decl.rawValue)
     } else {

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -82,7 +82,8 @@ public struct TypedProgram {
         tasks.append(t)
       }
 
-      let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)
+      let probe = profiler?.createAndStartProfilingProbe(MeasurementType.TypeChecker)
+      defer { probe?.stop() }
       let queue = OperationQueue()
       queue.addOperations(tasks, waitUntilFinished: true)
       for t in tasks {
@@ -95,7 +96,8 @@ public struct TypedProgram {
         constructing: $0,
         tracingInferenceIf: typeCheckingIsParallel ? nil : shouldTraceInference,
         loggingRequirementSystemIf: typeCheckingIsParallel ? nil : shouldLogRequirements)
-      let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)
+      let probe = profiler?.createAndStartProfilingProbe(MeasurementType.TypeChecker)
+      defer { probe?.stop() }
       checker.checkAllDeclarations()
 
       log.formUnion(checker.diagnostics)
@@ -126,7 +128,8 @@ public struct TypedProgram {
       tracingInferenceIf: shouldTraceInference,
       loggingRequirementSystemIf: shouldLogRequirements)
 
-    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)
+    let probe = profiler?.createAndStartProfilingProbe(MeasurementType.TypeChecker)
+    defer { probe?.stop() }
     checker.checkModule(m)
 
     log.formUnion(checker.diagnostics)

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -95,7 +95,7 @@ public struct TypedProgram {
         constructing: $0,
         tracingInferenceIf: typeCheckingIsParallel ? nil : shouldTraceInference,
         loggingRequirementSystemIf: typeCheckingIsParallel ? nil : shouldLogRequirements)
-      let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)        
+      let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)
       checker.checkAllDeclarations()
 
       log.formUnion(checker.diagnostics)
@@ -126,7 +126,7 @@ public struct TypedProgram {
       tracingInferenceIf: shouldTraceInference,
       loggingRequirementSystemIf: shouldLogRequirements)
 
-    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)   
+    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)
     checker.checkModule(m)
 
     log.formUnion(checker.diagnostics)

--- a/Sources/FrontEnd/TypedProgram.swift
+++ b/Sources/FrontEnd/TypedProgram.swift
@@ -64,7 +64,8 @@ public struct TypedProgram {
     inParallel typeCheckingIsParallel: Bool = false,
     reportingDiagnosticsTo log: inout DiagnosticSet,
     tracingInferenceIf shouldTraceInference: ((AnyNodeID, TypedProgram) -> Bool)? = nil,
-    loggingRequirementSystemIf shouldLogRequirements: ((AnyDeclID, TypedProgram) -> Bool)? = nil
+    loggingRequirementSystemIf shouldLogRequirements: ((AnyDeclID, TypedProgram) -> Bool)? = nil,
+    profileWith profiler: ProfilingMeasurements? = nil
   ) throws {
     let instanceUnderConstruction = SharedMutable(TypedProgram(partiallyFormedFrom: base))
 
@@ -81,6 +82,7 @@ public struct TypedProgram {
         tasks.append(t)
       }
 
+      let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)
       let queue = OperationQueue()
       queue.addOperations(tasks, waitUntilFinished: true)
       for t in tasks {
@@ -93,6 +95,7 @@ public struct TypedProgram {
         constructing: $0,
         tracingInferenceIf: typeCheckingIsParallel ? nil : shouldTraceInference,
         loggingRequirementSystemIf: typeCheckingIsParallel ? nil : shouldLogRequirements)
+      let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)        
       checker.checkAllDeclarations()
 
       log.formUnion(checker.diagnostics)
@@ -111,7 +114,8 @@ public struct TypedProgram {
     reportingDiagnosticsTo log: inout DiagnosticSet,
     tracingInferenceIf shouldTraceInference: ((AnyNodeID, TypedProgram) -> Bool)? = nil,
     loggingRequirementSystemIf shouldLogRequirements: ((AnyDeclID, TypedProgram) -> Bool)? = nil,
-    creatingContentsWith make: AST.ModuleLoader
+    creatingContentsWith make: AST.ModuleLoader,
+    profileWith profiler: ProfilingMeasurements? = nil
   ) throws -> (Self, ModuleDecl.ID) {
     let (p, m) = try base.loadModule(reportingDiagnosticsTo: &log, creatingContentsWith: make)
     var extended = self
@@ -121,6 +125,8 @@ public struct TypedProgram {
       constructing: extended,
       tracingInferenceIf: shouldTraceInference,
       loggingRequirementSystemIf: shouldLogRequirements)
+
+    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.TypeChecker)   
     checker.checkModule(m)
 
     log.formUnion(checker.diagnostics)

--- a/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
+++ b/Sources/GenerateHyloFileTests/GenerateHyloFileTests.swift
@@ -34,13 +34,13 @@ struct GenerateHyloFileTests: ParsableCommand {
       let trailing = test.arguments.reduce(into: "", { (s, a) in s.write(", \(a)") })
       swiftCode += """
 
-        func test_\(test.methodName)_\(testID)() throws {
-          try \(test.methodName)(
-            \(String(reflecting: source.fileSystemPath)),
-            extending: programToExtend!\(trailing))
-        }
+          func test_\(test.methodName)_\(testID)() throws {
+            try \(test.methodName)(
+              \(String(reflecting: source.fileSystemPath)),
+              extending: programToExtend!\(trailing))
+          }
 
-      """
+        """
     }
   }
 
@@ -131,7 +131,7 @@ extension StringProtocol where Self.SubSequence == Substring {
 }
 
 /// The name of a method implementing the logic of a test runner.
-fileprivate enum TestMethod: String {
+private enum TestMethod: String {
 
   /// Compiles and runs the program.
   case compileAndRun
@@ -154,7 +154,7 @@ fileprivate enum TestMethod: String {
 }
 
 /// An argument of a test runner.
-fileprivate struct TestArgument: CustomStringConvertible {
+private struct TestArgument: CustomStringConvertible {
 
   /// The label of an argument.
   enum Label: String {

--- a/Sources/IR/Analysis/AbstractObject.swift
+++ b/Sources/IR/Analysis/AbstractObject.swift
@@ -74,7 +74,7 @@ struct AbstractObject<Domain: AbstractDomain>: Equatable {
       // Compute the canonical form of each part and unify if possible.
       subobjects[0] = subobjects[0].canonical
       var partsAreUniform = subobjects[0].isUniform
-      for i in 1 ..< subobjects.count {
+      for i in 1..<subobjects.count {
         subobjects[i] = subobjects[i].canonical
         partsAreUniform = partsAreUniform && subobjects[i] == subobjects[0]
       }

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -6,7 +6,8 @@ extension IR.Program {
 
   /// Generates the non-parametric reslient APIs of the modules in `self`.
   public mutating func depolymorphize(profileWith profiler: ProfilingMeasurements? = nil) {
-    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Depolymorphize)
+    let probe = profiler?.createAndStartProfilingProbe(MeasurementType.Depolymorphize)
+    defer { probe?.stop() }
     for m in modules.keys {
       depolymorphize(m)
     }

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -5,7 +5,8 @@ import Utils
 extension IR.Program {
 
   /// Generates the non-parametric reslient APIs of the modules in `self`.
-  public mutating func depolymorphize() {
+  public mutating func depolymorphize(profileWith profiler: ProfilingMeasurements? = nil) {
+    let _probe = profiler?.createTimeMeasurementProbe(MeasurementType.Depolymorphize)
     for m in modules.keys {
       depolymorphize(m)
     }

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -575,21 +575,23 @@ extension Module {
       insertingDeinitializationBefore i: InstructionID,
       reportingDiagnosticsAt site: SourceRange
     ) {
-      context.withObject(at: .root(p), { (o) in
-        let s = o.value.initializedSubfields
-        if s == [[]] && isDeinit(i.function) {
-          // We cannot call `deinit` in `deinit` itself.
-          insertDeinitParts(
-            of: p, before: i,
-            anchoringInstructionsTo: site, reportingDiagnosticsTo: &diagnostics)
-        } else {
-          insertDeinit(
-            p, at: s, before: i,
-            anchoringInstructionsTo: site, reportingDiagnosticsTo: &diagnostics)
-        }
+      context.withObject(
+        at: .root(p),
+        { (o) in
+          let s = o.value.initializedSubfields
+          if s == [[]] && isDeinit(i.function) {
+            // We cannot call `deinit` in `deinit` itself.
+            insertDeinitParts(
+              of: p, before: i,
+              anchoringInstructionsTo: site, reportingDiagnosticsTo: &diagnostics)
+          } else {
+            insertDeinit(
+              p, at: s, before: i,
+              anchoringInstructionsTo: site, reportingDiagnosticsTo: &diagnostics)
+          }
 
-        o.value = .full(.uninitialized)
-      })
+          o.value = .full(.uninitialized)
+        })
     }
 
     /// Checks that the return value is initialized in `context`.
@@ -906,7 +908,7 @@ extension AbstractObject.Value where Domain == State {
   ) {
     guard case .partial(let subobjects) = self else { return }
 
-    for i in 0 ..< subobjects.count {
+    for i in 0..<subobjects.count {
       switch subobjects[i] {
       case .full(.initialized):
         paths.initialized.append(prefix + [i])
@@ -1007,7 +1009,7 @@ extension AbstractObject.Value where Domain == State {
     case (.partial(let lhs), .partial(let rhs)):
       // LHS and RHS are partially initialized.
       assert(lhs.count == rhs.count)
-      return (0 ..< lhs.count).reduce(into: []) { (result, i) in
+      return (0..<lhs.count).reduce(into: []) { (result, i) in
         result.append(contentsOf: (lhs[i] - rhs[i]).map({ [i] + $0 }))
       }
     }

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -270,7 +270,7 @@ struct Emitter {
     // Convert Hylo arguments to their foreign representation. Note that the last parameter of the
     // entry is the address of the FFI's return value.
     var arguments: [Operand] = []
-    for i in 0 ..< module[entry].inputs.count - 1 {
+    for i in 0..<module[entry].inputs.count - 1 {
       let a = emitConvertToForeign(.parameter(entry, i), at: site)
       arguments.append(a)
     }
@@ -2244,7 +2244,7 @@ struct Emitter {
     let r = emitLValue(receiver: s, at: ast[callee].site)
     return emitMemberFunctionCallee(
       referringTo: d, memberOf: r, markedForMutation: isMutating,
-      specializedBy: a, in:program[callee].scope,
+      specializedBy: a, in: program[callee].scope,
       at: program[callee].site)
   }
 
@@ -2367,7 +2367,6 @@ struct Emitter {
     let c = insert(module.makeAccess(entityToCall.capabilities, from: r, at: ast[callee].site))!
     return (entityToCall, [c])
   }
-
 
   /// Returns `(success: a, failure: b)` where `a` is the basic block reached if all items in
   /// `condition` hold and `b` is the basic block reached otherwise, creating new basic blocks

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -245,7 +245,7 @@ extension IR.Program {
       let x2 = s.targets.reduce(into: UnionSwitch.Targets()) { (d, kv) in
         _ = d[t.transform(kv.key, in: &self)].setIfNil(t.transform(kv.value, in: &self))
       }
-      return insert(at: p, in:n) { (target) in
+      return insert(at: p, in: n) { (target) in
         target.makeUnionSwitch(over: x0, of: x1, toOneOf: x2, at: s.site)
       }
 

--- a/Sources/IR/Mangling/Base64VarUInt.swift
+++ b/Sources/IR/Mangling/Base64VarUInt.swift
@@ -141,7 +141,7 @@ extension Base64VarUInt: LosslessStringConvertible {
     var digits: [Base64Digit] = []
     digits.reserveCapacity(digitCount)
 
-    for _ in 0 ..< digitCount {
+    for _ in 0..<digitCount {
       guard let ai = digit() else { return nil }
       digits.append(ai)
     }

--- a/Sources/IR/Mangling/Demangler.swift
+++ b/Sources/IR/Mangling/Demangler.swift
@@ -491,7 +491,7 @@ struct Demangler {
     let ts = takeItems(from: &stream) { (me, s) in
       me.demangleType(from: &s)
     }
-    return ts.map({ (s) in .type(.existentialTrait(s))})
+    return ts.map({ (s) in .type(.existentialTrait(s)) })
   }
 
   /// Demangles an arrow type from `stream`.
@@ -562,7 +562,7 @@ struct Demangler {
 
     var elements: [DemangledType] = []
     elements.reserveCapacity(Int(elementCount.rawValue))
-    for _ in 0 ..< elementCount.rawValue {
+    for _ in 0..<elementCount.rawValue {
       // Elements only do not share the same symbol lookup table; only a prefix.
       var d = self
       guard
@@ -644,7 +644,7 @@ struct Demangler {
   private mutating func takeString(from stream: inout Substring) -> Substring? {
     switch takeInteger(from: &stream)?.rawValue {
     case .some(0):
-      return stream[stream.startIndex ..< stream.startIndex]
+      return stream[stream.startIndex..<stream.startIndex]
     case .some(1):
       return takeInteger(from: &stream).flatMap({ (m) in strings[Int(m.rawValue)] })
     case .some(let n):
@@ -691,7 +691,7 @@ struct Demangler {
     var xs: [T] = []
     xs.reserveCapacity(Int(n.rawValue))
 
-    for _ in 0 ..< n.rawValue {
+    for _ in 0..<n.rawValue {
       guard let x = takeItem(&self, &stream) else { return nil }
       xs.append(x)
     }

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -140,7 +140,7 @@ public struct Module {
 
   /// If `p` is a function parameter, returns its passing convention. Otherwise, returns `nil`.
   public func passingConvention(of p: Operand) -> AccessEffect? {
-    if case .parameter(let e, let i) = p, (entry(of: e.function) == e) {
+    if case .parameter(let e, let i) = p, entry(of: e.function) == e {
       return passingConvention(parameter: i, of: e.function)
     } else {
       return nil
@@ -903,7 +903,7 @@ public struct Module {
     let user = impl(&self, newInstruction)
 
     // Update the def-use chains.
-    for i in 0 ..< newInstruction.operands.count {
+    for i in 0..<newInstruction.operands.count {
       uses[newInstruction.operands[i], default: []].append(Use(user: user, index: i))
     }
 

--- a/Sources/IR/Operands/Instruction/Switch.swift
+++ b/Sources/IR/Operands/Instruction/Switch.swift
@@ -30,7 +30,7 @@ public struct Switch: Terminator {
 
   mutating func replaceSuccessor(_ old: Block.ID, with new: Block.ID) -> Bool {
     precondition(new.function == successors[0].function)
-    for i in 0 ..< successors.count {
+    for i in 0..<successors.count {
       if successors[i] == old {
         successors[i] = new
         return true

--- a/Sources/IR/Operands/Instruction/UnionSwitch.swift
+++ b/Sources/IR/Operands/Instruction/UnionSwitch.swift
@@ -27,8 +27,6 @@ public struct UnionSwitch: Terminator {
     self.site = site
   }
 
-  
-
   public var operands: [Operand] {
     [discriminator]
   }
@@ -45,7 +43,10 @@ public struct UnionSwitch: Terminator {
   mutating func replaceSuccessor(_ old: Block.ID, with new: Block.ID) -> Bool {
     precondition(new.function == successors[0].function)
     for (t, b) in targets {
-      if b == old { targets[t] = b; return true }
+      if b == old {
+        targets[t] = b
+        return true
+      }
     }
     return false
   }

--- a/Sources/TestUtils/TestAnnotation.swift
+++ b/Sources/TestUtils/TestAnnotation.swift
@@ -92,7 +92,7 @@ public struct TestAnnotation: Hashable {
       self.argument = nil
     } else {
       var argument = ""
-      for i in 0 ..< lines.count {
+      for i in 0..<lines.count {
         if i != 0 { argument.append("\n") }
         argument.append(contentsOf: lines[i].dropFirst(indentation.count))
       }
@@ -152,7 +152,7 @@ public struct TestAnnotation: Hashable {
           openedBlockComments = 0
           if let start = indexAfterAnnotationBlockOpener {
             annotations.append(
-              TestAnnotation(in: sourceCode.url, atLine: line, parsing: stream[start ..< index]))
+              TestAnnotation(in: sourceCode.url, atLine: line, parsing: stream[start..<index]))
             indexAfterAnnotationBlockOpener = nil
           }
 
@@ -184,7 +184,7 @@ public struct TestAnnotation: Hashable {
 
         if let start = start {
           annotations.append(
-            TestAnnotation(in: sourceCode.url, atLine: line, parsing: stream[start ..< index]))
+            TestAnnotation(in: sourceCode.url, atLine: line, parsing: stream[start..<index]))
         }
 
         continue

--- a/Sources/Utils/BitArray.swift
+++ b/Sources/Utils/BitArray.swift
@@ -75,7 +75,7 @@ public struct BitArray {
     if isEmpty { return true }
 
     let k = (count - 1) >> UInt.bitWidth.trailingZeroBitCount
-    for i in 0 ..< k {
+    for i in 0..<k {
       if bits[i] != 0 { return false }
     }
     let m = (1 as UInt) << (count & (UInt.bitWidth - 1)) - 1
@@ -87,7 +87,7 @@ public struct BitArray {
     if isEmpty { return true }
 
     let k = (count - 1) >> UInt.bitWidth.trailingZeroBitCount
-    for i in 0 ..< k {
+    for i in 0..<k {
       if bits[i] != ~(0 as UInt) { return false }
     }
     let m = (1 as UInt) << (count & (UInt.bitWidth - 1)) - 1
@@ -195,7 +195,7 @@ public struct BitArray {
     if isEmpty { return }
 
     let k = (count - 1) >> UInt.bitWidth.trailingZeroBitCount
-    for i in 0 ..< k {
+    for i in 0..<k {
       bits[i] = operation(bits[i], other.bits[i])
     }
     let m = (1 as UInt) << (count & (UInt.bitWidth - 1)) - 1

--- a/Sources/Utils/ChunkSequence.swift
+++ b/Sources/Utils/ChunkSequence.swift
@@ -53,7 +53,7 @@ extension Chunks: Collection {
 
   /// Accesses the chunk at `position`.
   public subscript(position: Index) -> Element {
-    base[position ..< index(after: position)]
+    base[position..<index(after: position)]
   }
 
 }

--- a/Sources/Utils/Collection+Extensions.swift
+++ b/Sources/Utils/Collection+Extensions.swift
@@ -59,7 +59,7 @@ extension Collection {
       j = i + 1
     }
 
-    return candidates[0 ..< end].map({ self[$0] })
+    return candidates[0..<end].map({ self[$0] })
   }
 
 }

--- a/Sources/Utils/DirectedGraph.swift
+++ b/Sources/Utils/DirectedGraph.swift
@@ -71,7 +71,7 @@ public struct DirectedGraph<Vertex: Hashable, Label> {
   @discardableResult
   public mutating func insertVertex(_ v: Vertex) -> Bool {
     modify(&out[v]) { (o) in
-      if (o == nil) {
+      if o == nil {
         o = [:]
         return true
       } else {

--- a/Sources/Utils/Profiling.swift
+++ b/Sources/Utils/Profiling.swift
@@ -1,100 +1,99 @@
-
 /// The type of metric to report
-public enum MeasurementType : Int, CaseIterable {
-    case Lexer = 0
-    case Parser
-    case TypeChecker
-    case IRLowering
-    case Depolymorphize
-    case IRConversion        
-    case MandatoryPass    
-    case Optimizations
-    case EmitPhase
-    case LinkPhase
+public enum MeasurementType: Int, CaseIterable {
+  case Lexer = 0
+  case Parser
+  case TypeChecker
+  case IRLowering
+  case Depolymorphize
+  case IRConversion
+  case MandatoryPass
+  case Optimizations
+  case EmitPhase
+  case LinkPhase
 
-    public static var count : Int{
-        get {
-            return MeasurementType.allCases.count
-        }
-    }
+  public static var count: Int {
+    return MeasurementType.allCases.count
+  }
 }
 
+public struct TimeMeasurementProbe: ~Copyable {
 
-public struct TimeMeasurementProbe : ~Copyable {
+  var beginning: ContinuousClock.Instant
+  var measure_type: MeasurementType
+  var pool: ProfilingMeasurements
 
-    var beginning : ContinuousClock.Instant
-    var measure_type : MeasurementType
-    var pool : ProfilingMeasurements
+  init(_ measure_type: MeasurementType, _ pool: ProfilingMeasurements) {
+    self.beginning = ContinuousClock.Instant.now
+    self.pool = pool
+    self.measure_type = measure_type
+  }
 
-    init(_ measure_type : MeasurementType, _ pool  : ProfilingMeasurements){
-        self.beginning = ContinuousClock.Instant.now
-        self.pool = pool
-        self.measure_type = measure_type
-    }
-
-    deinit {
-        let time : Duration = ContinuousClock.Instant.now - beginning
-        pool.addProfiledDuration(self.measure_type, time)
-    }
+  deinit {
+    let time: Duration = ContinuousClock.Instant.now - beginning
+    pool.addProfiledDuration(self.measure_type, time)
+  }
 
 }
 
 /// A container for profiling measurement
 public class ProfilingMeasurements {
 
-    public init() {}
+  public init() {}
 
-    var cumulatedDurations : [Duration] = Array<Duration>(repeating: Duration.seconds(0), count: MeasurementType.count)
+  var cumulatedDurations: [Duration] = [Duration](
+    repeating: Duration.seconds(0), count: MeasurementType.count)
 
-    public func createTimeMeasurementProbe(_ measure_type : MeasurementType) -> TimeMeasurementProbe {
-        return TimeMeasurementProbe(measure_type, self)
+  public func createTimeMeasurementProbe(_ measure_type: MeasurementType) -> TimeMeasurementProbe {
+    return TimeMeasurementProbe(measure_type, self)
+  }
+
+  public func addProfiledDuration(_ measure_type: MeasurementType, _ duration: Duration) {
+    self.cumulatedDurations[measure_type.rawValue] += duration
+  }
+
+  public func printProfilingReport() {
+    let profilingReport = """
+      **Compile time profiling summary**
+        Frontend:
+          Lexer: \(formattedMeasurement(MeasurementType.Lexer))
+          Parser: \(formattedMeasurement(MeasurementType.Parser))
+          TypeChecker: \(formattedMeasurement(MeasurementType.TypeChecker))
+        Backend:
+          IR Lowering: \(formattedMeasurement(MeasurementType.IRLowering))
+          Depolymorphize: \(formattedMeasurement(MeasurementType.Depolymorphize))
+          LLVM IR Conversion: \(formattedMeasurement(MeasurementType.IRConversion))                   
+          LLVM Mandatory pass: \(formattedMeasurement(MeasurementType.MandatoryPass))                
+          LLVM Optimizations: \(formattedMeasurement(MeasurementType.Optimizations))
+          LLVM Emit phase: \(formattedMeasurement(MeasurementType.EmitPhase))
+          Linking phase: \(formattedMeasurement(MeasurementType.LinkPhase))
+
+      """
+    print(profilingReport)
+  }
+
+  public func measurement(_ measure_type: MeasurementType) -> Duration {
+    switch measure_type {
+    case .Parser:
+      return cumulatedDurations[MeasurementType.Parser.rawValue]
+        - cumulatedDurations[MeasurementType.Lexer.rawValue]
+    default:
+      return cumulatedDurations[measure_type.rawValue]
     }
+  }
 
-    public func addProfiledDuration(_ measure_type : MeasurementType, _ duration: Duration) -> Void{
-        self.cumulatedDurations[measure_type.rawValue] += duration
+  public func formattedMeasurement(_ measure_type: MeasurementType) -> String {
+    let measure = measurement(measure_type)
+    let measurementDouble =
+      Double(measure.components.seconds) + Double(measure.components.attoseconds) / 1e18
+    let unitArrays = ["s", "ms", "us", "ns", "ps"]
+    var factor = 1
+    for i in 0...unitArrays.count {
+      let scaledMeasurement = measurementDouble * Double(factor)
+      if scaledMeasurement > 1.0 {
+        return "\(String(format: "%.03f", scaledMeasurement)) \(unitArrays[i])"
+      }
+      factor *= 1000
     }
-
-    public func printProfilingReport() -> Void{
-        let profilingReport = """
-            **Compile time profiling summary**
-              Frontend:
-                Lexer: \(formattedMeasurement(MeasurementType.Lexer))
-                Parser: \(formattedMeasurement(MeasurementType.Parser))
-                TypeChecker: \(formattedMeasurement(MeasurementType.TypeChecker))
-              Backend:
-                IR Lowering: \(formattedMeasurement(MeasurementType.IRLowering))
-                Depolymorphize: \(formattedMeasurement(MeasurementType.Depolymorphize))
-                LLVM IR Conversion: \(formattedMeasurement(MeasurementType.IRConversion))                   
-                LLVM Mandatory pass: \(formattedMeasurement(MeasurementType.MandatoryPass))                
-                LLVM Optimizations: \(formattedMeasurement(MeasurementType.Optimizations))
-                LLVM Emit phase: \(formattedMeasurement(MeasurementType.EmitPhase))
-                Linking phase: \(formattedMeasurement(MeasurementType.LinkPhase))
-
-            """
-        print(profilingReport)               
-    }
-
-    public func measurement(_ measure_type : MeasurementType) -> Duration{
-        switch(measure_type){
-            case .Parser:
-                return cumulatedDurations[MeasurementType.Parser.rawValue] - cumulatedDurations[MeasurementType.Lexer.rawValue]
-            default:
-                return cumulatedDurations[measure_type.rawValue]                                                                        
-        }
-    }
-
-    public func formattedMeasurement(_ measure_type : MeasurementType) -> String{
-        let measure = measurement(measure_type)
-        let measurementDouble = Double(measure.components.seconds) + Double(measure.components.attoseconds) / 1e18
-        let unitArrays = [ "s", "ms", "us", "ns", "ps"]
-        var factor = 1
-        for i in 0...unitArrays.count {
-            let scaledMeasurement = measurementDouble * Double(factor);
-            if scaledMeasurement > 1.0 {
-                return "\(String(format: "%.03f", scaledMeasurement)) \(unitArrays[i])"
-            }
-            factor *= 1000
-        }
-        return "N/A"
-    }    
+    return "N/A"
+  }
 }

--- a/Sources/Utils/Profiling.swift
+++ b/Sources/Utils/Profiling.swift
@@ -1,0 +1,100 @@
+
+/// The type of metric to report
+public enum MeasurementType : Int, CaseIterable {
+    case Lexer = 0
+    case Parser
+    case TypeChecker
+    case IRLowering
+    case Depolymorphize
+    case IRConversion        
+    case MandatoryPass    
+    case Optimizations
+    case EmitPhase
+    case LinkPhase
+
+    public static var count : Int{
+        get {
+            return MeasurementType.allCases.count
+        }
+    }
+}
+
+
+public struct TimeMeasurementProbe : ~Copyable {
+
+    var beginning : ContinuousClock.Instant
+    var measure_type : MeasurementType
+    var pool : ProfilingMeasurements
+
+    init(_ measure_type : MeasurementType, _ pool  : ProfilingMeasurements){
+        self.beginning = ContinuousClock.Instant.now
+        self.pool = pool
+        self.measure_type = measure_type
+    }
+
+    deinit {
+        let time : Duration = ContinuousClock.Instant.now - beginning
+        pool.addProfiledDuration(self.measure_type, time)
+    }
+
+}
+
+/// A container for profiling measurement
+public class ProfilingMeasurements {
+
+    public init() {}
+
+    var cumulatedDurations : [Duration] = Array<Duration>(repeating: Duration.seconds(0), count: MeasurementType.count)
+
+    public func createTimeMeasurementProbe(_ measure_type : MeasurementType) -> TimeMeasurementProbe {
+        return TimeMeasurementProbe(measure_type, self)
+    }
+
+    public func addProfiledDuration(_ measure_type : MeasurementType, _ duration: Duration) -> Void{
+        self.cumulatedDurations[measure_type.rawValue] += duration
+    }
+
+    public func printProfilingReport() -> Void{
+        let profilingReport = """
+            **Compile time profiling summary**
+              Frontend:
+                Lexer: \(formattedMeasurement(MeasurementType.Lexer))
+                Parser: \(formattedMeasurement(MeasurementType.Parser))
+                TypeChecker: \(formattedMeasurement(MeasurementType.TypeChecker))
+              Backend:
+                IR Lowering: \(formattedMeasurement(MeasurementType.IRLowering))
+                Depolymorphize: \(formattedMeasurement(MeasurementType.Depolymorphize))
+                LLVM IR Conversion: \(formattedMeasurement(MeasurementType.IRConversion))                   
+                LLVM Mandatory pass: \(formattedMeasurement(MeasurementType.MandatoryPass))                
+                LLVM Optimizations: \(formattedMeasurement(MeasurementType.Optimizations))
+                LLVM Emit phase: \(formattedMeasurement(MeasurementType.EmitPhase))
+                Linking phase: \(formattedMeasurement(MeasurementType.LinkPhase))
+
+            """
+        print(profilingReport)               
+    }
+
+    public func measurement(_ measure_type : MeasurementType) -> Duration{
+        switch(measure_type){
+            case .Parser:
+                return cumulatedDurations[MeasurementType.Parser.rawValue] - cumulatedDurations[MeasurementType.Lexer.rawValue]
+            default:
+                return cumulatedDurations[measure_type.rawValue]                                                                        
+        }
+    }
+
+    public func formattedMeasurement(_ measure_type : MeasurementType) -> String{
+        let measure = measurement(measure_type)
+        let measurementDouble = Double(measure.components.seconds) + Double(measure.components.attoseconds) / 1e18
+        let unitArrays = [ "s", "ms", "us", "ns", "ps"]
+        var factor = 1
+        for i in 0...unitArrays.count {
+            let scaledMeasurement = measurementDouble * Double(factor);
+            if scaledMeasurement > 1.0 {
+                return "\(String(format: "%.03f", scaledMeasurement)) \(unitArrays[i])"
+            }
+            factor *= 1000
+        }
+        return "N/A"
+    }    
+}

--- a/Sources/Utils/String+Extensions.swift
+++ b/Sources/Utils/String+Extensions.swift
@@ -75,7 +75,7 @@ extension StringProtocol {
 
       // Copy non-whitespace text, and advance the text we need to copy
       result.append(contentsOf: remaining[..<idx])
-      remaining = remaining[idx ..< self.endIndex]
+      remaining = remaining[idx..<self.endIndex]
     }
 
     return result

--- a/Sources/Utils/StronglyConnectedComponents.swift
+++ b/Sources/Utils/StronglyConnectedComponents.swift
@@ -24,7 +24,7 @@ public struct StronglyConnectedComponents<Vertex: Hashable> {
   /// Returns the strongly connected component containing `v`, calling `enumerateSuccessors` to
   /// obtain the successors of a vertex.
   public mutating func component(
-    containing v: Vertex, 
+    containing v: Vertex,
     enumeratingSuccessorsWith enumerateSuccessors: (Vertex) -> [Vertex]
   ) -> Int {
     if let c = properties[v]?.component { return c }
@@ -54,7 +54,7 @@ public struct StronglyConnectedComponents<Vertex: Hashable> {
           pw.isOnStack = false
           pw.component = c
         }
-        if (w == v) { break }
+        if w == v { break }
       }
     }
 


### PR DESCRIPTION
Dear all,

I have added an option to the compiler in the spirit of clang `-ftime-trace` to profile and report the time taken by each phase of the compilation of `hc`.

This is an example of such report

```bash
./Sources/hc  ../Examples/factorial.hylo  -o test --profile-compiler  
**Compile time profiling summary**
  Frontend:
    Lexer: 69.934 us
    Parser: 496.462 us
    TypeChecker: 1.537 s
  Backend:
    IR Lowering: 1.042 s
    Depolymorphize: 100.963 ms
    LLVM IR Conversion: 539.563 ms                   
    LLVM Mandatory pass: 90.476 ms                
    LLVM Optimizations: N/A
    LLVM Emit phase: 1.413 s
    Linking phase: 51.975 ms
```

If you find that useful, let me know and I will do the necessary to respect the CONTRIBUTING guidelines and iterate on that.

PS: I am not experienced in Swift. That might currently be my first PR in Swift. Do not hesitate to point any obvious wrong usage of the language.