### PR TITLE
Prepare for expanding projections

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -286,6 +286,9 @@ public struct Driver: ParsableCommand {
 
     var ir = try lower(program: program, reportingDiagnosticsTo: &log)
 
+    logVerbose("begin expandProjections pass.\n")
+    ir.expandProjections()
+
     if outputType == .ir || outputType == .rawIR {
       let m = ir.modules[sourceModule]!
       try m.description.write(to: irFile(productName), atomically: true, encoding: .utf8)

--- a/Sources/IR/Analysis/Program+ExpandProjections.swift
+++ b/Sources/IR/Analysis/Program+ExpandProjections.swift
@@ -1,0 +1,27 @@
+import Foundation
+import FrontEnd
+import Utils
+
+extension IR.Program {
+
+  /// Expands projections into regular function calls for the modules in `self`.
+  public mutating func expandProjections() {
+    for m in modules.values {
+      lowerProjections(in: m)
+    }
+    for m in modules.values {
+      lowerProjectCalls(in: m)
+    }
+  }
+
+  /// Lowers the projections in `m` into a pair of ramp+slide functions.
+  private mutating func lowerProjections(in m: Module) {
+    // TODO
+  }
+
+  /// Lowers the `Project` instructions in `m` into regular function calls to projection's ramp & slide functions.
+  private mutating func lowerProjectCalls(in m: Module) {
+    // TODO
+  }
+
+}

--- a/Sources/IR/FunctionID.swift
+++ b/Sources/IR/FunctionID.swift
@@ -21,6 +21,12 @@ extension Function {
       /// The identity of a monomorphized function.
       indirect case monomorphized(base: ID, arguments: GenericArguments)
 
+      /// The identity of a ramp function generated for a projection.
+      indirect case projectionRamp(base: ID)
+
+      /// The identity of a slide function generated for a projection.
+      indirect case projectionSlide(base: ID)
+
     }
 
     /// The value of this identity.
@@ -55,6 +61,16 @@ extension Function {
       precondition(!arguments.isEmpty)
       precondition(arguments.allSatisfy(\.value.isCanonical))
       self.value = .monomorphized(base: base, arguments: arguments)
+    }
+
+    /// Creates the identity of the ramp created for projection `base`.
+    init(projectionRamp base: Function.ID) {
+      self.value = .projectionRamp(base: base)
+    }
+
+    /// Creates the identity of the slide created for projection `base`.
+    init(projectionSlide base: Function.ID) {
+      self.value = .projectionSlide(base: base)
     }
 
     /// `true` if `self` is the identity of a synthesized function.
@@ -92,6 +108,10 @@ extension Function.ID: CustomStringConvertible {
       return "\(b).existentialized"
     case .monomorphized(let b, let a):
       return "<\(list: a.values)>(\(b))"
+    case .projectionRamp(let b):
+      return "\(b).ramp"
+    case .projectionSlide(let b):
+      return "\(b).slide"
     }
   }
 

--- a/Sources/IR/Mangling/Demangler.swift
+++ b/Sources/IR/Mangling/Demangler.swift
@@ -90,6 +90,10 @@ struct Demangler {
         demangled = takePropertyDecl(qualifiedBy: qualification, from: &stream)
       case .productTypeDecl:
         demangled = take(ProductTypeDecl.self, qualifiedBy: qualification, from: &stream)
+      case .projectionRampFunctionDecl:
+        demangled = takeProjectionRampDecl(qualifiedBy: qualification, from: &stream)
+      case .projectionSlideFunctionDecl:
+        demangled = takeProjectionSlideDecl(qualifiedBy: qualification, from: &stream)
       case .remoteType:
         demangled = takeRemoteType(from: &stream)
       case .reserved:
@@ -405,6 +409,44 @@ struct Demangler {
       qualification: q,
       kind: NodeKind(SubscriptImpl.self),
       name: Name(stem: "\(a)"))
+    return .entity(e)
+  }
+
+  /// Demangles a projection ramp declaration from `stream`.
+  private mutating func takeProjectionRampDecl(
+    qualifiedBy qualification: DemangledQualification?,
+    from stream: inout Substring
+  ) -> DemangledSymbol? {
+    guard
+      let q = qualification,
+      let stem = takeString(from: &stream),
+      let type = demangleType(from: &stream)
+    else { return nil }
+
+    let e = DemangledEntity(
+      qualification: q,
+      kind: NodeKind(SubscriptDecl.self),
+      name: Name(stem: String(stem) + ".ramp"),
+      type: type)
+    return .entity(e)
+  }
+
+  /// Demangles a projection slide declaration from `stream`.
+  private mutating func takeProjectionSlideDecl(
+    qualifiedBy qualification: DemangledQualification?,
+    from stream: inout Substring
+  ) -> DemangledSymbol? {
+    guard
+      let q = qualification,
+      let stem = takeString(from: &stream),
+      let type = demangleType(from: &stream)
+    else { return nil }
+
+    let e = DemangledEntity(
+      qualification: q,
+      kind: NodeKind(SubscriptDecl.self),
+      name: Name(stem: String(stem) + ".slide"),
+      type: type)
     return .entity(e)
   }
 

--- a/Sources/IR/Mangling/Mangler.swift
+++ b/Sources/IR/Mangling/Mangler.swift
@@ -363,6 +363,10 @@ struct Mangler {
       append(monomorphized: f, for: a, to: &output)
     case .synthesized(let d):
       append(synthesized: d, to: &output)
+    case .projectionRamp(let b):
+      append(projectionRamp: b, to: &output)
+    case .projectionSlide(let b):
+      append(projectionSlide: b, to: &output)
     case .existentialized:
       UNIMPLEMENTED()
     }
@@ -375,6 +379,20 @@ struct Mangler {
     append(operator: .monomorphizedFunctionDecl, to: &output)
     append(function: s, to: &output)
     append(specialization: arguments, to: &output)
+  }
+
+  /// Writes the mangled representation of `s` to `output`.
+  private mutating func append(projectionRamp s: Function.ID, to output: inout Output
+  ) {
+    append(operator: .projectionRampFunctionDecl, to: &output)
+    append(function: s, to: &output)
+  }
+
+  /// Writes the mangled representation of `s` to `output`.
+  private mutating func append(projectionSlide s: Function.ID, to output: inout Output
+  ) {
+    append(operator: .projectionSlideFunctionDecl, to: &output)
+    append(function: s, to: &output)
   }
 
   /// Writes the mangled representation of `z` to `output`.

--- a/Sources/IR/Mangling/ManglingOperator.swift
+++ b/Sources/IR/Mangling/ManglingOperator.swift
@@ -30,6 +30,10 @@ public enum ManglingOperator: String {
 
   case monomorphizedFunctionDecl = "mF"
 
+  case projectionRampFunctionDecl = "pR"
+
+  case projectionSlideFunctionDecl = "pS"
+
   case staticFunctionDecl = "sF"
 
   case synthesizedFunctionDecl = "xF"

--- a/Sources/IR/Module+Description.swift
+++ b/Sources/IR/Module+Description.swift
@@ -83,6 +83,10 @@ extension Module: TextOutputStreamable {
       return "Monomorphized form of '\(debugDescription(base))' for <\(list: arguments.values)>"
     case .synthesized(let d):
       return debugDescription(d)
+    case .projectionRamp(let b):
+      return "Projection ramp of '\(debugDescription(b))'"
+    case .projectionSlide(let b):
+      return "Projection slide of '\(debugDescription(b))'"
     }
   }
 

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -257,6 +257,8 @@ public struct Module {
       return isDeinit(j)
     case .synthesized(let d):
       return d.kind == .deinitialize
+    case .projectionRamp(_), .projectionSlide(_):
+      return false
     }
   }
 

--- a/Sources/IR/ModulePass.swift
+++ b/Sources/IR/ModulePass.swift
@@ -5,4 +5,6 @@ public enum ModulePass: String {
 
   case inline
 
+  case expandProjections
+
 }

--- a/Sources/IR/Program.swift
+++ b/Sources/IR/Program.swift
@@ -36,6 +36,8 @@ public struct Program: FrontEnd.Program {
       depolymorphize()
     case .inline:
       inlineCalls(where: .hasNoControlFlow)
+    case .expandProjections:
+      expandProjections()
     }
   }
 
@@ -50,6 +52,10 @@ public struct Program: FrontEnd.Program {
       return module(defining: i)
     case .synthesized(let d):
       return base.module(containing: d.scope)
+    case .projectionRamp(let b):
+      return module(defining: b)
+    case .projectionSlide(let b):
+      return module(defining: b)
     }
   }
 


### PR DESCRIPTION
Add:
- add a new program pass to expand projections; this has two steps:
  - lower projections into ramp and slide pairs
  - lower project calls into calls to ramps and slides
- two new types of synthesized functions: projection ramp and slide
- add support for name mangling & demangling for ramps and slides