### PR TITLE
Simplify IRGen

### DIFF
--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -131,7 +131,7 @@ extension Module {
     // Nothing to do if the request set is already a singleton.
     if s.capabilities == [k] { return }
 
-    let reified = makeAccess(k, from: s.source, correspondingTo: s.binding, at: s.site)
+    let reified = Access(k, from: s.source, correspondingTo: s.binding, at: s.site, in: self)
     replace(i, with: reified)
   }
 
@@ -142,7 +142,7 @@ extension Module {
     // Generate the proper instructions to prepare the projection's arguments.
     var arguments = s.operands
     for a in arguments.indices where s.parameters[a].access == .yielded {
-      let b = makeAccess(k, from: arguments[a], at: s.site)
+      let b = Access(k, from: arguments[a], at: s.site, in: self)
       arguments[a] = .register(insert(b, before: i))
     }
 

--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -147,8 +147,9 @@ extension Module {
     }
 
     let o = RemoteType(k, s.projection)
-    let reified = makeProject(
-      o, applying: s.variants[k]!, specializedBy: s.bundle.arguments, to: arguments, at: s.site)
+    let reified = Project(
+      o, applying: s.variants[k]!, specializedBy: s.bundle.arguments, to: arguments, at: s.site,
+      in: self)
     replace(i, with: reified)
   }
 

--- a/Sources/IR/Analysis/Module+CallBundleReification.swift
+++ b/Sources/IR/Analysis/Module+CallBundleReification.swift
@@ -17,7 +17,7 @@ extension Module {
     let k = s.capabilities.weakest!
 
     var arguments = Array(s.arguments)
-    let r = makeAccess(k, from: arguments[0], at: s.site)
+    let r = Access(k, from: arguments[0], at: s.site, in: self)
     arguments[0] = .register(insert(r, before: i))
 
     let b = Block.ID(containing: i)

--- a/Sources/IR/Analysis/Module+CallBundleReification.swift
+++ b/Sources/IR/Analysis/Module+CallBundleReification.swift
@@ -24,8 +24,8 @@ extension Module {
     let f = FunctionReference(
       to: s.variants[k]!, in: self, specializedBy: s.bundle.arguments, in: self[b].scope)
 
-    let reified = makeCall(
-      applying: .constant(f), to: arguments, writingResultTo: s.output, at: s.site)
+    let reified = Call(
+      applying: .constant(f), to: arguments, writingResultTo: s.output, at: s.site, in: self)
     replace(i, with: reified)
   }
 

--- a/Sources/IR/Analysis/Module+CloseBorrows.swift
+++ b/Sources/IR/Analysis/Module+CloseBorrows.swift
@@ -34,25 +34,25 @@ extension Module {
       }
 
       insertClose(i, atBoundariesOf: region) { (this, site) in
-        this.makeEndAccess(.register(i), at: site)
+        EndAccess(.register(i), at: site, in: this)
       }
 
     case is OpenCapture:
       let region = extendedLiveRange(of: .register(i))
       insertClose(i, atBoundariesOf: region) { (this, site) in
-        this.makeCloseCapture(.register(i), at: site)
+        CloseCapture(.register(i), at: site, in: this)
       }
 
     case is OpenUnion:
       let region = extendedLiveRange(of: .register(i))
       insertClose(i, atBoundariesOf: region) { (this, site) in
-        this.makeCloseUnion(.register(i), at: site)
+        CloseUnion(.register(i), at: site, in: this)
       }
 
     case is Project:
       let region = extendedLiveRange(of: .register(i))
       insertClose(i, atBoundariesOf: region) { (this, site) in
-        this.makeEndProject(.register(i), at: site)
+        EndProject(.register(i), at: site, in: this)
       }
 
     default:

--- a/Sources/IR/Analysis/Module+DeadCodeElimination.swift
+++ b/Sources/IR/Analysis/Module+DeadCodeElimination.swift
@@ -64,7 +64,7 @@ extension Module {
     for b in blocks(in: f) {
       if let i = instructions(in: b).first(where: returnsNever) {
         removeAllInstructions(after: i)
-        insert(makeUnreachable(at: self[i].site), at: .after(i))
+        insert(Unreachable(at: self[i].site, in: self), at: .after(i))
       }
     }
   }

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -575,21 +575,23 @@ extension Module {
       insertingDeinitializationBefore i: InstructionID,
       reportingDiagnosticsAt site: SourceRange
     ) {
-      context.withObject(at: .root(p), { (o) in
-        let s = o.value.initializedSubfields
-        if s == [[]] && isDeinit(i.function) {
-          // We cannot call `deinit` in `deinit` itself.
-          insertDeinitParts(
-            of: p, before: i,
-            anchoringInstructionsTo: site, reportingDiagnosticsTo: &diagnostics)
-        } else {
-          insertDeinit(
-            p, at: s, before: i,
-            anchoringInstructionsTo: site, reportingDiagnosticsTo: &diagnostics)
-        }
+      context.withObject(
+        at: .root(p),
+        { (o) in
+          let s = o.value.initializedSubfields
+          if s == [[]] && isDeinit(i.function) {
+            // We cannot call `deinit` in `deinit` itself.
+            insertDeinitParts(
+              of: p, before: i,
+              anchoringInstructionsTo: site, reportingDiagnosticsTo: &diagnostics)
+          } else {
+            insertDeinit(
+              p, at: s, before: i,
+              anchoringInstructionsTo: site, reportingDiagnosticsTo: &diagnostics)
+          }
 
-        o.value = .full(.uninitialized)
-      })
+          o.value = .full(.uninitialized)
+        })
     }
 
     /// Checks that the return value is initialized in `context`.

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -430,7 +430,7 @@ struct Emitter {
       pushing(Frame(locals: locals)) { (this) in
         let x0 = this.emitLValue(e)
         let x1 = this.insert(
-          this.module.makeAccess(this.ast[d].introducer.value, from: x0, at: this.ast[e].site))!
+          Access(this.ast[d].introducer.value, from: x0, at: this.ast[e].site, in: this.module))!
         this.insert(this.module.makeYield(this.ast[d].introducer.value, x1, at: this.ast[e].site))
       }
       insert(module.makeReturn(at: ast[e].site))
@@ -630,8 +630,8 @@ struct Emitter {
       let bindingType = canonical(program[partDecl].type)
       part = emitCoerce(part, to: bindingType, at: ast[partDecl].site)
 
-      let b = module.makeAccess(
-        request, from: part, correspondingTo: partDecl, at: ast[partDecl].site)
+      let b = Access(
+        request, from: part, correspondingTo: partDecl, at: ast[partDecl].site, in: module)
       frames[partDecl] = insert(b)!
     }
   }
@@ -1240,7 +1240,7 @@ struct Emitter {
     insert(module.makeBranch(to: head, at: introducer))
     insertionPoint = .end(of: head)
 
-    let x0 = insert(module.makeAccess(.inout, from: domain, at: introducer))!
+    let x0 = insert(Access(.inout, from: domain, at: introducer, in: module))!
     emitApply(witness.next, to: [x0], writingResultTo: element, at: introducer)
     insert(module.makeEndAccess(x0, at: introducer))
 
@@ -1300,8 +1300,8 @@ struct Emitter {
     insert(module.makeBranch(to: head, at: introducer))
 
     insertionPoint = .end(of: head)
-    let x0 = insert(module.makeAccess(.let, from: currentPosition, at: introducer))!
-    let x1 = insert(module.makeAccess(.let, from: endPosition, at: introducer))!
+    let x0 = insert(Access(.let, from: currentPosition, at: introducer, in: module))!
+    let x1 = insert(Access(.let, from: endPosition, at: introducer, in: module))!
     emitApply(.constant(equal), to: [x0, x1], writingResultTo: quit, at: introducer)
     insert(module.makeEndAccess(x1, at: introducer))
     insert(module.makeEndAccess(x0, at: introducer))
@@ -1309,8 +1309,8 @@ struct Emitter {
     insert(module.makeCondBranch(if: x2, then: exit, else: enter, at: introducer))
 
     insertionPoint = .end(of: enter)
-    let x6 = insert(module.makeAccess(.let, from: domain, at: introducer))!
-    let x7 = insert(module.makeAccess(.let, from: currentPosition, at: introducer))!
+    let x6 = insert(Access(.let, from: domain, at: introducer, in: module))!
+    let x7 = insert(Access(.let, from: currentPosition, at: introducer, in: module))!
 
     let t = RemoteType(.let, collectionWitness.element)
     let x8 = insert(
@@ -1333,8 +1333,8 @@ struct Emitter {
 
     insertionPoint = .end(of: tail)
     let x3 = insert(module.makeAllocStack(collectionWitness.position, at: introducer))!
-    let x4 = insert(module.makeAccess(.let, from: domain, at: introducer))!
-    let x5 = insert(module.makeAccess(.let, from: currentPosition, at: introducer))!
+    let x4 = insert(Access(.let, from: domain, at: introducer, in: module))!
+    let x5 = insert(Access(.let, from: currentPosition, at: introducer, in: module))!
     emitApply(collectionWitness.positionAfter, to: [x4, x5], writingResultTo: x3, at: introducer)
     insert(module.makeEndAccess(x4, at: introducer))
     insert(module.makeEndAccess(x5, at: introducer))
@@ -1355,7 +1355,7 @@ struct Emitter {
     let start = emitAllocStack(for: witness.position, at: site)
     let end = emitAllocStack(for: witness.position, at: site)
 
-    let x0 = insert(module.makeAccess(.let, from: domain, at: site))!
+    let x0 = insert(Access(.let, from: domain, at: site, in: module))!
     emitApply(witness.startPosition, to: [x0], writingResultTo: start, at: site)
     emitApply(witness.endPosition, to: [x0], writingResultTo: end, at: site)
     insert(module.makeEndAccess(x0, at: site))
@@ -1409,7 +1409,7 @@ struct Emitter {
     // TODO: Read mutability of current subscript
 
     let x0 = emitLValue(ast[s].value)
-    let x1 = insert(module.makeAccess(.let, from: x0, at: ast[s].site))!
+    let x1 = insert(Access(.let, from: x0, at: ast[s].site, in: module))!
     insert(module.makeYield(.let, x1, at: ast[s].site))
     return .next
   }
@@ -1420,7 +1420,7 @@ struct Emitter {
   private mutating func emitInitialize(
     storage: Operand, to value: Operand, at site: SourceRange
   ) {
-    let x0 = insert(module.makeAccess(.set, from: storage, at: site))!
+    let x0 = insert(Access(.set, from: storage, at: site, in: module))!
     insert(module.makeStore(value, at: x0, at: site))
     insert(module.makeEndAccess(x0, at: site))
   }
@@ -1504,7 +1504,7 @@ struct Emitter {
     let s = program[e].site
 
     let x0 = emitLValue(program[e].source)
-    let x1 = insert(module.makeAccess(t.access, from: x0, at: s))!
+    let x1 = insert(Access(t.access, from: x0, at: s, in: module))!
     emitStore(access: x1, to: storage, at: s)
   }
 
@@ -1609,7 +1609,7 @@ struct Emitter {
       switch program[n].referredDecl {
       case .builtinFunction(let f):
         let x0 = emit(apply: f, to: ast[e].arguments, at: ast[e].site)
-        let x1 = insert(module.makeAccess(.set, from: storage, at: ast[e].site))!
+        let x1 = insert(Access(.set, from: storage, at: ast[e].site, in: module))!
         insert(module.makeStore(x0, at: x1, at: ast[e].site))
         return
 
@@ -1671,7 +1671,7 @@ struct Emitter {
 
     for c in program[e].decl.implicitCaptures {
       let y0 = emitLValue(directReferenceTo: c.decl, at: site)
-      let y1 = insert(module.makeAccess(c.type.access, from: y0, at: site))!
+      let y1 = insert(Access(c.type.access, from: y0, at: site, in: module))!
       let y2 = emitSubfieldView(x2, at: [i], at: site)
       emitStore(access: y1, to: y2, at: site)
       i += 1
@@ -1707,7 +1707,7 @@ struct Emitter {
     let s = program[e].site
 
     let x0 = emitLValue(program[e].operand)
-    let x1 = insert(module.makeAccess(t.access, from: x0, at: s))!
+    let x1 = insert(Access(t.access, from: x0, at: s, in: module))!
     emitStore(access: x1, to: storage, at: s)
   }
 
@@ -1846,7 +1846,7 @@ struct Emitter {
   ) {
     let syntax = ast[literal]
     let x0 = emitSubfieldView(storage, at: [0], at: syntax.site)
-    let x1 = insert(module.makeAccess(.set, from: x0, at: syntax.site))!
+    let x1 = insert(Access(.set, from: x0, at: syntax.site, in: module))!
     let x2 = Operand.constant(evaluate(syntax.value))
     insert(module.makeStore(x2, at: x1, at: syntax.site))
   }
@@ -1867,7 +1867,7 @@ struct Emitter {
     }
 
     let x0 = emitSubfieldView(storage, at: [0], at: syntax.site)
-    let x1 = insert(module.makeAccess(.set, from: x0, at: syntax.site))!
+    let x1 = insert(Access(.set, from: x0, at: syntax.site, in: module))!
     let x2 = Operand.constant(IntegerConstant(bits))
     insert(module.makeStore(x2, at: x1, at: syntax.site))
   }
@@ -1877,7 +1877,7 @@ struct Emitter {
   /// - Requires: `storage` is the address of uninitialized memory of type `Hylo.Int`.
   private mutating func emitStore(boolean v: Bool, to storage: Operand, at site: SourceRange) {
     let x0 = emitSubfieldView(storage, at: [0], at: site)
-    let x1 = insert(module.makeAccess(.set, from: x0, at: site))!
+    let x1 = insert(Access(.set, from: x0, at: site, in: module))!
     insert(module.makeStore(.i1(v), at: x1, at: site))
     insert(module.makeEndAccess(x1, at: site))
   }
@@ -1887,7 +1887,7 @@ struct Emitter {
   /// - Requires: `storage` is the address of uninitialized memory of type `Hylo.Int`.
   mutating func emitStore(int v: Int, to storage: Operand, at site: SourceRange) {
     let x0 = emitSubfieldView(storage, at: [0], at: site)
-    let x1 = insert(module.makeAccess(.set, from: x0, at: site))!
+    let x1 = insert(Access(.set, from: x0, at: site, in: module))!
     insert(module.makeStore(.word(v), at: x1, at: site))
     insert(module.makeEndAccess(x1, at: site))
   }
@@ -1898,7 +1898,7 @@ struct Emitter {
   private mutating func emitStore(string v: String, to storage: Operand, at site: SourceRange) {
     let x0 = insert(module.makeConstantString(utf8: v.unescaped.data(using: .utf8)!, at: site))!
     let x1 = emitSubfieldView(storage, at: [0, 0], at: site)
-    let x2 = insert(module.makeAccess(.set, from: x1, at: site))!
+    let x2 = insert(Access(.set, from: x1, at: site, in: module))!
     insert(module.makeStore(x0, at: x2, at: site))
     insert(module.makeEndAccess(x2, at: site))
   }
@@ -1915,7 +1915,7 @@ struct Emitter {
       return
     }
 
-    let x0 = insert(module.makeAccess(.set, from: storage, at: site))!
+    let x0 = insert(Access(.set, from: storage, at: site, in: module))!
     insert(module.makeCapture(a, in: x0, at: site))
     insert(module.makeEndAccess(x0, at: site))
     frames.top.setMayHoldCaptures(s)
@@ -1941,7 +1941,7 @@ struct Emitter {
     _ callee: Operand, to arguments: [Operand],
     writingResultTo storage: Operand, at site: SourceRange
   ) {
-    let o = insert(module.makeAccess(.set, from: storage, at: site))!
+    let o = insert(Access(.set, from: storage, at: site, in: module))!
     insert(module.makeCall(applying: callee, to: arguments, writingResultTo: o, at: site))
     insert(module.makeEndAccess(o, at: site))
   }
@@ -1951,7 +1951,7 @@ struct Emitter {
     _ callee: BundleReference<MethodDecl>, to arguments: [Operand],
     writingResultTo storage: Operand, at site: SourceRange
   ) {
-    let o = insert(module.makeAccess(.set, from: storage, at: site))!
+    let o = insert(Access(.set, from: storage, at: site, in: module))!
     let s = module.makeCallBundle(
       applying: callee, to: arguments, writingResultTo: o, at: site,
       canonicalizingTypesIn: insertionScope!)
@@ -1984,13 +1984,13 @@ struct Emitter {
       usingExplicit: ast[call].arguments, synthesizingDefaultAt: .empty(at: ast[call].site.end))
 
     // Receiver is captured next.
-    let receiver = insert(module.makeAccess(.set, from: s, at: ast[call].site))!
+    let receiver = insert(Access(.set, from: s, at: ast[call].site, in: module))!
 
     // Call is evaluated last.
     let f = Operand.constant(
       FunctionReference(to: AnyDeclID(d), in: &module, specializedBy: a, in: insertionScope!))
     let x0 = emitAllocStack(for: .void, at: ast[call].site)
-    let x1 = insert(module.makeAccess(.set, from: x0, at: ast[call].site))!
+    let x1 = insert(Access(.set, from: x0, at: ast[call].site, in: module))!
 
     let s = module.makeCall(
       applying: f, to: [receiver] + arguments, writingResultTo: x1, at: ast[call].site)
@@ -2059,7 +2059,7 @@ struct Emitter {
 
       case .implicit(let d):
         let s = emitLValue(directReferenceTo: d, at: syntheticSite)
-        result.append(insert(module.makeAccess(p.access, from: s, at: syntheticSite))!)
+        result.append(insert(Access(p.access, from: s, at: syntheticSite, in: module))!)
       }
     }
 
@@ -2090,7 +2090,7 @@ struct Emitter {
     let x0 = emitLValue(e)
     let x1 = unwrapCapture(x0, at: anchor)
     let x2 = emitCoerce(x1, to: p.bareType, at: anchor)
-    return insert(module.makeAccess(p.access, from: x2, at: anchor))!
+    return insert(Access(p.access, from: x2, at: anchor, in: module))!
   }
 
   /// Inserts the IR for argument `e` passed to an autoclosure parameter of type `p`.
@@ -2111,7 +2111,7 @@ struct Emitter {
     let x0 = insert(module.makeAddressToPointer(.constant(r), at: anchor))!
     let x1 = emitAllocStack(for: p.bareType, at: anchor)
     emitInitialize(storage: x1, to: x0, at: anchor)
-    return insert(module.makeAccess(p.access, from: x1, at: anchor))!
+    return insert(Access(p.access, from: x1, at: anchor, in: module))!
   }
 
   /// Inserts the IR for argument `e` passed to a parameter of type `p`, evaluating the literal's
@@ -2121,7 +2121,7 @@ struct Emitter {
   ) -> Operand {
     let x0 = emitAllocStack(for: program[e].type, at: site)
     emitStore(e, to: x0, at: site)
-    return insert(module.makeAccess(p.access, from: x0, at: site))!
+    return insert(Access(p.access, from: x0, at: site, in: module))!
   }
 
   /// Inserts the IR generating the operands of the subscript call `e`.
@@ -2146,7 +2146,7 @@ struct Emitter {
       let s = emitAllocStack(for: t.output, at: ast.site(of: e))
       emitStore(e, to: s)
       let u = emitCoerce(s, to: p.bareType, at: ast.site(of: e))
-      return insert(module.makeAccess(p.access, from: u, at: ast.site(of: e)))!
+      return insert(Access(p.access, from: u, at: ast.site(of: e), in: module))!
 
     case .leaf(let e):
       return emitArgument(e, to: p, at: program[e].site)
@@ -2171,7 +2171,7 @@ struct Emitter {
       var a: [Operand] = []
       for e in arguments {
         let x0 = emitStore(value: e.value)
-        let x1 = insert(module.makeAccess(.sink, from: x0, at: site))!
+        let x1 = insert(Access(.sink, from: x0, at: site, in: module))!
         let x2 = insert(module.makeLoad(x1, at: site))!
         a.append(x2)
         insert(module.makeEndAccess(x1, at: site))
@@ -2271,7 +2271,7 @@ struct Emitter {
     if case .bundle(let b) = entityToCall {
       return emitMethodBundleCallee(referringTo: b, on: r, at: site)
     } else {
-      let c = insert(module.makeAccess(requested, from: r, at: site))!
+      let c = insert(Access(requested, from: r, at: site, in: module))!
       return (callee: entityToCall, captures: [c])
     }
   }
@@ -2288,10 +2288,10 @@ struct Emitter {
     if let k = b.capabilities.uniqueElement {
       let d = module.demandDeclaration(lowering: program.ast.implementation(k, of: b.bundle)!)
       let f = FunctionReference(to: d, in: module, specializedBy: b.arguments, in: insertionScope!)
-      let c = insert(module.makeAccess(k, from: receiver, at: site))!
+      let c = insert(Access(k, from: receiver, at: site, in: module))!
       return (callee: .direct(f), captures: [c])
     } else {
-      let c = insert(module.makeAccess(b.capabilities.weakest!, from: receiver, at: site))!
+      let c = insert(Access(b.capabilities.weakest!, from: receiver, at: site, in: module))!
       return (callee: .bundle(b), captures: [c])
     }
   }
@@ -2308,7 +2308,7 @@ struct Emitter {
 
     case let k:
       let l = emitLValue(callee)
-      let b = module.makeAccess(k, from: l, at: ast[callee].site)
+      let b = Access(k, from: l, at: ast[callee].site, in: module)
       return insert(b)!
     }
   }
@@ -2364,7 +2364,7 @@ struct Emitter {
 
     let entityToCall = program.subscriptBundleReference(to: .init(d)!, specializedBy: a)
     let r = emitLValue(receiver: s, at: ast[callee].site)
-    let c = insert(module.makeAccess(entityToCall.capabilities, from: r, at: ast[callee].site))!
+    let c = insert(Access(entityToCall.capabilities, from: r, at: ast[callee].site, in: module))!
     return (entityToCall, [c])
   }
 
@@ -2476,7 +2476,7 @@ struct Emitter {
     insertionPoint = .end(of: next)
 
     if let target = storage {
-      let x0 = insert(module.makeAccess(.sink, from: rhs, at: site))!
+      let x0 = insert(Access(.sink, from: rhs, at: site, in: module))!
       let x1 = insert(module.makeOpenUnion(x0, as: lhsType, at: site))!
       emitMove([.set], x1, to: target, at: site)
       emitLocalDeclarations(introducedBy: lhs, referringTo: [], relativeTo: target)
@@ -2484,7 +2484,7 @@ struct Emitter {
       insert(module.makeEndAccess(x0, at: site))
     } else {
       let k = AccessEffect(program[lhs].introducer.value)
-      let x0 = insert(module.makeAccess(k, from: rhs, at: site))!
+      let x0 = insert(Access(k, from: rhs, at: site, in: module))!
       let x1 = insert(module.makeOpenUnion(x0, as: lhsType, at: site))!
       assignProjections(of: x1, to: lhs)
     }
@@ -2506,7 +2506,7 @@ struct Emitter {
   private mutating func emitLoadBuiltinBool(_ wrapper: Operand, at site: SourceRange) -> Operand {
     precondition(module.type(of: wrapper) == .address(ast.coreType("Bool")!))
     let x0 = emitSubfieldView(wrapper, at: [0], at: site)
-    let x1 = insert(module.makeAccess(.sink, from: x0, at: site))!
+    let x1 = insert(Access(.sink, from: x0, at: site, in: module))!
     let x2 = insert(module.makeLoad(x1, at: site))!
     insert(module.makeEndAccess(x1, at: site))
     return x2
@@ -2639,10 +2639,10 @@ struct Emitter {
       let f = module.reference(to: convert, implementedFor: foreignConvertibleConformance)
 
       let x0 = emitAllocStack(for: ir, at: site)
-      let x1 = insert(module.makeAccess(.set, from: x0, at: site))!
+      let x1 = insert(Access(.set, from: x0, at: site, in: module))!
       let x2 = emitAllocStack(for: ArrowType(f.type.ast)!.output, at: site)
-      let x3 = insert(module.makeAccess(.set, from: x2, at: site))!
-      let x4 = insert(module.makeAccess(.sink, from: source, at: site))!
+      let x3 = insert(Access(.set, from: x2, at: site, in: module))!
+      let x4 = insert(Access(.sink, from: source, at: site, in: module))!
 
       let s = module.makeCall(applying: .constant(f), to: [x1, x4], writingResultTo: x3, at: site)
       insert(s)
@@ -2676,14 +2676,14 @@ struct Emitter {
       let convert = module.demandDeclaration(lowering: m)!
       let f = module.reference(to: convert, implementedFor: foreignConvertibleConformance)
 
-      let x0 = insert(module.makeAccess(.let, from: o, at: site))!
+      let x0 = insert(Access(.let, from: o, at: site, in: module))!
       let x1 = emitAllocStack(for: ArrowType(f.type.ast)!.output, at: site)
-      let x2 = insert(module.makeAccess(.set, from: x1, at: site))!
+      let x2 = insert(Access(.set, from: x1, at: site, in: module))!
       insert(module.makeCall(applying: .constant(f), to: [x0], writingResultTo: x2, at: site))
       insert(module.makeEndAccess(x2, at: site))
       insert(module.makeEndAccess(x0, at: site))
 
-      let x3 = insert(module.makeAccess(.sink, from: x1, at: site))!
+      let x3 = insert(Access(.sink, from: x1, at: site, in: module))!
       let x4 = insert(module.makeLoad(x3, at: site))!
       insert(module.makeEndAccess(x3, at: site))
       return x4
@@ -2751,7 +2751,7 @@ struct Emitter {
   /// Inserts the IR for lvalue `e`.
   private mutating func emitLValue(pointerConversion e: CastExpr.ID) -> Operand {
     let x0 = emitLValue(ast[e].left)
-    let x1 = insert(module.makeAccess(.sink, from: x0, at: ast[e].site))!
+    let x1 = insert(Access(.sink, from: x0, at: ast[e].site, in: module))!
     let x2 = insert(module.makeLoad(x1, at: ast[e].site))!
     insert(module.makeEndAccess(x1, at: ast[e].site))
 
@@ -2880,7 +2880,7 @@ struct Emitter {
 
     let t = SubscriptType(canonicalType(of: d, specializedBy: z))!
     let b = BundleReference(to: d, specializedBy: z, requesting: t.capabilities)
-    let a = insert(module.makeAccess(t.capabilities, from: r, at: site))!
+    let a = insert(Access(t.capabilities, from: r, at: site, in: module))!
 
     let s = module.makeProjectBundle(
       applying: b, to: [a], at: site, canonicalizingTypesIn: insertionScope!)
@@ -2894,7 +2894,7 @@ struct Emitter {
   ) -> Operand {
     let t = SubscriptImplType(canonicalType(of: d, specializedBy: z))!
     let o = RemoteType(ast[d].introducer.value, t.output)
-    let a = insert(module.makeAccess(o.access, from: r, at: site))!
+    let a = insert(Access(o.access, from: r, at: site, in: module))!
     let f = module.demandDeclaration(lowering: d)
 
     let s = module.makeProject(o, applying: f, specializedBy: z, to: [a], at: site)
@@ -2954,8 +2954,8 @@ struct Emitter {
 
     // Use memcpy of `source` is trivially movable.
     if program.isTrivial(movable) {
-      let x0 = insert(module.makeAccess(.sink, from: value, at: site))!
-      let x1 = insert(module.makeAccess(.set, from: storage, at: site))!
+      let x0 = insert(Access(.sink, from: value, at: site, in: module))!
+      let x1 = insert(Access(.set, from: storage, at: site, in: module))!
       insert(module.makeMemoryCopy(x0, x1, at: site))
       insert(module.makeEndAccess(x1, at: site))
       insert(module.makeMarkState(x0, initialized: false, at: site))
@@ -2977,8 +2977,8 @@ struct Emitter {
     _ value: Operand, to storage: Operand, at site: SourceRange
   ) {
     // Built-in are always stored.
-    let x0 = insert(module.makeAccess(.set, from: storage, at: site))!
-    let x1 = insert(module.makeAccess(.sink, from: value, at: site))!
+    let x0 = insert(Access(.set, from: storage, at: site, in: module))!
+    let x1 = insert(Access(.sink, from: value, at: site, in: module))!
     let x2 = insert(module.makeLoad(x1, at: site))!
     insert(module.makeStore(x2, at: x0, at: site))
     insert(module.makeEndAccess(x1, at: site))
@@ -3001,9 +3001,9 @@ struct Emitter {
     let f = module.reference(to: d, implementedFor: movable)
 
     let x0 = insert(module.makeAllocStack(.void, at: site))!
-    let x1 = insert(module.makeAccess(.set, from: x0, at: site))!
-    let x2 = insert(module.makeAccess(semantics, from: storage, at: site))!
-    let x3 = insert(module.makeAccess(.sink, from: value, at: site))!
+    let x1 = insert(Access(.set, from: x0, at: site, in: module))!
+    let x2 = insert(Access(semantics, from: storage, at: site, in: module))!
+    let x3 = insert(Access(.sink, from: value, at: site, in: module))!
     insert(module.makeCall(applying: .constant(f), to: [x2, x3], writingResultTo: x1, at: site))
     insert(module.makeEndAccess(x3, at: site))
     insert(module.makeEndAccess(x2, at: site))
@@ -3043,8 +3043,8 @@ struct Emitter {
     let d = module.demandCopyDeclaration(definedBy: copyable)
     let f = module.reference(to: d, implementedFor: copyable)
 
-    let x0 = insert(module.makeAccess(.let, from: source, at: site))!
-    let x1 = insert(module.makeAccess(.set, from: target, at: site))!
+    let x0 = insert(Access(.let, from: source, at: site, in: module))!
+    let x1 = insert(Access(.set, from: target, at: site, in: module))!
     insert(module.makeCall(applying: .constant(f), to: [x0], writingResultTo: x1, at: site))
     insert(module.makeEndAccess(x1, at: site))
     insert(module.makeEndAccess(x0, at: site))
@@ -3086,8 +3086,8 @@ struct Emitter {
     let f = module.reference(to: d, implementedFor: deinitializable)
 
     let x0 = insert(module.makeAllocStack(.void, at: site))!
-    let x1 = insert(module.makeAccess(.set, from: x0, at: site))!
-    let x2 = insert(module.makeAccess(.sink, from: storage, at: site))!
+    let x1 = insert(Access(.set, from: x0, at: site, in: module))!
+    let x2 = insert(Access(.sink, from: storage, at: site, in: module))!
     insert(module.makeCall(applying: .constant(f), to: [x2], writingResultTo: x1, at: site))
     insert(module.makeEndAccess(x2, at: site))
     insert(module.makeEndAccess(x1, at: site))
@@ -3194,9 +3194,9 @@ struct Emitter {
       let d = module.demandEqualDeclaration(definedBy: equatable)
       let f = module.reference(to: d, implementedFor: equatable)
 
-      let x0 = insert(module.makeAccess(.set, from: target, at: site))!
-      let x1 = insert(module.makeAccess(.let, from: lhs, at: site))!
-      let x2 = insert(module.makeAccess(.let, from: rhs, at: site))!
+      let x0 = insert(Access(.set, from: target, at: site, in: module))!
+      let x1 = insert(Access(.let, from: lhs, at: site, in: module))!
+      let x2 = insert(Access(.let, from: rhs, at: site, in: module))!
       insert(module.makeCall(applying: .constant(f), to: [x1, x2], writingResultTo: x0, at: site))
       insert(module.makeEndAccess(x2, at: site))
       insert(module.makeEndAccess(x1, at: site))
@@ -3375,7 +3375,7 @@ struct Emitter {
   private mutating func emitUnionDiscriminator(
     _ container: Operand, at site: SourceRange
   ) -> Operand {
-    let x0 = insert(module.makeAccess(.let, from: container, at: site))!
+    let x0 = insert(Access(.let, from: container, at: site, in: module))!
     let x1 = insert(module.makeUnionDiscriminator(x0, at: site))!
     insert(module.makeEndAccess(x0, at: site))
     return x1

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1646,7 +1646,7 @@ struct Emitter {
       specializedBy: module.specialization(in: insertionFunction!), in: insertionScope!)
 
     let site = ast[e].site
-    let x0 = insert(module.makeAddressToPointer(.constant(r), at: site))!
+    let x0 = insert(AddressToPointer(.constant(r), at: site, in: module))!
     let x1 = emitSubfieldView(storage, at: [0], at: site)
     emitInitialize(storage: x1, to: x0, at: ast[e].site)
 
@@ -2108,7 +2108,7 @@ struct Emitter {
       specializedBy: module.specialization(in: insertionFunction!), in: insertionScope!)
 
     let anchor = program[e].site
-    let x0 = insert(module.makeAddressToPointer(.constant(r), at: anchor))!
+    let x0 = insert(AddressToPointer(.constant(r), at: anchor, in: module))!
     let x1 = emitAllocStack(for: p.bareType, at: anchor)
     emitInitialize(storage: x1, to: x0, at: anchor)
     return insert(Access(p.access, from: x1, at: anchor, in: module))!
@@ -2160,7 +2160,7 @@ struct Emitter {
     switch f {
     case .addressOf:
       let source = emitLValue(arguments[0].value)
-      return insert(module.makeAddressToPointer(source, at: site))!
+      return insert(AddressToPointer(source, at: site, in: module))!
 
     case .markUninitialized:
       let source = emitLValue(arguments[0].value)

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1952,8 +1952,8 @@ struct Emitter {
     writingResultTo storage: Operand, at site: SourceRange
   ) {
     let o = insert(Access(.set, from: storage, at: site, in: module))!
-    let s = module.makeCallBundle(
-      applying: callee, to: arguments, writingResultTo: o, at: site,
+    let s = CallBundle(
+      applying: callee, to: arguments, writingResultTo: o, at: site, in: &module,
       canonicalizingTypesIn: insertionScope!)
     insert(s)
     insert(EndAccess(o, at: site, in: module))
@@ -2771,8 +2771,8 @@ struct Emitter {
   /// Inserts the IR for lvalue `e`.
   private mutating func emitLValue(_ e: SubscriptCallExpr.ID) -> Operand {
     let (b, a) = emitOperands(e)
-    let s = module.makeProjectBundle(
-      applying: b, to: a, at: ast[e].site, canonicalizingTypesIn: insertionScope!)
+    let s = ProjectBundle(
+      applying: b, to: a, at: ast[e].site, in: &module, canonicalizingTypesIn: insertionScope!)
     return insert(s)!
   }
 
@@ -2880,9 +2880,8 @@ struct Emitter {
     let t = SubscriptType(canonicalType(of: d, specializedBy: z))!
     let b = BundleReference(to: d, specializedBy: z, requesting: t.capabilities)
     let a = insert(Access(t.capabilities, from: r, at: site, in: module))!
-
-    let s = module.makeProjectBundle(
-      applying: b, to: [a], at: site, canonicalizingTypesIn: insertionScope!)
+    let s = ProjectBundle(
+      applying: b, to: [a], at: site, in: &module, canonicalizingTypesIn: insertionScope!)
     return insert(s)!
   }
 

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -54,25 +54,25 @@ extension IR.Program {
       let x0 = t.transform(s.base, in: &self)
       let x1 = t.transform(s.byteOffset, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeAdvancedByBytes(source: x0, offset: x1, at: s.site)
+        AdvancedByBytes(source: x0, offset: x1, at: s.site, in: target)
       }
 
     case let s as AdvancedByStrides:
       let x0 = t.transform(s.base, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeAdvanced(x0, byStrides: s.offset, at: s.site)
+        AdvancedByStrides(x0, offset: s.offset, at: s.site, in: target)
       }
 
     case let s as AllocStack:
       let x0 = t.transform(s.allocatedType, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeAllocStack(x0, at: s.site)
+        AllocStack(x0, at: s.site, in: target)
       }
 
     case let s as Branch:
       let x0 = t.transform(s.target, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeBranch(to: x0, at: s.site)
+        Branch(to: x0, at: s.site, in: target)
       }
 
     case let s as Call:
@@ -80,33 +80,33 @@ extension IR.Program {
       let x1 = t.transform(s.arguments, in: &self)
       let x2 = t.transform(s.output, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeCall(applying: x0, to: x1, writingResultTo: x2, at: s.site)
+        Call(applying: x0, to: x1, writingResultTo: x2, at: s.site, in: target)
       }
 
     case let s as CallFFI:
       let x0 = t.transform(s.returnType, in: &self)
       let x1 = t.transform(s.operands, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeCallFFI(returning: x0, applying: s.callee, to: x1, at: s.site)
+        CallFFI(returning: x0, applying: s.callee, to: x1, at: s.site, in: target)
       }
 
     case let s as CaptureIn:
       let x0 = t.transform(s.source, in: &self)
       let x1 = t.transform(s.target, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeCapture(x0, in: x1, at: s.site)
+        CaptureIn(x0, in: x1, at: s.site, in: target)
       }
 
     case let s as CloseCapture:
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeCloseCapture(x0, at: s.site)
+        CloseCapture(x0, at: s.site, in: target)
       }
 
     case let s as CloseUnion:
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeCloseUnion(x0, at: s.site)
+        CloseUnion(x0, at: s.site, in: target)
       }
 
     case let s as CondBranch:
@@ -114,7 +114,7 @@ extension IR.Program {
       let x1 = t.transform(s.targetIfTrue, in: &self)
       let x2 = t.transform(s.targetIfFalse, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeCondBranch(if: x0, then: x1, else: x2, at: s.site)
+        CondBranch(if: x0, then: x1, else: x2, at: s.site, in: target)
       }
 
     case let s as ConstantString:
@@ -123,19 +123,19 @@ extension IR.Program {
     case let s as DeallocStack:
       let x0 = t.transform(s.location, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeDeallocStack(for: x0, at: s.site)
+        DeallocStack(for: x0, at: s.site, in: target)
       }
 
     case let s as EndAccess:
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeEndAccess(x0, at: s.site)
+        EndAccess(x0, at: s.site, in: target)
       }
 
     case let s as EndProject:
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeEndProject(x0, at: s.site)
+        EndProject(x0, at: s.site, in: target)
       }
 
     case let s as GenericParameter:
@@ -147,46 +147,46 @@ extension IR.Program {
     case let s as CallBuiltinFunction:
       let x0 = t.transform(s.operands, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeCallBuiltin(applying: s.callee, to: x0, at: s.site)
+        CallBuiltinFunction(applying: s.callee, to: x0, at: s.site, in: target)
       }
 
     case let s as MarkState:
       let x0 = t.transform(s.storage, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeMarkState(x0, initialized: s.initialized, at: s.site)
+        MarkState(x0, initialized: s.initialized, at: s.site, in: target)
       }
 
     case let s as MemoryCopy:
       let x0 = t.transform(s.source, in: &self)
       let x1 = t.transform(s.target, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeMemoryCopy(x0, x1, at: s.site)
+        MemoryCopy(x0, x1, at: s.site, in: target)
       }
 
     case let s as Load:
       let x0 = t.transform(s.source, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeLoad(x0, at: s.site)
+        Load(x0, at: s.site, in: target)
       }
 
     case let s as OpenCapture:
       let x0 = t.transform(s.source, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeOpenCapture(x0, at: s.site)
+        OpenCapture(x0, at: s.site, in: target)
       }
 
     case let s as OpenUnion:
       let x0 = t.transform(s.container, in: &self)
       let x1 = t.transform(s.payloadType, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeOpenUnion(x0, as: x1, forInitialization: s.isUsedForInitialization, at: s.site)
+        OpenUnion(x0, as: x1, forInitialization: s.isUsedForInitialization, at: s.site, in: target)
       }
 
     case let s as PointerToAddress:
       let x0 = t.transform(s.source, in: &self)
       let x1 = RemoteType(t.transform(^s.target, in: &self))!
       return insert(at: p, in: n) { (target) in
-        target.makePointerToAddress(x0, to: x1, at: s.site)
+        PointerToAddress(x0, to: x1, at: s.site, in: target)
       }
 
     case let s as Project:
@@ -199,15 +199,15 @@ extension IR.Program {
       let x0 = RemoteType(t.transform(^s.projection, in: &self))!
       let x1 = t.transform(s.operands, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeProject(
+        Project(
           x0, applying: newCallee.function, specializedBy: newCallee.specialization, to: x1,
-          at: s.site)
+          at: s.site, in: target)
       }
 
     case let s as ReleaseCaptures:
       let x0 = t.transform(s.container, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeReleaseCapture(x0, at: s.site)
+        ReleaseCaptures(x0, at: s.site, in: target)
       }
 
     case let s as Return:
@@ -217,26 +217,26 @@ extension IR.Program {
       let x0 = t.transform(s.object, in: &self)
       let x1 = t.transform(s.target, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeStore(x0, at: x1, at: s.site)
+        Store(x0, at: x1, at: s.site, in: target)
       }
 
     case let s as SubfieldView:
       let x0 = t.transform(s.recordAddress, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeSubfieldView(of: x0, subfield: s.subfield, at: s.site)
+        SubfieldView(of: x0, subfield: s.subfield, at: s.site, in: target)
       }
 
     case let s as Switch:
       let x0 = t.transform(s.index, in: &self)
       let x1 = s.successors.map({ (b) in t.transform(b, in: &self) })
       return insert(at: p, in: n) { (target) in
-        target.makeSwitch(on: x0, toOneOf: x1, at: s.site)
+        Switch(on: x0, toOneOf: x1, at: s.site, in: target)
       }
 
     case let s as UnionDiscriminator:
       let x0 = t.transform(s.container, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeUnionDiscriminator(x0, at: s.site)
+        UnionDiscriminator(x0, at: s.site, in: target)
       }
 
     case let s as UnionSwitch:
@@ -245,8 +245,8 @@ extension IR.Program {
       let x2 = s.targets.reduce(into: UnionSwitch.Targets()) { (d, kv) in
         _ = d[t.transform(kv.key, in: &self)].setIfNil(t.transform(kv.value, in: &self))
       }
-      return insert(at: p, in:n) { (target) in
-        target.makeUnionSwitch(over: x0, of: x1, toOneOf: x2, at: s.site)
+      return insert(at: p, in: n) { (target) in
+        UnionSwitch(over: x0, of: x1, toOneOf: x2, at: s.site, in: target)
       }
 
     case let s as Unreachable:
@@ -255,7 +255,7 @@ extension IR.Program {
     case let s as Yield:
       let x0 = t.transform(s.projection, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeYield(s.capability, x0, at: s.site)
+        Yield(s.capability, x0, at: s.site, in: target)
       }
 
     default:

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -41,7 +41,7 @@ extension IR.Program {
     case let s as Access:
       let x0 = t.transform(s.source, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeAccess(s.capabilities, from: x0, at: s.site)
+        Access(s.capabilities, from: x0, at: s.site, in: target)
       }
 
     case let s as AddressToPointer:

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -47,7 +47,7 @@ extension IR.Program {
     case let s as AddressToPointer:
       let x0 = t.transform(s.source, in: &self)
       return insert(at: p, in: n) { (target) in
-        target.makeAddressToPointer(x0, at: s.site)
+        AddressToPointer(x0, at: s.site, in: target)
       }
 
     case let s as AdvancedByBytes:

--- a/Sources/IR/Operands/Instruction/Access.swift
+++ b/Sources/IR/Operands/Instruction/Access.swift
@@ -67,20 +67,22 @@ extension Access: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Access {
 
   /// Creates an `access` anchored at `site` that may take any of `capabilities` from `source`,
   /// optionally associated with a variable declaration in the AST.
-  func makeAccess(
+  init(
     _ capabilities: AccessEffectSet, from source: Operand,
     correspondingTo binding: VarDecl.ID? = nil,
-    at site: SourceRange
-  ) -> Access {
+    at site: SourceRange,
+    in module: Module
+  ) {
     precondition(!capabilities.isEmpty)
-    precondition(type(of: source).isAddress)
-    return .init(
+    let sourceType = module.type(of: source)
+    precondition(sourceType.isAddress)
+    self.init(
       capabilities: capabilities,
-      accessedType: type(of: source).ast,
+      accessedType: sourceType.ast,
       source: source,
       binding: binding,
       site: site)
@@ -88,12 +90,13 @@ extension Module {
 
   /// Creates an `access` anchored at `site` that takes `capability` from `source`, optionally
   /// associated with a variable declaration in the AST.
-  func makeAccess(
+  init(
     _ capability: AccessEffect, from source: Operand,
     correspondingTo binding: VarDecl.ID? = nil,
-    at site: SourceRange
-  ) -> Access {
-    makeAccess([capability], from: source, correspondingTo: binding, at: site)
+    at site: SourceRange,
+    in module: Module
+  ) {
+    self.init([capability], from: source, correspondingTo: binding, at: site, in: module)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Access.swift
+++ b/Sources/IR/Operands/Instruction/Access.swift
@@ -29,16 +29,20 @@ public struct Access: RegionEntry {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    capabilities: AccessEffectSet,
-    accessedType: AnyType,
-    source: Operand,
-    binding: VarDecl.ID?,
-    site: SourceRange
+  /// Creates an `access` anchored at `site` that may take any of `capabilities` from `source`,
+  /// optionally associated with a variable declaration in the AST.
+  public init(
+    _ capabilities: AccessEffectSet,
+    from source: Operand,
+    correspondingTo binding: VarDecl.ID? = nil,
+    at site: SourceRange,
+    in module: Module
   ) {
+    precondition(!capabilities.isEmpty)
+    let sourceType = module.type(of: source)
+    precondition(sourceType.isAddress)
     self.capabilities = capabilities
-    self.accessedType = accessedType
+    self.accessedType = sourceType.ast
     self.source = source
     self.binding = binding
     self.site = site
@@ -68,25 +72,6 @@ extension Access: CustomStringConvertible {
 }
 
 extension Access {
-
-  /// Creates an `access` anchored at `site` that may take any of `capabilities` from `source`,
-  /// optionally associated with a variable declaration in the AST.
-  init(
-    _ capabilities: AccessEffectSet, from source: Operand,
-    correspondingTo binding: VarDecl.ID? = nil,
-    at site: SourceRange,
-    in module: Module
-  ) {
-    precondition(!capabilities.isEmpty)
-    let sourceType = module.type(of: source)
-    precondition(sourceType.isAddress)
-    self.init(
-      capabilities: capabilities,
-      accessedType: sourceType.ast,
-      source: source,
-      binding: binding,
-      site: site)
-  }
 
   /// Creates an `access` anchored at `site` that takes `capability` from `source`, optionally
   /// associated with a variable declaration in the AST.

--- a/Sources/IR/Operands/Instruction/AddressToPointer.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointer.swift
@@ -33,12 +33,12 @@ public struct AddressToPointer: Instruction {
 
 }
 
-extension Module {
+extension AddressToPointer {
 
   /// Creates an `address_to_pointer` anchored at `site` that converts `source` to a built-in
   /// pointer value.
-  func makeAddressToPointer(_ source: Operand, at site: SourceRange) -> AddressToPointer {
-    .init(source: source, site: site)
+  init(_ source: Operand, at site: SourceRange, in module: Module) {
+    self.init(source: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AddressToPointer.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointer.swift
@@ -12,8 +12,9 @@ public struct AddressToPointer: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(source: Operand, site: SourceRange) {
+  /// Creates an `address_to_pointer` anchored at `site` that converts `source` to a built-in
+  /// pointer value.
+  public init(_ source: Operand, at site: SourceRange, in module: Module) {
     self.source = source
     self.site = site
   }
@@ -29,16 +30,6 @@ public struct AddressToPointer: Instruction {
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     precondition(i == 0)
     source = new
-  }
-
-}
-
-extension AddressToPointer {
-
-  /// Creates an `address_to_pointer` anchored at `site` that converts `source` to a built-in
-  /// pointer value.
-  init(_ source: Operand, at site: SourceRange, in module: Module) {
-    self.init(source: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
@@ -12,12 +12,16 @@ public struct AdvancedByBytes: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
+  /// Creates an `advanced by bytes` instruction anchored at `site` computing the `source` address
+  /// value advanced by `offset` bytes.
+  public init(
     source: Operand,
     offset: Operand,
-    site: SourceRange
+    at site: SourceRange,
+    in m: Module
   ) {
+    precondition(m.type(of: source).isAddress)
+    precondition(m.type(of: offset).isAddress)
     self.base = source
     self.byteOffset = offset
     self.site = site
@@ -42,23 +46,6 @@ extension AdvancedByBytes: CustomStringConvertible {
 
   public var description: String {
     "\(base) advanced by \(byteOffset) bytes"
-  }
-
-}
-
-extension AdvancedByBytes {
-
-  /// Creates an `advanced by bytes` instruction anchored at `site` computing the `source` address
-  /// value advanced by `offset` bytes.
-  init(
-    source: Operand, offset: Operand, at site: SourceRange, in m: Module
-  ) {
-    precondition(m.type(of: source).isAddress)
-    precondition(m.type(of: offset).isAddress)
-    self.init(
-      source: source,
-      offset: offset,
-      site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
@@ -46,16 +46,16 @@ extension AdvancedByBytes: CustomStringConvertible {
 
 }
 
-extension Module {
+extension AdvancedByBytes {
 
   /// Creates an `advanced by bytes` instruction anchored at `site` computing the `source` address
   /// value advanced by `offset` bytes.
-  func makeAdvancedByBytes(
-    source: Operand, offset: Operand, at site: SourceRange
-  ) -> AdvancedByBytes {
-    precondition(type(of: source).isAddress)
-    precondition(type(of: offset).isAddress)
-    return .init(
+  init(
+    source: Operand, offset: Operand, at site: SourceRange, in m: Module
+  ) {
+    precondition(m.type(of: source).isAddress)
+    precondition(m.type(of: offset).isAddress)
+    self.init(
       source: source,
       offset: offset,
       site: site)

--- a/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
@@ -50,22 +50,26 @@ extension AdvancedByStrides: CustomStringConvertible {
 
 }
 
-extension Module {
+extension AdvancedByStrides {
 
   /// Creates an `advanced by strides` instruction anchored at `site` computing the `source`
   /// address advanced by `n` strides of its referred type.
-  func makeAdvanced(
-    _ source: Operand, byStrides n: Int, at site: SourceRange
-  ) -> AdvancedByStrides {
-    guard let b = sourceType(source) else {
+  init(
+    _ source: Operand, offset n: Int, at site: SourceRange, in m: Module
+  ) {
+    guard let b = m.sourceType(source) else {
       preconditionFailure("source must be the address of a buffer")
     }
 
-    return .init(source: source, offset: n, result: .address(b.element), site: site)
+    self.init(source: source, offset: n, result: .address(b.element), site: site)
   }
 
+}
+
+extension Module {
+
   /// Returns the AST type of `source` iff it is the address of a buffer.
-  private func sourceType(_ source: Operand) -> BufferType? {
+  fileprivate func sourceType(_ source: Operand) -> BufferType? {
     let s = type(of: source)
     if s.isAddress {
       return BufferType(s.ast)

--- a/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
@@ -18,16 +18,20 @@ public struct AdvancedByStrides: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    source: Operand,
-    offset: Int,
-    result: IR.`Type`,
-    site: SourceRange
+  /// Creates an `advanced by strides` instruction anchored at `site` computing the `source`
+  /// address advanced by `n` strides of its referred type.
+  public init(
+    _ source: Operand,
+    offset n: Int,
+    at site: SourceRange,
+    in m: Module
   ) {
+    guard let b = m.sourceType(source) else {
+      preconditionFailure("source must be the address of a buffer")
+    }
     self.base = source
-    self.offset = offset
-    self.result = result
+    self.offset = n
+    self.result = .address(b.element)
     self.site = site
   }
 
@@ -46,22 +50,6 @@ extension AdvancedByStrides: CustomStringConvertible {
 
   public var description: String {
     "\(base) advanced by \(offset) strides"
-  }
-
-}
-
-extension AdvancedByStrides {
-
-  /// Creates an `advanced by strides` instruction anchored at `site` computing the `source`
-  /// address advanced by `n` strides of its referred type.
-  init(
-    _ source: Operand, offset n: Int, at site: SourceRange, in m: Module
-  ) {
-    guard let b = m.sourceType(source) else {
-      preconditionFailure("source must be the address of a buffer")
-    }
-
-    self.init(source: source, offset: n, result: .address(b.element), site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AllocStack.swift
+++ b/Sources/IR/Operands/Instruction/AllocStack.swift
@@ -9,9 +9,10 @@ public struct AllocStack: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(allocatedType: AnyType, site: SourceRange) {
-    self.allocatedType = allocatedType
+  /// Creates an `alloc_stack` anchored at `site` that allocates storage of type `t`.
+  public init(_ t: AnyType, at site: SourceRange, in m: Module) {
+    precondition(t.isCanonical)
+    self.allocatedType = t
     self.site = site
   }
 
@@ -29,18 +30,6 @@ extension AllocStack: CustomStringConvertible {
 
   public var description: String {
     "alloc_stack \(allocatedType)"
-  }
-
-}
-
-extension AllocStack {
-
-  /// Creates an `alloc_stack` anchored at `site` that allocates storage of type `t`.
-  ///
-  /// - Requires: `t` is canonical.
-  init(_ t: AnyType, at site: SourceRange, in m: Module) {
-    precondition(t.isCanonical)
-    self.init(allocatedType: t, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AllocStack.swift
+++ b/Sources/IR/Operands/Instruction/AllocStack.swift
@@ -33,14 +33,14 @@ extension AllocStack: CustomStringConvertible {
 
 }
 
-extension Module {
+extension AllocStack {
 
   /// Creates an `alloc_stack` anchored at `site` that allocates storage of type `t`.
   ///
   /// - Requires: `t` is canonical.
-  func makeAllocStack(_ t: AnyType, at site: SourceRange) -> AllocStack {
+  init(_ t: AnyType, at site: SourceRange, in m: Module) {
     precondition(t.isCanonical)
-    return .init(allocatedType: t, site: site)
+    self.init(allocatedType: t, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Branch.swift
+++ b/Sources/IR/Operands/Instruction/Branch.swift
@@ -41,14 +41,14 @@ extension Branch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Branch {
 
   /// Creates a `branch` anchored at `site` that unconditionally jumps at the start of a block.
   ///
   /// - Parameters:
   ///   - target: The block in which control flow jumps.
-  func makeBranch(to target: Block.ID, at anchor: SourceRange) -> Branch {
-    .init(target: target, site: anchor)
+  init(to target: Block.ID, at anchor: SourceRange, in m: Module) {
+    self.init(target: target, site: anchor)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Call.swift
+++ b/Sources/IR/Operands/Instruction/Call.swift
@@ -56,7 +56,7 @@ extension Call: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Call {
 
   /// Creates a `call` anchored at `site` that applies `callee` on `arguments` and writes its
   /// result to `output`.
@@ -65,16 +65,16 @@ extension Module {
   ///   - callee: The function to call.
   ///   - output: The location at which the result of `callee` is stored.
   ///   - arguments: The arguments of the call; one for each input of `callee`'s type.
-  func makeCall(
+  init(
     applying callee: Operand, to arguments: [Operand], writingResultTo output: Operand,
-    at site: SourceRange
-  ) -> Call {
-    let t = ArrowType(type(of: callee).ast)!.strippingEnvironment
+    at site: SourceRange, in m: Module
+  ) {
+    let t = ArrowType(m.type(of: callee).ast)!.strippingEnvironment
     precondition(t.inputs.count == arguments.count)
-    precondition(arguments.allSatisfy({ self[$0] is Access }))
-    precondition(isBorrowSet(output))
+    precondition(arguments.allSatisfy({ m[$0] is Access }))
+    precondition(m.isBorrowSet(output))
 
-    return .init(callee: callee, output: output, arguments: arguments, site: site)
+    self.init(callee: callee, output: output, arguments: arguments, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallBuiltinFunction.swift
+++ b/Sources/IR/Operands/Instruction/CallBuiltinFunction.swift
@@ -37,23 +37,23 @@ extension CallBuiltinFunction: CustomStringConvertible {
 
 }
 
-extension Module {
+extension CallBuiltinFunction {
 
   /// Creates an instruction anchored at `site` that applies `f` to `operands`.
   ///
   /// - Parameters:
   ///   - f: A built-in function.
   ///   - operands: A collection of built-in objects.
-  func makeCallBuiltin(
-    applying s: BuiltinFunction, to operands: [Operand], at site: SourceRange
-  ) -> CallBuiltinFunction {
+  init(
+    applying s: BuiltinFunction, to operands: [Operand], at site: SourceRange, in m: Module
+  ) {
     precondition(
       operands.allSatisfy { (o) in
-        let t = type(of: o)
+        let t = m.type(of: o)
         return t.isObject && (t.ast.base is BuiltinType)
       })
 
-    return .init(applying: s, to: operands, site: site)
+    self.init(applying: s, to: operands, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallBundle.swift
+++ b/Sources/IR/Operands/Instruction/CallBundle.swift
@@ -19,19 +19,35 @@ public struct CallBundle: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    bundle: BundleReference<MethodDecl>,
-    bundleType: MethodType,
-    variants: [AccessEffect: Function.ID],
-    output: Operand,
-    arguments: [Operand],
-    site: SourceRange
+  /// Creates a `call_bundle` that applies one of the variants defined in `m` to arguments `a`,
+  /// canonicalizing types in `scopeOfUse`.
+  public init(
+    applying m: BundleReference<MethodDecl>,
+    to a: [Operand],
+    writingResultTo o: Operand,
+    at site: SourceRange,
+    in module: inout Module,
+    canonicalizingTypesIn scopeOfUse: AnyScopeID
   ) {
-    self.bundle = bundle
-    self.bundleType = bundleType
+    var variants: [AccessEffect: Function.ID] = [:]
+    for v in module.program[m.bundle].impls {
+      let i = module.program[v].introducer.value
+      if m.capabilities.contains(i) {
+        variants[i] = module.demandDeclaration(lowering: v)
+      }
+    }
+    precondition(variants.count > 1)
+
+    let t = MethodType(
+      module.program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!
+    precondition((t.inputs.count + 1) == a.count)
+    precondition(a.allSatisfy({ module[$0] is Access }))
+    precondition(module.isBorrowSet(o))
+
+    self.bundle = m
+    self.bundleType = t
     self.variants = variants
-    self.operands = [output] + arguments
+    self.operands = [o] + a
     self.site = site
   }
 
@@ -60,33 +76,3 @@ extension CallBundle: CustomStringConvertible {
 
 }
 
-extension Module {
-
-  /// Creates a `call_bundle` anchored at `site` that applies one of the variants defined in `m` to
-  /// arguments `a`, canonicalizing types in `scopeOfUse`.
-  mutating func makeCallBundle(
-    applying m: BundleReference<MethodDecl>, to a: [Operand],
-    writingResultTo o: Operand,
-    at site: SourceRange,
-    canonicalizingTypesIn scopeOfUse: AnyScopeID
-  ) -> CallBundle {
-    var variants: [AccessEffect: Function.ID] = [:]
-    for v in program[m.bundle].impls {
-      let i = program[v].introducer.value
-      if m.capabilities.contains(i) {
-        variants[program[v].introducer.value] = demandDeclaration(lowering: v)
-      }
-    }
-
-    precondition(variants.count > 1)
-
-    let t = MethodType(
-      program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!
-    precondition((t.inputs.count + 1) == a.count)
-    precondition(a.allSatisfy({ self[$0] is Access }))
-    precondition(isBorrowSet(o))
-
-    return .init(bundle: m, bundleType: t, variants: variants, output: o, arguments: a, site: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/CallFFI.swift
+++ b/Sources/IR/Operands/Instruction/CallFFI.swift
@@ -16,16 +16,20 @@ public struct CallFFI: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    returnType: IR.`Type`,
-    callee: String,
-    arguments: [Operand],
-    site: SourceRange
+  /// Creates a `call_ffi` anchored at `site` that applies `callee` on `arguments` using to return
+  /// and returns a value of `returnType`.
+  public init(
+    returning returnType: IR.`Type`, 
+    applying callee: String, 
+    to arguments: [Operand],
+    at site: SourceRange, 
+    in m: Module
   ) {
+    precondition(returnType.isObject)
+    precondition(arguments.allSatisfy({ m[$0] is Load }))
     self.returnType = returnType
     self.callee = callee
-    self.operands = arguments
+    self.operands = arguments 
     self.site = site
   }
 
@@ -44,26 +48,6 @@ extension CallFFI: CustomStringConvertible {
   public var description: String {
     let s = "call_ffi \(callee)"
     return operands.isEmpty ? s : "\(s), \(list: operands)"
-  }
-
-}
-
-extension CallFFI {
-
-  /// Creates a `call_ffi` anchored at `site` that applies `callee` on `arguments` using to return
-  /// and returns a value of `returnType`.
-  ///
-  /// - Parameters:
-  ///   - returnType: The return type of the callee.
-  ///   - callee: The name of the foreign function to call
-  ///   - arguments: The arguments of the call.
-  init(
-    returning returnType: IR.`Type`, applying callee: String, to arguments: [Operand],
-    at site: SourceRange, in m: Module
-  ) {
-    precondition(returnType.isObject)
-    precondition(arguments.allSatisfy({ m[$0] is Load }))
-    self.init(returnType: returnType, callee: callee, arguments: arguments, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallFFI.swift
+++ b/Sources/IR/Operands/Instruction/CallFFI.swift
@@ -48,7 +48,7 @@ extension CallFFI: CustomStringConvertible {
 
 }
 
-extension Module {
+extension CallFFI {
 
   /// Creates a `call_ffi` anchored at `site` that applies `callee` on `arguments` using to return
   /// and returns a value of `returnType`.
@@ -57,13 +57,13 @@ extension Module {
   ///   - returnType: The return type of the callee.
   ///   - callee: The name of the foreign function to call
   ///   - arguments: The arguments of the call.
-  func makeCallFFI(
+  init(
     returning returnType: IR.`Type`, applying callee: String, to arguments: [Operand],
-    at site: SourceRange
-  ) -> CallFFI {
+    at site: SourceRange, in m: Module
+  ) {
     precondition(returnType.isObject)
-    precondition(arguments.allSatisfy({ self[$0] is Load }))
-    return .init(returnType: returnType, callee: callee, arguments: arguments, site: site)
+    precondition(arguments.allSatisfy({ m[$0] is Load }))
+    self.init(returnType: returnType, callee: callee, arguments: arguments, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CaptureIn.swift
+++ b/Sources/IR/Operands/Instruction/CaptureIn.swift
@@ -15,8 +15,11 @@ public struct CaptureIn: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(source: Operand, target: Operand, site: SourceRange) {
+  /// Creates a `capture ... in` anchored at `site` that captures `source`, which is an access, and
+  /// stores it in `target`.
+  public init(_ source: Operand, in target: Operand, at site: SourceRange, in m: Module) {
+    precondition(m.type(of: source).isAddress)
+    precondition(m.type(of: target).isAddress)
     self.operands = [source, target]
     self.site = site
   }
@@ -37,18 +40,6 @@ extension CaptureIn: CustomStringConvertible {
 
   public var description: String {
     "capture \(source) in \(target)"
-  }
-
-}
-
-extension CaptureIn {
-
-  /// Creates a `capture ... in` anchored at `site` that captures `source`, which is an access, and
-  /// stores it in `target`.
-  init(_ source: Operand, in target: Operand, at site: SourceRange, in m: Module) {
-    precondition(m.type(of: source).isAddress)
-    precondition(m.type(of: target).isAddress)
-    self.init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CaptureIn.swift
+++ b/Sources/IR/Operands/Instruction/CaptureIn.swift
@@ -41,14 +41,14 @@ extension CaptureIn: CustomStringConvertible {
 
 }
 
-extension Module {
+extension CaptureIn {
 
   /// Creates a `capture ... in` anchored at `site` that captures `source`, which is an access, and
   /// stores it in `target`.
-  func makeCapture(_ source: Operand, in target: Operand, at site: SourceRange) -> CaptureIn {
-    precondition(type(of: source).isAddress)
-    precondition(type(of: target).isAddress)
-    return .init(source: source, target: target, site: site)
+  init(_ source: Operand, in target: Operand, at site: SourceRange, in m: Module) {
+    precondition(m.type(of: source).isAddress)
+    precondition(m.type(of: target).isAddress)
+    self.init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CloseCapture.swift
+++ b/Sources/IR/Operands/Instruction/CloseCapture.swift
@@ -2,12 +2,3 @@ import FrontEnd
 
 /// Ends the lifetime of a projection.
 public typealias CloseCapture = RegionExit<OpenCapture>
-
-extension Module {
-
-  /// Creates a `close_capture` anchored at `site` that ends the exposition of a captured access.
-  func makeCloseCapture(_ start: Operand, at site: SourceRange) -> CloseCapture {
-    makeRegionExit(start, at: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/CloseUnion.swift
+++ b/Sources/IR/Operands/Instruction/CloseUnion.swift
@@ -2,13 +2,3 @@ import FrontEnd
 
 /// Ends the lifetime of a projection.
 public typealias CloseUnion = RegionExit<OpenUnion>
-
-extension Module {
-
-  /// Creates an `close_union` anchored at `site` that ends an access to the payload of a union
-  /// opened previously by `start`.
-  func makeCloseUnion(_ start: Operand, at site: SourceRange) -> CloseUnion {
-    makeRegionExit(start, at: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/CondBranch.swift
+++ b/Sources/IR/Operands/Instruction/CondBranch.swift
@@ -62,7 +62,7 @@ extension CondBranch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension CondBranch {
 
   /// Creates a `cond_branch` anchored at `site` that jumps to `targetIfTrue` if `condition` is
   /// true or `targetIfFalse` otherwise.
@@ -72,15 +72,15 @@ extension Module {
   ///     object.
   ///   - targetIfTrue: The block in which control flow jumps if `condition` is true.
   ///   - targetIfFalse: The block in which control flow jumps if `condition` is false.
-  func makeCondBranch(
+  init(
     if condition: Operand,
     then targetIfTrue: Block.ID,
     else targetIfFalse: Block.ID,
-    at site: SourceRange
-  ) -> CondBranch {
-    precondition(type(of: condition) == .object(BuiltinType.i(1)))
+    at site: SourceRange, in m: Module
+  ) {
+    precondition(m.type(of: condition) == .object(BuiltinType.i(1)))
     precondition(targetIfTrue.function == targetIfFalse.function)
-    return .init(
+    self.init(
       condition: condition,
       targetIfTrue: targetIfTrue,
       targetIfFalse: targetIfFalse,

--- a/Sources/IR/Operands/Instruction/CondBranch.swift
+++ b/Sources/IR/Operands/Instruction/CondBranch.swift
@@ -15,13 +15,23 @@ public struct CondBranch: Terminator {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    condition: Operand,
-    targetIfTrue: Block.ID,
-    targetIfFalse: Block.ID,
-    site: SourceRange
+  /// Creates a `cond_branch` anchored at `site` that jumps to `targetIfTrue` if `condition` is
+  /// true or `targetIfFalse` otherwise.
+  ///
+  /// - Parameters:
+  ///   - condition: The condition tested to select the jump destination. Must a built-in `i1`
+  ///     object.
+  ///   - targetIfTrue: The block in which control flow jumps if `condition` is true.
+  ///   - targetIfFalse: The block in which control flow jumps if `condition` is false.
+  public init(
+    if condition: Operand,
+    then targetIfTrue: Block.ID,
+    else targetIfFalse: Block.ID,
+    at site: SourceRange,
+    in m: Module
   ) {
+    precondition(m.type(of: condition) == .object(BuiltinType.i(1)))
+    precondition(targetIfTrue.function == targetIfFalse.function)
     self.condition = condition
     self.targetIfTrue = targetIfTrue
     self.targetIfFalse = targetIfFalse
@@ -58,33 +68,6 @@ extension CondBranch: CustomStringConvertible {
 
   public var description: String {
     "cond_branch \(condition), \(targetIfTrue), \(targetIfFalse)"
-  }
-
-}
-
-extension CondBranch {
-
-  /// Creates a `cond_branch` anchored at `site` that jumps to `targetIfTrue` if `condition` is
-  /// true or `targetIfFalse` otherwise.
-  ///
-  /// - Parameters:
-  ///   - condition: The condition tested to select the jump destination. Must a built-in `i1`
-  ///     object.
-  ///   - targetIfTrue: The block in which control flow jumps if `condition` is true.
-  ///   - targetIfFalse: The block in which control flow jumps if `condition` is false.
-  init(
-    if condition: Operand,
-    then targetIfTrue: Block.ID,
-    else targetIfFalse: Block.ID,
-    at site: SourceRange, in m: Module
-  ) {
-    precondition(m.type(of: condition) == .object(BuiltinType.i(1)))
-    precondition(targetIfTrue.function == targetIfFalse.function)
-    self.init(
-      condition: condition,
-      targetIfTrue: targetIfTrue,
-      targetIfFalse: targetIfFalse,
-      site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/ConstantString.swift
+++ b/Sources/IR/Operands/Instruction/ConstantString.swift
@@ -38,12 +38,12 @@ extension ConstantString: CustomStringConvertible {
 
 }
 
-extension Module {
+extension ConstantString {
 
   /// Creates a `constant_string` anchored at `site` that returns a  string with given `value`,
   /// encoded in UTF8.
-  func makeConstantString(utf8 value: Data, at site: SourceRange) -> ConstantString {
-    .init(value: value, site: site)
+  init(utf8 value: Data, at site: SourceRange, in m: Module) {
+    self.init(value: value, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/ConstantString.swift
+++ b/Sources/IR/Operands/Instruction/ConstantString.swift
@@ -12,11 +12,13 @@ public struct ConstantString: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(value: Data, site: SourceRange) {
+  /// Creates a `constant_string` anchored at `site` that returns a string with given `value`,
+  /// encoded in UTF8.
+  public init(utf8 value: Data, at site: SourceRange, in m: Module) {
     self.value = value
     self.site = site
   }
+
 
   public var result: IR.`Type`? {
     .object(BuiltinType.i(64))
@@ -34,16 +36,6 @@ extension ConstantString: CustomStringConvertible {
 
   public var description: String {
     "constant_string \(String(data: value, encoding: .utf8)!.debugDescription)"
-  }
-
-}
-
-extension ConstantString {
-
-  /// Creates a `constant_string` anchored at `site` that returns a  string with given `value`,
-  /// encoded in UTF8.
-  init(utf8 value: Data, at site: SourceRange, in m: Module) {
-    self.init(value: value, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/DeallocStack.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStack.swift
@@ -10,7 +10,7 @@ public struct DeallocStack: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(location: Operand, site: SourceRange) {
+  private init(location: Operand, site: SourceRange) {
     self.location = location
     self.site = site
   }
@@ -26,15 +26,15 @@ public struct DeallocStack: Instruction {
 
 }
 
-extension Module {
+extension DeallocStack {
 
   /// Creates a `dealloc_stack` anchored at `site` that deallocates memory allocated by `alloc`.
   ///
   /// - Parameters:
   ///   - alloc: The address of the memory to deallocate. Must be the result of `alloc`.
-  func makeDeallocStack(for alloc: Operand, at site: SourceRange) -> DeallocStack {
-    precondition(alloc.instruction.map({ self[$0] is AllocStack }) ?? false)
-    return .init(location: alloc, site: site)
+  init(for alloc: Operand, at site: SourceRange, in m: Module) {
+    precondition(alloc.instruction.map({ m[$0] is AllocStack }) ?? false)
+    self.init(location: alloc, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/DeallocStack.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStack.swift
@@ -9,9 +9,14 @@ public struct DeallocStack: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  private init(location: Operand, site: SourceRange) {
-    self.location = location
+
+  /// Creates a `dealloc_stack` anchored at `site` that deallocates memory allocated by `alloc`.
+  ///
+  /// - Parameters:
+  ///   - alloc: The address of the memory to deallocate. Must be the result of `alloc`.
+  public init(for alloc: Operand, at site: SourceRange, in m: Module) {
+    precondition(alloc.instruction.map({ m[$0] is AllocStack }) ?? false)
+    self.location = alloc
     self.site = site
   }
 
@@ -22,19 +27,6 @@ public struct DeallocStack: Instruction {
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     precondition(i == 0)
     location = new
-  }
-
-}
-
-extension DeallocStack {
-
-  /// Creates a `dealloc_stack` anchored at `site` that deallocates memory allocated by `alloc`.
-  ///
-  /// - Parameters:
-  ///   - alloc: The address of the memory to deallocate. Must be the result of `alloc`.
-  init(for alloc: Operand, at site: SourceRange, in m: Module) {
-    precondition(alloc.instruction.map({ m[$0] is AllocStack }) ?? false)
-    self.init(location: alloc, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/EndAccess.swift
+++ b/Sources/IR/Operands/Instruction/EndAccess.swift
@@ -2,12 +2,3 @@ import FrontEnd
 
 /// Ends the lifetime of a projection.
 public typealias EndAccess = RegionExit<Access>
-
-extension Module {
-
-  /// Creates an `end_access` anchored at `site` that ends the projection created by `start`.
-  func makeEndAccess(_ start: Operand, at site: SourceRange) -> EndAccess {
-    makeRegionExit(start, at: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/EndProject.swift
+++ b/Sources/IR/Operands/Instruction/EndProject.swift
@@ -2,12 +2,3 @@ import FrontEnd
 
 /// Ends the lifetime of a projection.
 public typealias EndProject = RegionExit<Project>
-
-extension Module {
-
-  /// Creates an `end_project` anchored at `site` that ends the projection created by `start`.
-  func makeEndProject(_ start: Operand, at site: SourceRange) -> EndProject {
-    makeRegionExit(start, at: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/GenericParameter.swift
+++ b/Sources/IR/Operands/Instruction/GenericParameter.swift
@@ -12,14 +12,11 @@ public struct GenericParameter: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    parameter: GenericParameterDecl.ID,
-    result: IR.`Type`,
-    site: SourceRange
-  ) {
-    self.parameter = parameter
-    self.result = result
+  /// Creates an `generic_parameter` anchored at `site` that returns the address of the generic
+  /// argument passed to `p`.
+  public init(passedTo p: GenericParameterDecl.ID, at site: SourceRange, in m: Module) {
+    self.parameter = p
+    self.result = .address(m.program[p].type)
     self.site = site
   }
 
@@ -27,24 +24,13 @@ public struct GenericParameter: Instruction {
     preconditionFailure()
   }
 
+
 }
 
 extension GenericParameter: CustomStringConvertible {
 
   public var description: String {
     "generic_parameter @\(parameter)"
-  }
-
-}
-
-extension GenericParameter {
-
-  /// Creates an `generic_parameter` anchored at `site` that returns the address of the generic
-  /// argument passed to `p`.
-  init(
-    passedTo p: GenericParameterDecl.ID, at site: SourceRange, in m: Module
-  ) {
-    self.init(parameter: p, result: .address(m.program[p].type), site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/GenericParameter.swift
+++ b/Sources/IR/Operands/Instruction/GenericParameter.swift
@@ -37,14 +37,14 @@ extension GenericParameter: CustomStringConvertible {
 
 }
 
-extension Module {
+extension GenericParameter {
 
   /// Creates an `generic_parameter` anchored at `site` that returns the address of the generic
   /// argument passed to `p`.
-  func makeGenericParameter(
-    passedTo p: GenericParameterDecl.ID, at site: SourceRange
-  ) -> GenericParameter {
-    .init(parameter: p, result: .address(program[p].type), site: site)
+  init(
+    passedTo p: GenericParameterDecl.ID, at site: SourceRange, in m: Module
+  ) {
+    self.init(parameter: p, result: .address(m.program[p].type), site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/GlobalAddr.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddr.swift
@@ -41,12 +41,13 @@ extension GlobalAddr: CustomStringConvertible {
 
 }
 
-extension Module {
+extension GlobalAddr {
 
   /// Creates an `global_addr` anchored at `site` that returns the address of `binding`.
-  func makeGlobalAddr(of binding: BindingDecl.ID, at anchor: SourceRange) -> GlobalAddr {
-    let t = program.canonical(program[binding].type, in: program[binding].scope)
-    return .init(binding: binding, valueType: t, site: anchor)
+  init(of binding: BindingDecl.ID, at anchor: SourceRange, in m: Module) {
+    let b = m.program[binding]
+    let t = m.program.canonical(b.type, in: b.scope)
+    self.init(binding: binding, valueType: t, site: anchor)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/GlobalAddr.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddr.swift
@@ -12,15 +12,13 @@ public struct GlobalAddr: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    binding: BindingDecl.ID,
-    valueType: AnyType,
-    site: SourceRange
-  ) {
+  /// Creates an `global_addr` anchored at `site` that returns the address of `binding`.
+  public init(of binding: BindingDecl.ID, at anchor: SourceRange, in m: Module) {
+    let b = m.program[binding]
+    let t = m.program.canonical(b.type, in: b.scope)
     self.binding = binding
-    self.valueType = valueType
-    self.site = site
+    self.valueType = t
+    self.site = anchor
   }
 
   public var result: IR.`Type`? {
@@ -37,17 +35,6 @@ extension GlobalAddr: CustomStringConvertible {
 
   public var description: String {
     "global_addr @\(binding)"
-  }
-
-}
-
-extension GlobalAddr {
-
-  /// Creates an `global_addr` anchored at `site` that returns the address of `binding`.
-  init(of binding: BindingDecl.ID, at anchor: SourceRange, in m: Module) {
-    let b = m.program[binding]
-    let t = m.program.canonical(b.type, in: b.scope)
-    self.init(binding: binding, valueType: t, site: anchor)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Load.swift
+++ b/Sources/IR/Operands/Instruction/Load.swift
@@ -34,16 +34,16 @@ public struct Load: Instruction {
 
 }
 
-extension Module {
+extension Load {
 
   /// Creates a `load` anchored at `site` that loads the object at `source`.
   ///
   /// - Parameters:
   ///   - source: The location from which the object is loaded. Must be the result of an `access`
   ///     instruction requesting a `sink` capability.
-  func makeLoad(_ source: Operand, at site: SourceRange) -> Load {
-    precondition(self[source] is Access)
-    return .init(objectType: .object(type(of: source).ast), from: source, site: site)
+  init(_ source: Operand, at site: SourceRange, in m: Module) {
+    precondition(m[source] is Access)
+    self.init(objectType: .object(m.type(of: source).ast), from: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Load.swift
+++ b/Sources/IR/Operands/Instruction/Load.swift
@@ -12,9 +12,14 @@ public struct Load: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(objectType: IR.`Type`, from source: Operand, site: SourceRange) {
-    self.objectType = objectType
+  /// Creates a `load` anchored at `site` that loads the object at `source`.
+  ///
+  /// - Parameters:
+  ///   - source: The location from which the object is loaded. Must be the result of an `access`
+  ///     instruction requesting a `sink` capability.
+  public init(_ source: Operand, at site: SourceRange, in m: Module) {
+    precondition(m[source] is Access)
+    self.objectType = .object(m.type(of: source).ast)
     self.source = source
     self.site = site
   }
@@ -30,20 +35,6 @@ public struct Load: Instruction {
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     precondition(i == 0)
     source = new
-  }
-
-}
-
-extension Load {
-
-  /// Creates a `load` anchored at `site` that loads the object at `source`.
-  ///
-  /// - Parameters:
-  ///   - source: The location from which the object is loaded. Must be the result of an `access`
-  ///     instruction requesting a `sink` capability.
-  init(_ source: Operand, at site: SourceRange, in m: Module) {
-    precondition(m[source] is Access)
-    self.init(objectType: .object(m.type(of: source).ast), from: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MarkState.swift
+++ b/Sources/IR/Operands/Instruction/MarkState.swift
@@ -12,8 +12,10 @@ public struct MarkState: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  private init(storage: Operand, initialized: Bool, site: SourceRange) {
+  /// Creates a `mark_state` instruction anchored at `site` that marks `storage` has being fully
+  /// initialized if `initialized` is `true` or fully uninitialized otherwise.
+  public init(_ storage: Operand, initialized: Bool, at site: SourceRange, in m: Module) {
+    precondition(m.type(of: storage).isAddress)
     self.storage = storage
     self.initialized = initialized
     self.site = site
@@ -35,17 +37,6 @@ extension MarkState: CustomStringConvertible {
   public var description: String {
     let s = initialized ? "initialized" : "deinitialized"
     return "mark_state \(s) \(storage)"
-  }
-
-}
-
-extension MarkState {
-
-  /// Creates a `mark_state` instruction anchored at `site` that marks `storage` has being fully
-  /// initialized if `initialized` is `true` or fully uninitialized otherwise.
-  init(_ storage: Operand, initialized: Bool, at site: SourceRange, in m: Module) {
-    precondition(m.type(of: storage).isAddress)
-    self.init(storage: storage, initialized: initialized, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MarkState.swift
+++ b/Sources/IR/Operands/Instruction/MarkState.swift
@@ -13,7 +13,7 @@ public struct MarkState: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(storage: Operand, initialized: Bool, site: SourceRange) {
+  private init(storage: Operand, initialized: Bool, site: SourceRange) {
     self.storage = storage
     self.initialized = initialized
     self.site = site
@@ -39,13 +39,13 @@ extension MarkState: CustomStringConvertible {
 
 }
 
-extension Module {
+extension MarkState {
 
   /// Creates a `mark_state` instruction anchored at `site` that marks `storage` has being fully
   /// initialized if `initialized` is `true` or fully uninitialized otherwise.
-  func makeMarkState(_ storage: Operand, initialized: Bool, at site: SourceRange) -> MarkState {
-    precondition(type(of: storage).isAddress)
-    return .init(storage: storage, initialized: initialized, site: site)
+  init(_ storage: Operand, initialized: Bool, at site: SourceRange, in m: Module) {
+    precondition(m.type(of: storage).isAddress)
+    self.init(storage: storage, initialized: initialized, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MemoryCopy.swift
+++ b/Sources/IR/Operands/Instruction/MemoryCopy.swift
@@ -9,8 +9,14 @@ public struct MemoryCopy: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(source: Operand, target: Operand, site: SourceRange) {
+  /// Creates an `memory_copy` anchored at `site` that copies the memory representation of the
+  /// value stored at `source` to `target`.
+  ///
+  /// - Requires: `source` is a `let`-capable access and `target` is a `set`-capable access.
+  ///   `source` and `target` have the same type.
+  public init(_ source: Operand, _ target: Operand, at site: SourceRange, in m: Module) {
+    let s = m.type(of: source)
+    precondition(s.isAddress && (s == m.type(of: target)))
     self.operands = [source, target]
     self.site = site
   }
@@ -23,21 +29,6 @@ public struct MemoryCopy: Instruction {
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new
-  }
-
-}
-
-extension MemoryCopy {
-
-  /// Creates an `memory_copy` anchored at `site` that copies the memory representation of the
-  /// value stored at `source` to `target`.
-  ///
-  /// - Requires: `source` is a `let`-capable access and `target` is a `set`-capable access.
-  ///   `source` and `target` have the same type.
-  init(_ source: Operand, _ target: Operand, at site: SourceRange, in m: Module) {
-    let s = m.type(of: source)
-    precondition(s.isAddress && (s == m.type(of: target)))
-    self.init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MemoryCopy.swift
+++ b/Sources/IR/Operands/Instruction/MemoryCopy.swift
@@ -27,17 +27,17 @@ public struct MemoryCopy: Instruction {
 
 }
 
-extension Module {
+extension MemoryCopy {
 
   /// Creates an `memory_copy` anchored at `site` that copies the memory representation of the
   /// value stored at `source` to `target`.
   ///
   /// - Requires: `source` is a `let`-capable access and `target` is a `set`-capable access.
   ///   `source` and `target` have the same type.
-  func makeMemoryCopy(_ source: Operand, _ target: Operand, at site: SourceRange) -> MemoryCopy {
-    let s = self.type(of: source)
-    precondition(s.isAddress && (s == self.type(of: target)))
-    return .init(source: source, target: target, site: site)
+  init(_ source: Operand, _ target: Operand, at site: SourceRange, in m: Module) {
+    let s = m.type(of: source)
+    precondition(s.isAddress && (s == m.type(of: target)))
+    self.init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Move.swift
+++ b/Sources/IR/Operands/Instruction/Move.swift
@@ -15,12 +15,23 @@ public struct Move: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    object: Operand, target: Operand, movable: FrontEnd.Conformance, site: SourceRange
+  /// Creates a `move` anchored at `site` that moves `value` into `storage` using the move
+  /// operations defined by `movable`.
+  ///
+  /// This instruction is replaced during IR transformation by either the initialization or
+  /// assignment of `storage`, depending on its initialization state.
+  ///
+  /// - Parameters:
+  ///   - value: The object to move. Must have an address type.
+  ///   - storage: The location to initialize or assign. Must have an address type.
+  public init(
+    _ value: Operand, to storage: Operand, usingConformance movable: FrontEnd.Conformance,
+    at site: SourceRange, in m: Module
   ) {
-    self.object = object
-    self.target = target
+    precondition(m.type(of: value).isAddress)
+    precondition(m.type(of: storage).isAddress)
+    self.object = value
+    self.target = storage
     self.movable = movable
     self.site = site
   }
@@ -40,24 +51,3 @@ public struct Move: Instruction {
 
 }
 
-extension Move {
-
-  /// Creates a `move` anchored at `site` that moves `value` into `storage` using the move
-  /// operations defined by `movable`.
-  ///
-  /// This instruction is replaced during IR transformation by either the initialization or
-  /// assignment of `storage`, depending on its initialization state.
-  ///
-  /// - Parameters:
-  ///   - value: The object to move. Must have an address type.
-  ///   - storage: The location to initialize or assign. Must have an address type.
-  init(
-    _ value: Operand, to storage: Operand, usingConformance movable: FrontEnd.Conformance,
-    at site: SourceRange, in m: Module
-  ) {
-    precondition(m.type(of: value).isAddress)
-    precondition(m.type(of: storage).isAddress)
-    self.init(object: value, target: storage, movable: movable, site: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/Move.swift
+++ b/Sources/IR/Operands/Instruction/Move.swift
@@ -40,7 +40,7 @@ public struct Move: Instruction {
 
 }
 
-extension Module {
+extension Move {
 
   /// Creates a `move` anchored at `site` that moves `value` into `storage` using the move
   /// operations defined by `movable`.
@@ -51,13 +51,13 @@ extension Module {
   /// - Parameters:
   ///   - value: The object to move. Must have an address type.
   ///   - storage: The location to initialize or assign. Must have an address type.
-  func makeMove(
+  init(
     _ value: Operand, to storage: Operand, usingConformance movable: FrontEnd.Conformance,
-    at site: SourceRange
-  ) -> Move {
-    precondition(type(of: value).isAddress)
-    precondition(type(of: storage).isAddress)
-    return .init(object: value, target: storage, movable: movable, site: site)
+    at site: SourceRange, in m: Module
+  ) {
+    precondition(m.type(of: value).isAddress)
+    precondition(m.type(of: storage).isAddress)
+    self.init(object: value, target: storage, movable: movable, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/OpenCapture.swift
+++ b/Sources/IR/Operands/Instruction/OpenCapture.swift
@@ -15,9 +15,10 @@ public struct OpenCapture: RegionEntry {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(result: IR.`Type`, source: Operand, site: SourceRange) {
-    self.result = result
+  /// Creates an `open_capture` anchored at `site` that loads the address stored at `source`.
+  public init(_ source: Operand, at site: SourceRange, in m: Module) {
+    let t = RemoteType(m.type(of: source).ast) ?? preconditionFailure()
+    self.result = .address(t.bareType)
     self.operands = [source]
     self.site = site
   }
@@ -29,16 +30,6 @@ public struct OpenCapture: RegionEntry {
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[0] = new
-  }
-
-}
-
-extension OpenCapture {
-
-  /// Creates an `open_capture` anchored at `site` that loads the address stored at `source`.
-  init(_ source: Operand, at site: SourceRange, in m: Module) {
-    let t = RemoteType(m.type(of: source).ast) ?? preconditionFailure()
-    self.init(result: .address(t.bareType), source: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/OpenCapture.swift
+++ b/Sources/IR/Operands/Instruction/OpenCapture.swift
@@ -33,12 +33,12 @@ public struct OpenCapture: RegionEntry {
 
 }
 
-extension Module {
+extension OpenCapture {
 
   /// Creates an `open_capture` anchored at `site` that loads the address stored at `source`.
-  func makeOpenCapture(_ source: Operand, at site: SourceRange) -> OpenCapture {
-    let t = RemoteType(type(of: source).ast) ?? preconditionFailure()
-    return .init(result: .address(t.bareType), source: source, site: site)
+  init(_ source: Operand, at site: SourceRange, in m: Module) {
+    let t = RemoteType(m.type(of: source).ast) ?? preconditionFailure()
+    self.init(result: .address(t.bareType), source: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/OpenUnion.swift
+++ b/Sources/IR/Operands/Instruction/OpenUnion.swift
@@ -25,12 +25,20 @@ public struct OpenUnion: RegionEntry {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(
-    container: Operand, payloadType: AnyType, isUsedForInitialization: Bool, site: SourceRange
+  /// Creates an `open_union` anchored at `site` that projects the address of `container`'s payload
+  /// viewed as an instance of `payload`.
+  ///
+  /// If the bits of the union's discriminator are hidden in its storage, this function removes
+  /// them before projecting the address unless `isUsedForInitialization` is `true`.
+  public init(
+    _ container: Operand, as payload: AnyType,
+    forInitialization isUsedForInitialization: Bool = false,
+    at site: SourceRange, in m: Module
   ) {
+    precondition(m.type(of: container).isAddress)
+    precondition(payload.isCanonical)
     self.container = container
-    self.payloadType = payloadType
+    self.payloadType = payload
     self.isUsedForInitialization = isUsedForInitialization
     self.site = site
   }
@@ -58,29 +66,6 @@ extension OpenUnion: CustomStringConvertible {
     } else {
       return "open_union \(container) as \(payloadType)"
     }
-  }
-
-}
-
-extension OpenUnion {
-
-  /// Creates an `open_union` anchored at `site` that projects the address of `container`'s payload
-  /// viewed as an instance of `payload`.
-  ///
-  /// If the bits of the union's discriminator are hidden in its storage, this function removes
-  /// them before projecting the address unless `isUsedForInitialization` is `true`.
-  init(
-    _ container: Operand, as payload: AnyType,
-    forInitialization isUsedForInitialization: Bool = false,
-    at site: SourceRange, in m: Module
-  ) {
-    precondition(m.type(of: container).isAddress)
-    precondition(payload.isCanonical)
-    self.init(
-      container: container,
-      payloadType: payload,
-      isUsedForInitialization: isUsedForInitialization,
-      site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/OpenUnion.swift
+++ b/Sources/IR/Operands/Instruction/OpenUnion.swift
@@ -62,21 +62,21 @@ extension OpenUnion: CustomStringConvertible {
 
 }
 
-extension Module {
+extension OpenUnion {
 
   /// Creates an `open_union` anchored at `site` that projects the address of `container`'s payload
   /// viewed as an instance of `payload`.
   ///
   /// If the bits of the union's discriminator are hidden in its storage, this function removes
   /// them before projecting the address unless `isUsedForInitialization` is `true`.
-  func makeOpenUnion(
+  init(
     _ container: Operand, as payload: AnyType,
     forInitialization isUsedForInitialization: Bool = false,
-    at site: SourceRange
-  ) -> OpenUnion {
-    precondition(type(of: container).isAddress)
+    at site: SourceRange, in m: Module
+  ) {
+    precondition(m.type(of: container).isAddress)
     precondition(payload.isCanonical)
-    return .init(
+    self.init(
       container: container,
       payloadType: payload,
       isUsedForInitialization: isUsedForInitialization,

--- a/Sources/IR/Operands/Instruction/PointerToAddress.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddress.swift
@@ -15,8 +15,12 @@ public struct PointerToAddress: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(source: Operand, target: RemoteType, site: SourceRange) {
+  /// Creates a `pointer_to_address` anchored at `site` that converts `source`, which is a
+  /// built-in pointer value, to an address of type `target`.
+  public init(
+    _ source: Operand, to target: RemoteType, at site: SourceRange, in m: Module
+  ) {
+    precondition(target.access != .yielded)
     self.source = source
     self.target = target
     self.site = site
@@ -41,19 +45,6 @@ extension PointerToAddress: CustomStringConvertible {
 
   public var description: String {
     "pointer_to_address \(source) as \(target)"
-  }
-
-}
-
-extension PointerToAddress {
-
-  /// Creates a `pointer_to_address` anchored at `site` that converts `source`, which is a
-  /// built-in pointer value, to an address of type `target`.
-  init(
-    _ source: Operand, to target: RemoteType, at site: SourceRange, in m: Module
-  ) {
-    precondition(target.access != .yielded)
-    self.init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/PointerToAddress.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddress.swift
@@ -45,15 +45,15 @@ extension PointerToAddress: CustomStringConvertible {
 
 }
 
-extension Module {
+extension PointerToAddress {
 
   /// Creates a `pointer_to_address` anchored at `site` that converts `source`, which is a
   /// built-in pointer value, to an address of type `target`.
-  func makePointerToAddress(
-    _ source: Operand, to target: RemoteType, at site: SourceRange
-  ) -> PointerToAddress {
+  init(
+    _ source: Operand, to target: RemoteType, at site: SourceRange, in m: Module
+  ) {
     precondition(target.access != .yielded)
-    return .init(source: source, target: target, site: site)
+    self.init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Project.swift
+++ b/Sources/IR/Operands/Instruction/Project.swift
@@ -61,25 +61,26 @@ extension Project: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Project {
 
   /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
   /// which is a reference to a lowered subscript, on `arguments`.
-  func makeProject(
-    _ t: RemoteType, applying s: FunctionReference, to arguments: [Operand], at site: SourceRange
-  ) -> Project {
-    .init(
+  init(
+    _ t: RemoteType, applying s: FunctionReference, to arguments: [Operand], at site: SourceRange,
+    in m: Module
+  ) {
+    self.init(
       projection: t, callee: s.function, specialization: s.specialization,
       operands: arguments, site: site)
   }
 
   /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
   /// which is a lowered subscript, specialized by `z`, on `arguments`.
-  func makeProject(
+  init(
     _ t: RemoteType, applying s: Function.ID, specializedBy z: GenericArguments,
-    to arguments: [Operand], at site: SourceRange
-  ) -> Project {
-    .init(projection: t, callee: s, specialization: z, operands: arguments, site: site)
+    to arguments: [Operand], at site: SourceRange, in m: Module
+  ) {
+    self.init(projection: t, callee: s, specialization: z, operands: arguments, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/RegionExit.swift
+++ b/Sources/IR/Operands/Instruction/RegionExit.swift
@@ -9,10 +9,11 @@ public struct RegionExit<Entry: RegionEntry> {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(start: Operand, site: SourceRange) {
+  /// Creates a region exit anchored at `site` marking an exit of the regions started by `start`.
+  public init(_ start: Operand, at anchor: SourceRange, in m: Module) {
+    precondition(start.instruction.map({ m[$0] is Entry }) ?? false)
     self.operands = [start]
-    self.site = site
+    self.site = anchor
   }
 
   /// The exited region.
@@ -39,18 +40,6 @@ extension RegionExit: CustomStringConvertible {
     default:
       return "end_region \(start)"
     }
-  }
-
-}
-
-extension RegionExit {
-
-  /// Creates a region exit anchored at `site` marking an exit of the regions started by `start`.
-  init(
-    _ start: Operand, at anchor: SourceRange, in m: Module
-  ) {
-    precondition(start.instruction.map({ m[$0] is Entry }) ?? false)
-    self.init(start: start, site: anchor)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/RegionExit.swift
+++ b/Sources/IR/Operands/Instruction/RegionExit.swift
@@ -43,14 +43,14 @@ extension RegionExit: CustomStringConvertible {
 
 }
 
-extension Module {
+extension RegionExit {
 
   /// Creates a region exit anchored at `site` marking an exit of the regions started by `start`.
-  func makeRegionExit<Entry: RegionEntry>(
-    _ start: Operand, at anchor: SourceRange
-  ) -> RegionExit<Entry> {
-    precondition(start.instruction.map({ self[$0] is Entry }) ?? false)
-    return .init(start: start, site: anchor)
+  init(
+    _ start: Operand, at anchor: SourceRange, in m: Module
+  ) {
+    precondition(start.instruction.map({ m[$0] is Entry }) ?? false)
+    self.init(start: start, site: anchor)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
+++ b/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
@@ -25,13 +25,13 @@ public struct ReleaseCaptures: Instruction {
 
 }
 
-extension Module {
+extension ReleaseCaptures {
 
   /// Creates a `release_capture` anchored at `site` that releases the accesses previously captured
   /// in `container`.
-  func makeReleaseCapture(_ container: Operand, at site: SourceRange) -> ReleaseCaptures {
-    precondition(container.instruction.map({ self[$0] is AllocStack }) ?? false)
-    return .init(container: container, site: site)
+  init(_ container: Operand, at site: SourceRange, in module: Module) {
+    precondition(container.instruction.map({ module[$0] is AllocStack }) ?? false)
+    self.init(container: container, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
+++ b/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
@@ -10,8 +10,10 @@ public struct ReleaseCaptures: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(container: Operand, site: SourceRange) {
+  /// Creates a `release_capture` anchored at `site` that releases the accesses previously captured
+  /// in `container`.
+  init(_ container: Operand, at site: SourceRange, in module: Module) {
+    precondition(container.instruction.map({ module[$0] is AllocStack }) ?? false)
     self.operands = [container]
     self.site = site
   }
@@ -21,17 +23,6 @@ public struct ReleaseCaptures: Instruction {
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new
-  }
-
-}
-
-extension ReleaseCaptures {
-
-  /// Creates a `release_capture` anchored at `site` that releases the accesses previously captured
-  /// in `container`.
-  init(_ container: Operand, at site: SourceRange, in module: Module) {
-    precondition(container.instruction.map({ module[$0] is AllocStack }) ?? false)
-    self.init(container: container, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Return.swift
+++ b/Sources/IR/Operands/Instruction/Return.swift
@@ -23,11 +23,11 @@ public struct Return: Terminator {
 
 }
 
-extension Module {
+extension Return {
 
   /// Creates a `return` anchored at `site`.
-  func makeReturn(at site: SourceRange) -> Return {
-    .init(site: site)
+  init(at site: SourceRange, in module: Module) {
+    self.init(site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Return.swift
+++ b/Sources/IR/Operands/Instruction/Return.swift
@@ -6,8 +6,8 @@ public struct Return: Terminator {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(site: SourceRange) {
+  /// Creates a `return` anchored at `site`.
+  init(at site: SourceRange, in module: Module) {
     self.site = site
   }
 
@@ -19,15 +19,6 @@ public struct Return: Terminator {
 
   func replaceSuccessor(_ old: Block.ID, with new: Block.ID) -> Bool {
     false
-  }
-
-}
-
-extension Return {
-
-  /// Creates a `return` anchored at `site`.
-  init(at site: SourceRange, in module: Module) {
-    self.init(site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Store.swift
+++ b/Sources/IR/Operands/Instruction/Store.swift
@@ -34,17 +34,17 @@ public struct Store: Instruction {
 
 }
 
-extension Module {
+extension Store {
 
-  /// Creates a `record` anchored at `site` that stores `object` at `target.
+  /// Creates a `store` anchored at `site` that stores `object` at `target`.
   ///
   /// - Parameters:
   ///   - object: The object to store. Must have an object type.
   ///   - target: The location at which `object` is stored. Must have an address type.
-  func makeStore(_ object: Operand, at target: Operand, at site: SourceRange) -> Store {
-    precondition(type(of: object).isObject)
-    precondition(type(of: target).isAddress)
-    return .init(object: object, at: target, site: site)
+  init(_ object: Operand, at target: Operand, at site: SourceRange, in module: Module) {
+    precondition(module.type(of: object).isObject)
+    precondition(module.type(of: target).isAddress)
+    self.init(object: object, at: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Store.swift
+++ b/Sources/IR/Operands/Instruction/Store.swift
@@ -12,8 +12,14 @@ public struct Store: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(object: Operand, at target: Operand, site: SourceRange) {
+  /// Creates a `store` anchored at `site` that stores `object` at `target`.
+  ///
+  /// - Parameters:
+  ///   - object: The object to store. Must have an object type.
+  ///   - target: The location at which `object` is stored. Must have an address type.
+  init(_ object: Operand, at target: Operand, at site: SourceRange, in module: Module) {
+    precondition(module.type(of: object).isObject)
+    precondition(module.type(of: target).isAddress)
     self.object = object
     self.target = target
     self.site = site
@@ -30,21 +36,6 @@ public struct Store: Instruction {
     default:
       preconditionFailure()
     }
-  }
-
-}
-
-extension Store {
-
-  /// Creates a `store` anchored at `site` that stores `object` at `target`.
-  ///
-  /// - Parameters:
-  ///   - object: The object to store. Must have an object type.
-  ///   - target: The location at which `object` is stored. Must have an address type.
-  init(_ object: Operand, at target: Operand, at site: SourceRange, in module: Module) {
-    precondition(module.type(of: object).isObject)
-    precondition(module.type(of: target).isAddress)
-    self.init(object: object, at: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/SubfieldView.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldView.swift
@@ -53,20 +53,21 @@ extension SubfieldView: CustomStringConvertible {
 
 }
 
-extension Module {
+extension SubfieldView {
 
   /// Creates a `subfield_view` anchored at `site` computing the address of the given `subfield` of
   /// some record at `recordAddress`.
   ///
   /// - Note: `base` is returned unchanged if `elementPath` is empty.
-  func makeSubfieldView(
-    of recordAddress: Operand, subfield elementPath: RecordPath, at site: SourceRange
-  ) -> SubfieldView {
-    precondition(type(of: recordAddress).isAddress)
-    let l = AbstractTypeLayout(of: self.type(of: recordAddress).ast, definedIn: program)
+  init(
+    of recordAddress: Operand, subfield elementPath: RecordPath,
+    at site: SourceRange, in module: Module
+  ) {
+    precondition(module.type(of: recordAddress).isAddress)
+    let l = AbstractTypeLayout(of: module.type(of: recordAddress).ast, definedIn: module.program)
     let t = l[elementPath].type
 
-    return .init(
+    self.init(
       base: recordAddress,
       subfield: elementPath,
       subfieldType: .address(t),

--- a/Sources/IR/Operands/Instruction/Switch.swift
+++ b/Sources/IR/Operands/Instruction/Switch.swift
@@ -49,20 +49,18 @@ extension Switch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Switch {
 
   /// Creates a `switch` anchored at `site` that jumps to `successors[i]`.
   ///
   /// - Requires: `i` is a valid index in `successors`, expressed as a built-in integer, and
   ///   `successors` is not empty.
-  func makeSwitch(
-    on index: Operand, toOneOf successors: [Block.ID], at site: SourceRange
-  ) -> Switch {
-    let t = type(of: index)
+  init(on index: Operand, toOneOf successors: [Block.ID], at site: SourceRange, in module: Module) {
+    let t = module.type(of: index)
     precondition(t.isObject && t.ast.isBuiltinInteger)
     precondition(!successors.isEmpty)
 
-    return .init(index: index, successors: successors, site: site)
+    self.init(index: index, successors: successors, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Switch.swift
+++ b/Sources/IR/Operands/Instruction/Switch.swift
@@ -12,8 +12,15 @@ public struct Switch: Terminator {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(index: Operand, successors: [Block.ID], site: SourceRange) {
+  /// Creates a `switch` anchored at `site` that jumps to `successors[i]`.
+  ///
+  /// - Requires: `i` is a valid index in `successors`, expressed as a built-in integer, and
+  ///   `successors` is not empty.
+  init(on index: Operand, toOneOf successors: [Block.ID], at site: SourceRange, in module: Module) {
+    let t = module.type(of: index)
+    precondition(t.isObject && t.ast.isBuiltinInteger)
+    precondition(!successors.isEmpty)
+
     self.index = index
     self.successors = successors
     self.site = site
@@ -45,22 +52,6 @@ extension Switch: CustomStringConvertible {
 
   public var description: String {
     "switch \(index), \(list: successors)"
-  }
-
-}
-
-extension Switch {
-
-  /// Creates a `switch` anchored at `site` that jumps to `successors[i]`.
-  ///
-  /// - Requires: `i` is a valid index in `successors`, expressed as a built-in integer, and
-  ///   `successors` is not empty.
-  init(on index: Operand, toOneOf successors: [Block.ID], at site: SourceRange, in module: Module) {
-    let t = module.type(of: index)
-    precondition(t.isObject && t.ast.isBuiltinInteger)
-    precondition(!successors.isEmpty)
-
-    self.init(index: index, successors: successors, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
+++ b/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
@@ -30,15 +30,13 @@ public struct UnionDiscriminator: Instruction {
 
 }
 
-extension Module {
+extension UnionDiscriminator {
 
   /// Creates a `union_discriminator` anchored at `site` that returns the discriminator of the
   /// element stored in `container`.
-  func makeUnionDiscriminator(
-    _ container: Operand, at site: SourceRange
-  ) -> UnionDiscriminator {
-    precondition(type(of: container).isAddress)
-    return .init(container: container, site: site)
+  init(_ container: Operand, at site: SourceRange, in module: Module) {
+    precondition(module.type(of: container).isAddress)
+    self.init(container: container, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
+++ b/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
@@ -9,8 +9,10 @@ public struct UnionDiscriminator: Instruction {
   /// The site of the code corresponding to that instruction.
   public var site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(container: Operand, site: SourceRange) {
+  /// Creates a `union_discriminator` anchored at `site` that returns the discriminator of the
+  /// element stored in `container`.
+  init(_ container: Operand, at site: SourceRange, in module: Module) {
+    precondition(module.type(of: container).isAddress)
     self.container = container
     self.site = site
   }
@@ -30,13 +32,3 @@ public struct UnionDiscriminator: Instruction {
 
 }
 
-extension UnionDiscriminator {
-
-  /// Creates a `union_discriminator` anchored at `site` that returns the discriminator of the
-  /// element stored in `container`.
-  init(_ container: Operand, at site: SourceRange, in module: Module) {
-    precondition(module.type(of: container).isAddress)
-    self.init(container: container, site: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/UnionSwitch.swift
+++ b/Sources/IR/Operands/Instruction/UnionSwitch.swift
@@ -27,8 +27,6 @@ public struct UnionSwitch: Terminator {
     self.site = site
   }
 
-  
-
   public var operands: [Operand] {
     [discriminator]
   }
@@ -45,7 +43,10 @@ public struct UnionSwitch: Terminator {
   mutating func replaceSuccessor(_ old: Block.ID, with new: Block.ID) -> Bool {
     precondition(new.function == successors[0].function)
     for (t, b) in targets {
-      if b == old { targets[t] = b; return true }
+      if b == old {
+        targets[t] = b
+        return true
+      }
     }
     return false
   }
@@ -64,7 +65,7 @@ extension UnionSwitch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension UnionSwitch {
 
   /// Creates a `union_switch` anchored at `site` that switches over `discriminator`, which is the
   /// discriminator of a container of type `union`, jumping to corresponding block in `target`.
@@ -73,14 +74,14 @@ extension Module {
   /// than a constant.
   ///
   /// - Requires: `targets` has a key defined for each of `union`.
-  func makeUnionSwitch(
+  init(
     over discriminator: Operand, of union: UnionType, toOneOf targets: UnionSwitch.Targets,
-    at site: SourceRange
-  ) -> UnionSwitch {
-    let t = type(of: discriminator)
+    at site: SourceRange, in m: Module
+  ) {
+    let t = m.type(of: discriminator)
     precondition(t.isObject && t.ast.isBuiltinInteger)
     precondition(union.elements.allSatisfy({ (e) in targets[e] != nil }))
-    return .init(discriminator: discriminator, union: union, targets: targets, site: site)
+    self.init(discriminator: discriminator, union: union, targets: targets, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Unreachable.swift
+++ b/Sources/IR/Operands/Instruction/Unreachable.swift
@@ -6,13 +6,8 @@ public struct Unreachable: Terminator {
   /// The site of the code corresponding to that instruction.
   public var site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(site: SourceRange) {
-    self.site = site
-  }
-
-  /// Creates an instance anchored at `site` that marks the execution path unreachable.
-  init(at site: SourceRange) {
+  /// Creates an instance in `m` with the given properties.
+  init(at site: SourceRange, in m: Module) {
     self.site = site
   }
 
@@ -24,15 +19,6 @@ public struct Unreachable: Terminator {
 
   func replaceSuccessor(_ old: Block.ID, with new: Block.ID) -> Bool {
     false
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `unreachable` anchored at `site` that marks the execution path unreachable.
-  func makeUnreachable(at site: SourceRange) -> Unreachable {
-    .init(site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
@@ -51,7 +51,7 @@ extension WrapExistentialAddr: CustomStringConvertible {
 
 }
 
-extension Module {
+extension WrapExistentialAddr {
 
   /// Creates a `wrap_existential_addr` anchored at `site` that creates an existential container of
   /// type `interface` wrapping `witness` and `table`.
@@ -60,12 +60,12 @@ extension Module {
   ///   - witness: The address of the object wrapped in the container.
   ///   - interface: The type of the container.
   ///   - table: The witness table of the wrapped value. Must be a pointer to a witness table.
-  func makeWrapExistentialAddr(
+  init(
     _ witness: Operand, _ table: Operand, as interface: ExistentialType,
-    at site: SourceRange
-  ) -> WrapExistentialAddr {
-    precondition(type(of: witness).isAddress)
-    return .init(witness: witness, table: table, interface: .address(interface), site: site)
+    at site: SourceRange, in m: Module
+  ) {
+    precondition(m.type(of: witness).isAddress)
+    self.init(witness: witness, table: table, interface: .address(interface), site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
@@ -16,11 +16,21 @@ public struct WrapExistentialAddr: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(witness: Operand, table: Operand, interface: IR.`Type`, site: SourceRange) {
+  /// Creates a `wrap_existential_addr` anchored at `site` that creates an existential container of
+  /// type `interface` wrapping `witness` and `table`.
+  ///
+  /// - Parameters:
+  ///   - witness: The address of the object wrapped in the container.
+  ///   - interface: The type of the container.
+  ///   - table: The witness table of the wrapped value. Must be a pointer to a witness table.
+  init(
+    _ witness: Operand, _ table: Operand, as interface: ExistentialType,
+    at site: SourceRange, in m: Module
+  ) {
+    precondition(m.type(of: witness).isAddress)
     self.witness = witness
     self.table = table
-    self.interface = interface
+    self.interface = .address(interface)
     self.site = site
   }
 
@@ -47,25 +57,6 @@ extension WrapExistentialAddr: CustomStringConvertible {
 
   public var description: String {
     "wrap_existential_addr \(witness), \(table) as \(interface)"
-  }
-
-}
-
-extension WrapExistentialAddr {
-
-  /// Creates a `wrap_existential_addr` anchored at `site` that creates an existential container of
-  /// type `interface` wrapping `witness` and `table`.
-  ///
-  /// - Parameters:
-  ///   - witness: The address of the object wrapped in the container.
-  ///   - interface: The type of the container.
-  ///   - table: The witness table of the wrapped value. Must be a pointer to a witness table.
-  init(
-    _ witness: Operand, _ table: Operand, as interface: ExistentialType,
-    at site: SourceRange, in m: Module
-  ) {
-    precondition(m.type(of: witness).isAddress)
-    self.init(witness: witness, table: table, interface: .address(interface), site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Yield.swift
+++ b/Sources/IR/Operands/Instruction/Yield.swift
@@ -12,10 +12,11 @@ public struct Yield: Instruction {
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
-  /// Creates an instance with the given properties.
-  fileprivate init(capability: AccessEffect, projection: Operand, site: SourceRange) {
-    self.capability = capability
-    self.projection = projection
+  /// Creates a `yield` anchored at `site` that projects `a` with capability `c`.
+  init(_ c: AccessEffect, _ a: Operand, at site: SourceRange, in m: Module) {
+    precondition(m.type(of: a).isAddress)
+    self.capability = c
+    self.projection = a
     self.site = site
   }
 
@@ -32,16 +33,6 @@ public struct Yield: Instruction {
 
   func replaceSuccessor(_ old: Block.ID, _ new: Block.ID) -> Bool {
     false
-  }
-
-}
-
-extension Yield {
-
-  /// Creates a `yield` anchored at `site` that projects `a` with capability `c`.
-  init(_ c: AccessEffect, _ a: Operand, at site: SourceRange, in m: Module) {
-    precondition(m.type(of: a).isAddress)
-    self.init(capability: c, projection: a, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Yield.swift
+++ b/Sources/IR/Operands/Instruction/Yield.swift
@@ -36,12 +36,12 @@ public struct Yield: Instruction {
 
 }
 
-extension Module {
+extension Yield {
 
   /// Creates a `yield` anchored at `site` that projects `a` with capability `c`.
-  func makeYield(_ c: AccessEffect, _ a: Operand, at site: SourceRange) -> Yield {
-    precondition(type(of: a).isAddress)
-    return .init(capability: c, projection: a, site: site)
+  init(_ c: AccessEffect, _ a: Operand, at site: SourceRange, in m: Module) {
+    precondition(m.type(of: a).isAddress)
+    self.init(capability: c, projection: a, site: site)
   }
 
 }


### PR DESCRIPTION
This removes the module methods that generate instructions and puts the functionality directly into instruction constructors.  The simplifications probably will be subsumed by whatever EDSL we end up with.  Willing to close if you don't think it's a win, @kyouko-taiga .