### PR TITLE
Move creation of IR instructions in `Function`.

### DIFF
--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -131,7 +131,7 @@ extension Module {
     // Nothing to do if the request set is already a singleton.
     if s.capabilities == [k] { return }
 
-    let reified = makeAccess([k], from: s.source, correspondingTo: s.binding, in: f, at: s.site)
+    let reified = self[f].makeAccess([k], from: s.source, correspondingTo: s.binding, at: s.site)
     self[f].replace(i, with: reified)
   }
 
@@ -143,12 +143,12 @@ extension Module {
     // Generate the proper instructions to prepare the projection's arguments.
     var arguments = s.operands
     for a in arguments.indices where s.parameters[a].access == .yielded {
-      let b = makeAccess([k], from: arguments[a], in: f, at: s.site)
-      arguments[a] = .register(self[f].insert(b, at: .before(i)))
+      let b = self[f].makeAccess([k], from: arguments[a], at: s.site, insertingAt: .before(i))
+      arguments[a] = .register(b)
     }
 
     let o = RemoteType(k, s.projection)
-    let reified = makeProject(
+    let reified = self[f].makeProject(
       o, applying: s.variants[k]!, specializedBy: s.bundle.arguments, to: arguments, at: s.site)
     self[f].replace(i, with: reified)
   }

--- a/Sources/IR/Analysis/Module+CloseBorrows.swift
+++ b/Sources/IR/Analysis/Module+CloseBorrows.swift
@@ -32,25 +32,25 @@ extension Module {
       }
 
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeEndAccess(.register(i), in: f, at: site)
+        this[f].makeEndAccess(.register(i), at: site)
       }
 
     case is OpenCapture:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeCloseCapture(.register(i), in: f, at: site)
+        this[f].makeCloseCapture(.register(i), at: site)
       }
 
     case is OpenUnion:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeCloseUnion(.register(i), in: f, at: site)
+        this[f].makeCloseUnion(.register(i), at: site)
       }
 
     case is Project:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeEndProject(.register(i), in: f, at: site)
+        this[f].makeEndProject(.register(i), at: site)
       }
 
     default:

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -62,8 +62,8 @@ extension IR.Program {
 
     let g = monomorphize(callee, usedIn: modules[m]![f].scope(containing: i))
     let r = FunctionReference(to: g, in: modules[m]!)
-    let new = modules[m]!.makeCall(
-      applying: .constant(r), to: Array(s.arguments), writingResultTo: s.output, in: f, at: s.site)
+    let new = modules[m]![f].makeCall(
+      applying: .constant(r), to: Array(s.arguments), writingResultTo: s.output, at: s.site)
     modules[m]![f].replace(i, with: new)
   }
 
@@ -79,7 +79,7 @@ extension IR.Program {
 
     let z = base.canonical(s.specialization, in: modules[m]![f].scope(containing: i))
     let g = monomorphize(s.callee, for: z, usedIn: modules[m]![f].scope(containing: i))
-    let new = modules[m]!.makeProject(
+    let new = modules[m]![f].makeProject(
       s.projection, applying: g, specializedBy: .empty, to: s.operands, at: s.site)
     modules[m]![f].replace(i, with: new)
   }
@@ -179,11 +179,11 @@ extension IR.Program {
     /// Rewrites `i`, which is in `source`, at the end of `b`, which is in `target`.
     func rewrite(return i: InstructionID, to b: Block.ID) {
       let s = modules[source]![i, in: f] as! Return
-      let j = modify(&modules[target]!) { (m) in
+      let j = modify(&modules[target]![result]) { (f) in
         for i in rewrittenGenericValue.values.reversed() {
-          m[result].insert(m.makeDeallocStack(for: .register(i), in: result, at: s.site), at: .end(of: b))
+          _ = f.makeDeallocStack(for: .register(i), at: s.site, insertingAt: .end(of: b))
         }
-        return m[result].insert(m.makeReturn(at: s.site), at: .end(of: b))
+        return f.makeReturn(at: s.site, insertingAt: .end(of: b))
       }
       monomorphizer.rewrittenInstruction[i] = j
     }
@@ -297,7 +297,7 @@ extension Module {
         UNIMPLEMENTED("arbitrary compile-time values")
       }
 
-      let s = self[monomorphized].insert(makeAllocStack(^program.ast.coreType("Int")!, at: insertionSite), at: .end(of: entry))
+      let s = self[monomorphized].makeAllocStack(^program.ast.coreType("Int")!, at: insertionSite, insertingAt: .end(of: entry))
 
       var log = DiagnosticSet()
       Emitter.withInstance(insertingIn: &self, reportingDiagnosticsTo: &log) { (e) in

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -78,6 +78,11 @@ struct Emitter {
     program.ast
   }
 
+  /// The `Function` object in which we are currently inserting.
+  private var insertionIR: Function {
+    module[insertionFunction!]
+  }
+
   /// The basic block in which new instructions are currently inserted.
   private var insertionBlock: Block.ID? {
     insertionPoint?.block
@@ -3369,7 +3374,7 @@ struct Emitter {
     // having set up a record of frames and allocations.  When we recompute
     // allocations as on-demand, that will become a non-issue.
     if frames.isEmpty { frames.push() }
-    let s = insert(module.makeAllocStack(canonical(t), at: currentSource))!
+    let s = insert(insertionIR.makeAllocStack(canonical(t), at: currentSource))!
     frames.top.allocs.append((source: s, mayHoldCaptures: false))
     return s
   }
@@ -3393,7 +3398,7 @@ struct Emitter {
     if a.mayHoldCaptures {
       _release_capture(a.source)
     }
-    insert(module.makeDeallocStack(for: source, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeDeallocStack(for: source, at: currentSource))
   }
 
   /// Appends the IR for computing the address of the given `subfield` of the record at
@@ -3403,14 +3408,18 @@ struct Emitter {
   ) -> Operand {
     if subfield.isEmpty { return recordAddress }
 
+    var o: Operand
+    var p: RecordPath
     if let r = module[recordAddress, in: insertionFunction!] as? SubfieldView {
-      let p = r.subfield + subfield
-      let s = module.makeSubfieldView(of: r.recordAddress, subfield: p, in: insertionFunction!, at: currentSource)
-      return insert(s)!
+      o = r.recordAddress
+      p = r.subfield + subfield
     } else {
-      let s = module.makeSubfieldView(of: recordAddress, subfield: subfield, in: insertionFunction!, at: currentSource)
-      return insert(s)!
+      o = recordAddress
+      p = subfield
     }
+    let l = AbstractTypeLayout(of: module[insertionFunction!].type(of: o).ast, definedIn: program)
+    let s = insertionIR.makeSubfieldView(of: o, subfield: p, resultType: l[p].type, at: currentSource)
+    return insert(s)!
   }
 
   /// Emits the IR for copying the union discriminator of `container`, which is the address of
@@ -3481,7 +3490,7 @@ struct Emitter {
   mutating func _cond_branch(if condition: Operand, then targetIfTrue: Block.ID, else targetIfFalse: Block.ID) {
     checkEntryStack(targetIfTrue)
     checkEntryStack(targetIfFalse)
-    insert(module.makeCondBranch(if: condition, then: targetIfTrue, else: targetIfFalse, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeCondBranch(if: condition, then: targetIfTrue, else: targetIfFalse, at: currentSource))
   }
 
 }
@@ -3702,40 +3711,40 @@ extension Emitter {
 extension Emitter {
 
   fileprivate mutating func _mark_state(_ x: InitializationState, _ op: Operand?) {
-    insert(module.makeMarkState(op!, initialized: x == .initialized, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeMarkState(op!, initialized: x == .initialized, at: currentSource))
   }
 
   fileprivate mutating func _call_ffi<T: TypeProtocol>(_ foreignName: String, on arguments: [Operand], returning returnType: T) -> Operand {
     insert(
-      module.makeCallFFI(
-        returning: .object(returnType), applying: foreignName, to: arguments, in: insertionFunction!, at: currentSource))!
+      insertionIR.makeCallFFI(
+        returning: .object(returnType), applying: foreignName, to: arguments, at: currentSource))!
   }
 
   fileprivate mutating func _unreachable() {
-    insert(module.makeUnreachable(at: currentSource))
+    insert(insertionIR.makeUnreachable(at: currentSource))
   }
 
   fileprivate mutating func _return() {
-    insert(module.makeReturn(at: currentSource))
+    insert(insertionIR.makeReturn(at: currentSource))
   }
 
   fileprivate mutating func _access(
     _ capabilities: AccessEffectSet, from s: Operand, correspondingTo binding: VarDecl.ID? = nil
   ) -> Operand {
-    insert(module.makeAccess(capabilities, from: s, correspondingTo: binding, in: insertionFunction!, at: currentSource))!
+    insert(insertionIR.makeAccess(capabilities, from: s, correspondingTo: binding, at: currentSource))!
   }
 
   fileprivate mutating func _end_access(_ x: Operand) {
-    insert(module.makeEndAccess(x, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeEndAccess(x, at: currentSource))
   }
 
   fileprivate mutating func _yield(_ c: AccessEffect, _ a: Operand) {
-    _ = insert(module.makeYield(c, a, in: insertionFunction!, at: currentSource))
+    _ = insert(insertionIR.makeYield(c, a, at: currentSource))
   }
 
   fileprivate mutating func _branch(to x: Block.ID) {
     checkEntryStack(x)
-    _ = insert(module.makeBranch(to: x, at: currentSource))
+    _ = insert(insertionIR.makeBranch(to: x, at: currentSource))
   }
 
   fileprivate mutating func _open_union(
@@ -3743,12 +3752,12 @@ extension Emitter {
     _ option: OpenUnionOption = .notForInitialization
   ) -> Operand {
     insert(
-      module.makeOpenUnion(
-        container, as: payload, forInitialization: option == .forInitialization, in: insertionFunction!, at: currentSource))!
+      insertionIR.makeOpenUnion(
+        container, as: payload, forInitialization: option == .forInitialization, at: currentSource))!
   }
 
   fileprivate mutating func _close_union(_ x: Operand  ) {
-    insert(module.makeCloseUnion(x, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeCloseUnion(x, at: currentSource))
   }
 
   fileprivate mutating func _project(
@@ -3756,62 +3765,72 @@ extension Emitter {
     to arguments: [Operand]
   ) -> Operand {
     insert(
-      module.makeProject(t, applying: s, specializedBy: z, to: arguments, at: currentSource))!
+      insertionIR.makeProject(t, applying: s, specializedBy: z, to: arguments, at: currentSource))!
   }
 
   fileprivate mutating func _store(_ source: Operand, _ target: Operand) {
-    insert(module.makeStore(source, at: target, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeStore(source, at: target, at: currentSource))
   }
 
   /// Inserts a `load` instruction reading from `source`.
   fileprivate mutating func _load(_ source: Operand) -> Operand {
-    insert(module.makeLoad(source, in: insertionFunction!, at: currentSource))!
+    insert(insertionIR.makeLoad(source, at: currentSource))!
   }
 
 
   fileprivate mutating func _address_to_pointer(_ source: Operand) -> Operand {
-    insert(module.makeAddressToPointer(source, at: currentSource))!
+    insert(insertionIR.makeAddressToPointer(source, at: currentSource))!
   }
 
   fileprivate mutating func _call_builtin(
     _ f: BuiltinFunction, _ arguments: [Operand]
   ) -> Operand {
-    insert(module.makeCallBuiltin(applying: f, to: arguments, in: insertionFunction!, at: currentSource))!
+    insert(insertionIR.makeCallBuiltin(applying: f, to: arguments, at: currentSource))!
   }
 
   fileprivate mutating func _project_bundle(
     applying b: BundleReference<SubscriptDecl>, to arguments: [Operand]
   ) -> Operand {
-    insert(
-      module.makeProjectBundle(
-        applying: b, to: arguments, at: currentSource,
+    var variants: [AccessEffect: Function.ID] = [:]
+    for v in program[b.bundle].impls {
+      let i = program[v].introducer.value
+      if b.capabilities.contains(i) {
+        variants[program[v].introducer.value] = module.demandDeclaration(lowering: v)
+      }
+    }
+
+    let t = SubscriptType(
+      program.canonicalType(of: b.bundle, specializedBy: b.arguments, in: insertionScope!))!.pure
+    return insert(
+      insertionIR.makeProjectBundle(
+        applying: b, ofType: t, to: arguments, with: variants, at: currentSource,
         canonicalizingTypesIn: insertionScope!))!
   }
 
   fileprivate mutating func _open_capture(_ s: Operand) -> Operand {
-    insert(module.makeOpenCapture(s, in: insertionFunction!, at: currentSource))!
+    insert(insertionIR.makeOpenCapture(s, at: currentSource))!
   }
 
   fileprivate mutating func _release_capture(_ source: Operand) {
-    insert(module.makeReleaseCapture(source, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeReleaseCapture(source, at: currentSource))
   }
 
   fileprivate mutating func _advanced(_ source: Operand, byStrides n: Int) -> Operand {
-    insert(module.makeAdvanced(source, byStrides: n, in: insertionFunction!, at: currentSource))!
+    insert(insertionIR.makeAdvanced(source, byStrides: n, at: currentSource))!
   }
 
   fileprivate mutating func _constant_string(utf8 value: Data) -> Operand {
-    insert(module.makeConstantString(utf8: value, at: currentSource))!
+    insert(insertionIR.makeConstantString(utf8: value, at: currentSource))!
   }
 
   fileprivate mutating func _capture(_ source: Operand, in target: Operand) {
-    insert(module.makeCapture(source, in: target, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeCapture(source, in: target, at: currentSource))
   }
 
   fileprivate mutating func _call(
     _ callee: Operand, _ arguments: [Operand], to output: Operand
   ) {
-    insert(module.makeCall(applying: callee, to: arguments, writingResultTo: output, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeCall(applying: callee, to: arguments, writingResultTo: output, at: currentSource))
   }
 
   fileprivate mutating func _call_bundle(
@@ -3819,43 +3838,57 @@ extension Emitter {
     to o: Operand,
     scopeOfUse: AnyScopeID
   ) {
-    insert(module.makeCallBundle(
-      applying: m, to: a, writingResultTo: o, in: insertionFunction!, at: currentSource,
+    var variants: [AccessEffect: Function.ID] = [:]
+    for v in program[m.bundle].impls {
+      let i = program[v].introducer.value
+      if m.capabilities.contains(i) {
+        variants[program[v].introducer.value] = module.demandDeclaration(lowering: v)
+      }
+    }
+
+    precondition(variants.count > 1)
+
+    let t = MethodType(
+      program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!
+
+    insert(insertionIR.makeCallBundle(
+      applying: m, ofType: t, to: a, with: variants, writingResultTo: o, at: currentSource,
       canonicalizingTypesIn: scopeOfUse))
   }
 
   fileprivate mutating func _wrap_existential_addr(
     _ witness: Operand, _ table: Operand, as interface: ExistentialType
   ) -> Operand {
-    insert(module.makeWrapExistentialAddr(witness, table, as: interface, in: insertionFunction!, at: currentSource))!
+    insert(insertionIR.makeWrapExistentialAddr(witness, table, as: interface, at: currentSource))!
   }
 
   fileprivate mutating func _pointer_to_address(_ x: Operand, as t: RemoteType) -> Operand {
-    insert(module.makePointerToAddress(x, to: t, at: currentSource))!
+    insert(insertionIR.makePointerToAddress(x, to: t, at: currentSource))!
   }
 
   fileprivate mutating func _generic_parameter(at x: GenericParameterDecl.ID) -> Operand {
-    insert(module.makeGenericParameter(passedTo: x, at: currentSource))!
+    insert(insertionIR.makeGenericParameter(passedTo: x, ofType: program[x].type, at: currentSource))!
   }
 
   fileprivate mutating func _global_addr(at x: BindingDecl.ID) -> Operand {
-    insert(module.makeGlobalAddr(of: x, at: currentSource))!
+    let t = program.canonical(program[x].type, in: program[x].scope)
+    return insert(insertionIR.makeGlobalAddr(of: x, valueType: t, at: currentSource))!
   }
 
   fileprivate mutating func _memory_copy(_ source: Operand, _ target: Operand) {
-    insert(module.makeMemoryCopy(source, target, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeMemoryCopy(source, target, at: currentSource))
   }
 
   fileprivate mutating func _move(_ source: Operand, _ target: Operand, via movability: FrontEnd.Conformance) {
-    insert(module.makeMove(source, to: target, usingConformance: movability, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeMove(source, to: target, usingConformance: movability, at: currentSource))
   }
 
   fileprivate mutating func _union_discriminator(_ x: Operand) -> Operand {
-    insert(module.makeUnionDiscriminator(x, in: insertionFunction!, at: currentSource))!
+    insert(insertionIR.makeUnionDiscriminator(x, at: currentSource))!
   }
 
   fileprivate mutating func _union_switch(case discriminator: Operand, of u: UnionType, _ targets: UnionSwitch.Targets) {
-    insert(module.makeUnionSwitch(over: discriminator, of: u, toOneOf: targets, in: insertionFunction!, at: currentSource))
+    insert(insertionIR.makeUnionSwitch(over: discriminator, of: u, toOneOf: targets, at: currentSource))
   }
 
 }

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -40,103 +40,73 @@ extension IR.Program {
     switch modules[m]![i, in: f] {
     case let s as Access:
       let x0 = t.transform(s.source, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeAccess(s.capabilities, from: x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeAccess(s.capabilities, from: x0, at: s.site, insertingAt: p)
 
     case let s as AddressToPointer:
       let x0 = t.transform(s.source, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeAddressToPointer(x0, at: s.site)
-      }
+      return modules[n]![g].makeAddressToPointer(x0, at: s.site, insertingAt: p)
 
     case let s as AdvancedByBytes:
       let x0 = t.transform(s.base, in: &self)
       let x1 = t.transform(s.byteOffset, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeAdvancedByBytes(source: x0, offset: x1, in: g, at: s.site)
-      }
+      return modules[n]![g].makeAdvancedByBytes(source: x0, offset: x1, at: s.site, insertingAt: p)
 
     case let s as AdvancedByStrides:
       let x0 = t.transform(s.base, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeAdvanced(x0, byStrides: s.offset, in: g, at: s.site)
-      }
+      return modules[n]![g].makeAdvanced(x0, byStrides: s.offset, at: s.site, insertingAt: p)
 
     case let s as AllocStack:
       let x0 = t.transform(s.allocatedType, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeAllocStack(x0, at: s.site)
-      }
+      return modules[n]![g].makeAllocStack(x0, at: s.site, insertingAt: p)
 
     case let s as Branch:
       let x0 = t.transform(s.target, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeBranch(to: x0, at: s.site)
-      }
+      return modules[n]![g].makeBranch(to: x0, at: s.site, insertingAt: p)
 
     case let s as Call:
       let x0 = t.transform(s.callee, in: &self)
       let x1 = t.transform(s.arguments, in: &self)
       let x2 = t.transform(s.output, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeCall(applying: x0, to: x1, writingResultTo: x2, in: g, at: s.site)
-      }
+      return modules[n]![g].makeCall(applying: x0, to: x1, writingResultTo: x2, at: s.site, insertingAt: p)
 
     case let s as CallFFI:
       let x0 = t.transform(s.returnType, in: &self)
       let x1 = t.transform(s.operands, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeCallFFI(returning: x0, applying: s.callee, to: x1, in: g, at: s.site)
-      }
+      return modules[n]![g].makeCallFFI(returning: x0, applying: s.callee, to: x1, at: s.site, insertingAt: p)
 
     case let s as CaptureIn:
       let x0 = t.transform(s.source, in: &self)
       let x1 = t.transform(s.target, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeCapture(x0, in: x1, in: g, at: s.site)
-      }
+      return modules[n]![g].makeCapture(x0, in: x1, at: s.site, insertingAt: p)
 
     case let s as CloseCapture:
       let x0 = t.transform(s.start, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeCloseCapture(x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeCloseCapture(x0, at: s.site, insertingAt: p)
 
     case let s as CloseUnion:
       let x0 = t.transform(s.start, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeCloseUnion(x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeCloseUnion(x0, at: s.site, insertingAt: p)
 
     case let s as CondBranch:
       let x0 = t.transform(s.condition, in: &self)
       let x1 = t.transform(s.targetIfTrue, in: &self)
       let x2 = t.transform(s.targetIfFalse, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeCondBranch(if: x0, then: x1, else: x2, in: g, at: s.site)
-      }
+      return modules[n]![g].makeCondBranch(if: x0, then: x1, else: x2, at: s.site, insertingAt: p)
 
     case let s as ConstantString:
       return modules[n]![g].insert(s, at: p)
 
     case let s as DeallocStack:
       let x0 = t.transform(s.location, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeDeallocStack(for: x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeDeallocStack(for: x0, at: s.site, insertingAt: p)
 
     case let s as EndAccess:
       let x0 = t.transform(s.start, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeEndAccess(x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeEndAccess(x0, at: s.site, insertingAt: p)
 
     case let s as EndProject:
       let x0 = t.transform(s.start, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeEndProject(x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeEndProject(x0, at: s.site, insertingAt: p)
 
     case let s as GenericParameter:
       return modules[n]![g].insert(s, at: p)
@@ -146,48 +116,34 @@ extension IR.Program {
 
     case let s as CallBuiltinFunction:
       let x0 = t.transform(s.operands, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeCallBuiltin(applying: s.callee, to: x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeCallBuiltin(applying: s.callee, to: x0, at: s.site, insertingAt: p)
 
     case let s as MarkState:
       let x0 = t.transform(s.storage, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeMarkState(x0, initialized: s.initialized, in: g, at: s.site)
-      }
+      return modules[n]![g].makeMarkState(x0, initialized: s.initialized, at: s.site, insertingAt: p)
 
     case let s as MemoryCopy:
       let x0 = t.transform(s.source, in: &self)
       let x1 = t.transform(s.target, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeMemoryCopy(x0, x1, in: g, at: s.site)
-      }
+      return modules[n]![g].makeMemoryCopy(x0, x1, at: s.site, insertingAt: p)
 
     case let s as Load:
       let x0 = t.transform(s.source, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeLoad(x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeLoad(x0, at: s.site, insertingAt: p)
 
     case let s as OpenCapture:
       let x0 = t.transform(s.source, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeOpenCapture(x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeOpenCapture(x0, at: s.site, insertingAt: p)
 
     case let s as OpenUnion:
       let x0 = t.transform(s.container, in: &self)
       let x1 = t.transform(s.payloadType, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeOpenUnion(x0, as: x1, forInitialization: s.isUsedForInitialization, in: g, at: s.site)
-      }
+      return modules[n]![g].makeOpenUnion(x0, as: x1, forInitialization: s.isUsedForInitialization, at: s.site, insertingAt: p)
 
     case let s as PointerToAddress:
       let x0 = t.transform(s.source, in: &self)
       let x1 = RemoteType(t.transform(^s.target, in: &self))!
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makePointerToAddress(x0, to: x1, at: s.site)
-      }
+      return modules[n]![g].makePointerToAddress(x0, to: x1, at: s.site, insertingAt: p)
 
     case let s as Project:
       let r = FunctionReference(
@@ -198,17 +154,14 @@ extension IR.Program {
 
       let x0 = RemoteType(t.transform(^s.projection, in: &self))!
       let x1 = t.transform(s.operands, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeProject(
-          x0, applying: newCallee.function, specializedBy: newCallee.specialization, to: x1,
-          at: s.site)
-      }
+      return modules[n]![g].makeProject(
+        x0, applying: newCallee.function, specializedBy: newCallee.specialization, to: x1,
+        at: s.site, insertingAt: p
+      )
 
     case let s as ReleaseCaptures:
       let x0 = t.transform(s.container, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeReleaseCapture(x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeReleaseCapture(x0, at: s.site, insertingAt: p)
 
     case let s as Return:
       return modules[n]![g].insert(s, at: p)
@@ -216,28 +169,24 @@ extension IR.Program {
     case let s as Store:
       let x0 = t.transform(s.object, in: &self)
       let x1 = t.transform(s.target, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeStore(x0, at: x1, in: g, at: s.site)
-      }
+      return modules[n]![g].makeStore(x0, at: x1, at: s.site, insertingAt: p)
 
     case let s as SubfieldView:
       let x0 = t.transform(s.recordAddress, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeSubfieldView(of: x0, subfield: s.subfield, in: g, at: s.site)
-      }
+      let l = AbstractTypeLayout(of: modules[n]![g].type(of: x0).ast, definedIn: modules[n]!.program)
+      let t = l[s.subfield].type
+      return modules[n]![g].makeSubfieldView(
+        of: x0, subfield: s.subfield, resultType: t, at: s.site, insertingAt: p
+      )
 
     case let s as Switch:
       let x0 = t.transform(s.index, in: &self)
       let x1 = s.successors.map({ (b) in t.transform(b, in: &self) })
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeSwitch(on: x0, toOneOf: x1, in: g, at: s.site)
-      }
+      return modules[n]![g].makeSwitch(on: x0, toOneOf: x1, at: s.site, insertingAt: p)
 
     case let s as UnionDiscriminator:
       let x0 = t.transform(s.container, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeUnionDiscriminator(x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeUnionDiscriminator(x0, at: s.site, insertingAt: p)
 
     case let s as UnionSwitch:
       let x0 = t.transform(s.discriminator, in: &self)
@@ -245,18 +194,14 @@ extension IR.Program {
       let x2 = s.targets.reduce(into: UnionSwitch.Targets()) { (d, kv) in
         _ = d[t.transform(kv.key, in: &self)].setIfNil(t.transform(kv.value, in: &self))
       }
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeUnionSwitch(over: x0, of: x1, toOneOf: x2, in: g, at: s.site)
-      }
+      return modules[n]![g].makeUnionSwitch(over: x0, of: x1, toOneOf: x2, at: s.site, insertingAt: p)
 
     case let s as Unreachable:
       return modules[n]![g].insert(s, at: p)
 
     case let s as Yield:
       let x0 = t.transform(s.projection, in: &self)
-      return insert(at: p, in: g, in: n) { (target) in
-        target.makeYield(s.capability, x0, in: g, at: s.site)
-      }
+      return modules[n]![g].makeYield(s.capability, x0, at: s.site, insertingAt: p)
 
     default:
       unreachable()

--- a/Sources/IR/Operands/Instruction/Access.swift
+++ b/Sources/IR/Operands/Instruction/Access.swift
@@ -67,23 +67,34 @@ extension Access: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `access` anchored at `site` that may take any of `capabilities` from `source`,
   /// optionally associated with a variable declaration in the AST.
   func makeAccess(
     _ capabilities: AccessEffectSet, from source: Operand,
     correspondingTo binding: VarDecl.ID? = nil,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> Access {
     precondition(!capabilities.isEmpty)
-    precondition(self[f].type(of: source).isAddress)
+    precondition(type(of: source).isAddress)
     return .init(
       capabilities: capabilities,
-      accessedType: self[f].type(of: source).ast,
+      accessedType: type(of: source).ast,
       source: source,
       binding: binding,
       site: site)
+  }
+
+  /// Creates an `access` anchored at `site` that may take any of `capabilities` from `source`,
+  /// optionally associated with a variable declaration in the AST.
+  mutating func makeAccess(
+    _ capabilities: AccessEffectSet, from source: Operand,
+    correspondingTo binding: VarDecl.ID? = nil,
+    at site: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeAccess(capabilities, from: source, correspondingTo: binding, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AddressToPointer.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointer.swift
@@ -33,12 +33,21 @@ public struct AddressToPointer: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `address_to_pointer` anchored at `site` that converts `source` to a built-in
   /// pointer value.
   func makeAddressToPointer(_ source: Operand, at site: SourceRange) -> AddressToPointer {
     .init(source: source, site: site)
+  }
+
+  /// Creates an `address_to_pointer` anchored at `site` that converts `source` to a built-in
+  /// pointer value, inserting it at `p`.
+  mutating func makeAddressToPointer(
+    _ source: Operand, at site: SourceRange,
+    insertingAt p: InsertionPoint
+    ) -> InstructionID {
+    insert(makeAddressToPointer(source, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
@@ -46,19 +46,27 @@ extension AdvancedByBytes: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `advanced by bytes` instruction anchored at `site` computing the `source` address
   /// value advanced by `offset` bytes.
   func makeAdvancedByBytes(
-    source: Operand, offset: Operand, in f: Function.ID, at site: SourceRange
+    source: Operand, offset: Operand, at site: SourceRange
   ) -> AdvancedByBytes {
-    precondition(self[f].type(of: source).isAddress)
-    precondition(self[f].type(of: offset).isAddress)
+    precondition(type(of: source).isAddress)
+    precondition(type(of: offset).isAddress)
     return .init(
       source: source,
       offset: offset,
       site: site)
   }
 
+  /// Creates an `advanced by bytes` instruction anchored at `site` computing the `source` address
+  /// value advanced by `offset` bytes, inserting it at `p`.
+  mutating func makeAdvancedByBytes(
+    source: Operand, offset: Operand, at site: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeAdvancedByBytes(source: source, offset: offset, at: site), at: p)
+  }
 }

--- a/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
@@ -50,23 +50,32 @@ extension AdvancedByStrides: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `advanced by strides` instruction anchored at `site` computing the `source`
   /// address advanced by `n` strides of its referred type.
   func makeAdvanced(
-    _ source: Operand, byStrides n: Int, in f: Function.ID, at site: SourceRange
+    _ source: Operand, byStrides n: Int, at site: SourceRange
   ) -> AdvancedByStrides {
-    guard let b = sourceType(source, in: f) else {
+    guard let b = sourceType(source) else {
       preconditionFailure("source must be the address of a buffer")
     }
 
     return .init(source: source, offset: n, result: .address(b.element), site: site)
   }
 
+  /// Creates an `advanced by strides` instruction anchored at `site` computing the `source`
+  /// address advanced by `n` strides of its referred type, inserting it at `p`.
+  mutating func makeAdvanced(
+    _ source: Operand, byStrides n: Int, at site: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeAdvanced(source, byStrides: n, at: site), at: p)
+  }
+
   /// Returns the AST type of `source` iff it is the address of a buffer.
-  private func sourceType(_ source: Operand, in f: Function.ID) -> BufferType? {
-    let s = self[f].type(of: source)
+  private func sourceType(_ source: Operand) -> BufferType? {
+    let s = type(of: source)
     if s.isAddress {
       return BufferType(s.ast)
     } else {

--- a/Sources/IR/Operands/Instruction/AllocStack.swift
+++ b/Sources/IR/Operands/Instruction/AllocStack.swift
@@ -33,7 +33,7 @@ extension AllocStack: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `alloc_stack` anchored at `site` that allocates storage of type `t`.
   ///
@@ -41,6 +41,16 @@ extension Module {
   func makeAllocStack(_ t: AnyType, at site: SourceRange) -> AllocStack {
     precondition(t.isCanonical)
     return .init(allocatedType: t, site: site)
+  }
+
+  /// Creates an `alloc_stack` anchored at `site` that allocates storage of type `t`, inserting it at `p`.
+  ///
+  /// - Requires: `t` is canonical.
+  mutating func makeAllocStack(
+    _ t: AnyType, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID
+  {
+    insert(makeAllocStack(t, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Branch.swift
+++ b/Sources/IR/Operands/Instruction/Branch.swift
@@ -40,7 +40,7 @@ extension Branch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `branch` anchored at `site` that unconditionally jumps at the start of a block.
   ///
@@ -48,6 +48,16 @@ extension Module {
   ///   - target: The block in which control flow jumps.
   func makeBranch(to target: Block.ID, at anchor: SourceRange) -> Branch {
     .init(target: target, site: anchor)
+  }
+
+  /// Creates a `branch` anchored at `site` that unconditionally jumps at the start of a block, inserting it at `p`.
+  ///
+  /// - Parameters:
+  ///   - target: The block in which control flow jumps.
+  mutating func makeBranch(
+    to target: Block.ID, at anchor: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeBranch(to: target, at: anchor), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Call.swift
+++ b/Sources/IR/Operands/Instruction/Call.swift
@@ -56,7 +56,7 @@ extension Call: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `call` anchored at `site` that applies `callee` on `arguments` and writes its
   /// result to `output`.
@@ -67,14 +67,28 @@ extension Module {
   ///   - arguments: The arguments of the call; one for each input of `callee`'s type.
   func makeCall(
     applying callee: Operand, to arguments: [Operand], writingResultTo output: Operand,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> Call {
-    let t = ArrowType(self[f].type(of: callee).ast)!.strippingEnvironment
+    let t = ArrowType(type(of: callee).ast)!.strippingEnvironment
     precondition(t.inputs.count == arguments.count)
-    precondition(arguments.allSatisfy({ self[$0, in: f] is Access }))
-    precondition(self[f].isBorrowSet(output))
+    precondition(arguments.allSatisfy({ self[$0] is Access }))
+    precondition(isBorrowSet(output))
 
     return .init(callee: callee, output: output, arguments: arguments, site: site)
+  }
+
+  /// Creates a `call` anchored at `site` that applies `callee` on `arguments` and writes its
+  /// result to `output`, inserting it at `p`.
+  ///
+  /// - Parameters:
+  ///   - callee: The function to call.
+  ///   - output: The location at which the result of `callee` is stored.
+  ///   - arguments: The arguments of the call; one for each input of `callee`'s type.
+  mutating func makeCall(
+    applying callee: Operand, to arguments: [Operand], writingResultTo output: Operand,
+    at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeCall(applying: callee, to: arguments, writingResultTo: output, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallBuiltinFunction.swift
+++ b/Sources/IR/Operands/Instruction/CallBuiltinFunction.swift
@@ -37,23 +37,35 @@ extension CallBuiltinFunction: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
-  /// Creates an instruction anchored at `site` that applies `f` to `operands`.
+  /// Creates an instruction anchored at `site` that applies `s` to `operands`.
   ///
   /// - Parameters:
-  ///   - f: A built-in function.
+  ///   - s: A built-in function.
   ///   - operands: A collection of built-in objects.
   func makeCallBuiltin(
-    applying s: BuiltinFunction, to operands: [Operand], in f: Function.ID, at site: SourceRange
+    applying s: BuiltinFunction, to operands: [Operand], at site: SourceRange
   ) -> CallBuiltinFunction {
     precondition(
       operands.allSatisfy { (o) in
-        let t = self[f].type(of: o)
+        let t = type(of: o)
         return t.isObject && (t.ast.base is BuiltinType)
       })
 
     return .init(applying: s, to: operands, site: site)
+  }
+
+  /// Creates an instruction anchored at `site` that applies `s` to `operands`, inserting it at `p`.
+  ///
+  /// - Parameters:
+  ///   - s: A built-in function.
+  ///   - operands: A collection of built-in objects.
+  mutating func makeCallBuiltin(
+    applying s: BuiltinFunction, to operands: [Operand], at site: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeCallBuiltin(applying: s, to: operands, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallBundle.swift
+++ b/Sources/IR/Operands/Instruction/CallBundle.swift
@@ -60,34 +60,43 @@ extension CallBundle: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
-  /// Creates a `call_bundle` anchored at `site` that applies one of the variants defined in `m` to
-  /// arguments `a`, canonicalizing types in `scopeOfUse`.
-  mutating func makeCallBundle(
-    applying m: BundleReference<MethodDecl>, to a: [Operand],
+  /// Creates a `call_bundle` anchored at `site` that applies one of the `variants` defined in `m`,
+  /// of type `t` to arguments `a`, canonicalizing types in `scopeOfUse`.
+  func makeCallBundle(
+    applying m: BundleReference<MethodDecl>,
+    ofType t: MethodType,
+    to a: [Operand],
+    with variants: [AccessEffect: Function.ID] = [:],
     writingResultTo o: Operand,
-    in f: Function.ID,
     at site: SourceRange,
     canonicalizingTypesIn scopeOfUse: AnyScopeID
   ) -> CallBundle {
-    var variants: [AccessEffect: Function.ID] = [:]
-    for v in program[m.bundle].impls {
-      let i = program[v].introducer.value
-      if m.capabilities.contains(i) {
-        variants[program[v].introducer.value] = demandDeclaration(lowering: v)
-      }
-    }
-
     precondition(variants.count > 1)
-
-    let t = MethodType(
-      program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!
     precondition((t.inputs.count + 1) == a.count)
-    precondition(a.allSatisfy({ self[$0, in: f] is Access }))
-    precondition(self[f].isBorrowSet(o))
+    precondition(a.allSatisfy({ self[$0] is Access }))
+    precondition(isBorrowSet(o))
 
     return .init(bundle: m, bundleType: t, variants: variants, output: o, arguments: a, site: site)
+  }
+
+  /// Creates a `call_bundle` anchored at `site` that applies one of the `variants` defined in `m`,
+  /// of type `t`, to arguments `a`, canonicalizing types in `scopeOfUse`, inserting it at `p`.
+  mutating func makeCallBundle(
+    applying m: BundleReference<MethodDecl>,
+    ofType t: MethodType,
+    to a: [Operand],
+    with variants: [AccessEffect: Function.ID] = [:],
+    writingResultTo o: Operand,
+    at site: SourceRange,
+    canonicalizingTypesIn scopeOfUse: AnyScopeID,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(
+      makeCallBundle(
+        applying: m, ofType: t, to: a, with: variants, writingResultTo: o,
+        at: site, canonicalizingTypesIn: scopeOfUse), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallFFI.swift
+++ b/Sources/IR/Operands/Instruction/CallFFI.swift
@@ -48,7 +48,7 @@ extension CallFFI: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `call_ffi` anchored at `site` that applies `callee` on `arguments` using to return
   /// and returns a value of `returnType`.
@@ -59,11 +59,26 @@ extension Module {
   ///   - arguments: The arguments of the call.
   func makeCallFFI(
     returning returnType: IR.`Type`, applying callee: String, to arguments: [Operand],
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> CallFFI {
     precondition(returnType.isObject)
-    precondition(arguments.allSatisfy({ self[$0, in: f] is Load }))
+    precondition(arguments.allSatisfy({ self[$0] is Load }))
     return .init(returnType: returnType, callee: callee, arguments: arguments, site: site)
+  }
+
+  /// Creates a `call_ffi` anchored at `site` that applies `callee` on `arguments` using to return
+  /// and returns a value of `returnType`, inserting it at `p`.
+  ///
+  /// - Parameters:
+  ///   - returnType: The return type of the callee.
+  ///   - callee: The name of the foreign function to call
+  ///   - arguments: The arguments of the call.
+  mutating func makeCallFFI(
+    returning returnType: IR.`Type`, applying callee: String, to arguments: [Operand],
+    at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(
+      makeCallFFI(returning: returnType, applying: callee, to: arguments, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CaptureIn.swift
+++ b/Sources/IR/Operands/Instruction/CaptureIn.swift
@@ -41,14 +41,23 @@ extension CaptureIn: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `capture ... in` anchored at `site` that captures `source`, which is an access, and
   /// stores it in `target`.
-  func makeCapture(_ source: Operand, in target: Operand, in f: Function.ID, at site: SourceRange) -> CaptureIn {
-    precondition(self[f].type(of: source).isAddress)
-    precondition(self[f].type(of: target).isAddress)
+  func makeCapture(_ source: Operand, in target: Operand, at site: SourceRange) -> CaptureIn {
+    precondition(type(of: source).isAddress)
+    precondition(type(of: target).isAddress)
     return .init(source: source, target: target, site: site)
+  }
+
+  /// Creates a `capture ... in` anchored at `site` that captures `source`, which is an access, and
+  /// stores it in `target`, inserting it at `p`.
+  mutating func makeCapture(
+    _ source: Operand, in target: Operand, at site: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeCapture(source, in: target, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CloseCapture.swift
+++ b/Sources/IR/Operands/Instruction/CloseCapture.swift
@@ -3,11 +3,18 @@ import FrontEnd
 /// Ends the lifetime of a projection.
 public typealias CloseCapture = RegionExit<OpenCapture>
 
-extension Module {
+extension Function {
 
   /// Creates a `close_capture` anchored at `site` that ends the exposition of a captured access.
-  func makeCloseCapture(_ start: Operand, in f: Function.ID, at site: SourceRange) -> CloseCapture {
-    makeRegionExit(start, in: f, at: site)
+  func makeCloseCapture(_ start: Operand, at site: SourceRange) -> CloseCapture {
+    makeRegionExit(start, at: site)
+  }
+
+  /// Creates a `close_capture` anchored at `site` that ends the exposition of a captured access, inserting it at `p`.
+  mutating func makeCloseCapture(
+    _ start: Operand, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeCloseCapture(start, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CloseUnion.swift
+++ b/Sources/IR/Operands/Instruction/CloseUnion.swift
@@ -3,12 +3,20 @@ import FrontEnd
 /// Ends the lifetime of a projection.
 public typealias CloseUnion = RegionExit<OpenUnion>
 
-extension Module {
+extension Function {
 
   /// Creates an `close_union` anchored at `site` that ends an access to the payload of a union
   /// opened previously by `start`.
-  func makeCloseUnion(_ start: Operand, in f: Function.ID, at site: SourceRange) -> CloseUnion {
-    makeRegionExit(start, in: f, at: site)
+  func makeCloseUnion(_ start: Operand, at site: SourceRange) -> CloseUnion {
+    makeRegionExit(start, at: site)
+  }
+
+  /// Creates an `close_union` anchored at `site` that ends an access to the payload of a union
+  /// opened previously by `start`, inserting it at `p`.
+  mutating func makeCloseUnion(
+    _ start: Operand, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeCloseUnion(start, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CondBranch.swift
+++ b/Sources/IR/Operands/Instruction/CondBranch.swift
@@ -61,7 +61,7 @@ extension CondBranch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `cond_branch` anchored at `site` that jumps to `targetIfTrue` if `condition` is
   /// true or `targetIfFalse` otherwise.
@@ -75,15 +75,32 @@ extension Module {
     if condition: Operand,
     then targetIfTrue: Block.ID,
     else targetIfFalse: Block.ID,
-    in f: Function.ID,
     at site: SourceRange
   ) -> CondBranch {
-    precondition(self[f].type(of: condition) == .object(BuiltinType.i(1)))
+    precondition(type(of: condition) == .object(BuiltinType.i(1)))
     return .init(
       condition: condition,
       targetIfTrue: targetIfTrue,
       targetIfFalse: targetIfFalse,
       site: site)
+  }
+
+  /// Creates a `cond_branch` anchored at `site` that jumps to `targetIfTrue` if `condition` is
+  /// true or `targetIfFalse` otherwise, inserting it at `p`.
+  ///
+  /// - Parameters:
+  ///   - condition: The condition tested to select the jump destination. Must a built-in `i1`
+  ///     object.
+  ///   - targetIfTrue: The block in which control flow jumps if `condition` is true.
+  ///   - targetIfFalse: The block in which control flow jumps if `condition` is false.
+  mutating func makeCondBranch(
+    if condition: Operand,
+    then targetIfTrue: Block.ID,
+    else targetIfFalse: Block.ID,
+    at site: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeCondBranch(if: condition, then: targetIfTrue, else: targetIfFalse, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/ConstantString.swift
+++ b/Sources/IR/Operands/Instruction/ConstantString.swift
@@ -38,12 +38,18 @@ extension ConstantString: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `constant_string` anchored at `site` that returns a  string with given `value`,
   /// encoded in UTF8.
   func makeConstantString(utf8 value: Data, at site: SourceRange) -> ConstantString {
     .init(value: value, site: site)
+  }
+
+  /// Creates a `constant_string` anchored at `site` that returns a  string with given `value`,
+  /// encoded in UTF8, inserting it at `p`.
+  mutating func makeConstantString(utf8 value: Data, at site: SourceRange, insertingAt p: InsertionPoint) -> InstructionID {
+    insert(makeConstantString(utf8: value, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/DeallocStack.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStack.swift
@@ -26,15 +26,23 @@ public struct DeallocStack: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `dealloc_stack` anchored at `site` that deallocates memory allocated by `alloc`.
   ///
   /// - Parameters:
   ///   - alloc: The address of the memory to deallocate. Must be the result of `alloc`.
-  func makeDeallocStack(for alloc: Operand, in f: Function.ID, at site: SourceRange) -> DeallocStack {
-    precondition(alloc.instruction.map({ self[$0, in: f] is AllocStack }) ?? false)
+  func makeDeallocStack(for alloc: Operand, at site: SourceRange) -> DeallocStack {
+    precondition(alloc.instruction.map({ self[$0] is AllocStack }) ?? false)
     return .init(location: alloc, site: site)
+  }
+
+  /// Creates a `dealloc_stack` anchored at `site` that deallocates memory allocated by `alloc`.
+  /// inserting it at `p`.
+  mutating func makeDeallocStack(
+    for alloc: Operand, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeDeallocStack(for: alloc, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/EndAccess.swift
+++ b/Sources/IR/Operands/Instruction/EndAccess.swift
@@ -3,11 +3,16 @@ import FrontEnd
 /// Ends the lifetime of a projection.
 public typealias EndAccess = RegionExit<Access>
 
-extension Module {
+extension Function {
 
   /// Creates an `end_access` anchored at `site` that ends the projection created by `start`.
-  func makeEndAccess(_ start: Operand, in f: Function.ID, at site: SourceRange) -> EndAccess {
-    makeRegionExit(start, in: f, at: site)
+  func makeEndAccess(_ start: Operand, at site: SourceRange) -> EndAccess {
+    makeRegionExit(start, at: site)
+  }
+
+  /// Creates an `end_access` anchored at `site` that ends the projection created by `start`, inserting it at `p`.
+  mutating func makeEndAccess(_ start: Operand, at site: SourceRange, insertingAt p: InsertionPoint) -> InstructionID {
+    insert(makeEndAccess(start, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/EndProject.swift
+++ b/Sources/IR/Operands/Instruction/EndProject.swift
@@ -3,11 +3,16 @@ import FrontEnd
 /// Ends the lifetime of a projection.
 public typealias EndProject = RegionExit<Project>
 
-extension Module {
+extension Function {
 
   /// Creates an `end_project` anchored at `site` that ends the projection created by `start`.
-  func makeEndProject(_ start: Operand, in f: Function.ID, at site: SourceRange) -> EndProject {
-    makeRegionExit(start, in: f, at: site)
+  func makeEndProject(_ start: Operand, at site: SourceRange) -> EndProject {
+    makeRegionExit(start, at: site)
+  }
+
+  /// Creates an `end_project` anchored at `site` that ends the projection created by `start`, inserting it at `p`.
+  mutating func makeEndProject(_ start: Operand, at site: SourceRange, insertingAt p: InsertionPoint) -> InstructionID {
+    insert(makeEndProject(start, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/GenericParameter.swift
+++ b/Sources/IR/Operands/Instruction/GenericParameter.swift
@@ -37,14 +37,22 @@ extension GenericParameter: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `generic_parameter` anchored at `site` that returns the address of the generic
-  /// argument passed to `p`.
+  /// argument passed to `p` of type `t`.
   func makeGenericParameter(
-    passedTo p: GenericParameterDecl.ID, at site: SourceRange
+    passedTo p: GenericParameterDecl.ID, ofType t: AnyType, at site: SourceRange
   ) -> GenericParameter {
-    .init(parameter: p, result: .address(program[p].type), site: site)
+    .init(parameter: p, result: .address(t), site: site)
+  }
+
+  /// Creates an `generic_parameter` anchored at `site` that returns the address of the generic
+  /// argument passed to `p` of type `t`, inserting it at `i`.
+  mutating func makeGenericParameter(
+    passedTo p: GenericParameterDecl.ID, ofType t: AnyType, at site: SourceRange, insertingAt i: InsertionPoint
+  ) -> InstructionID {
+    insert(makeGenericParameter(passedTo: p, ofType: t, at: site), at: i)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/GlobalAddr.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddr.swift
@@ -41,12 +41,21 @@ extension GlobalAddr: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
-  /// Creates an `global_addr` anchored at `site` that returns the address of `binding`.
-  func makeGlobalAddr(of binding: BindingDecl.ID, at anchor: SourceRange) -> GlobalAddr {
-    let t = program.canonical(program[binding].type, in: program[binding].scope)
-    return .init(binding: binding, valueType: t, site: anchor)
+  /// Creates an `global_addr` anchored at `site` of type `t` that returns the address of `binding`.
+  func makeGlobalAddr(
+    of binding: BindingDecl.ID, valueType t: AnyType, at anchor: SourceRange
+  ) -> GlobalAddr {
+    .init(binding: binding, valueType: t, site: anchor)
+  }
+
+  /// Creates an `global_addr` anchored at `site` of type `t` that returns the address of `binding`, inserting it at `p`.
+  mutating func makeGlobalAddr(
+    of binding: BindingDecl.ID, valueType t: AnyType, at anchor: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeGlobalAddr(of: binding, valueType: t, at: anchor), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Load.swift
+++ b/Sources/IR/Operands/Instruction/Load.swift
@@ -34,16 +34,27 @@ public struct Load: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `load` anchored at `site` that loads the object at `source`.
   ///
   /// - Parameters:
   ///   - source: The location from which the object is loaded. Must be the result of an `access`
   ///     instruction requesting a `sink` capability.
-  func makeLoad(_ source: Operand, in f: Function.ID, at site: SourceRange) -> Load {
-    precondition(self[source, in: f] is Access)
-    return .init(objectType: .object(self[f].type(of: source).ast), from: source, site: site)
+  func makeLoad(_ source: Operand, at site: SourceRange) -> Load {
+    precondition(self[source] is Access)
+    return .init(objectType: .object(type(of: source).ast), from: source, site: site)
+  }
+
+  /// Creates a `load` anchored at `site` that loads the object at `source`, inserting it at `p`.
+  ///
+  /// - Parameters:
+  ///   - source: The location from which the object is loaded. Must be the result of an `access`
+  ///     instruction requesting a `sink` capability.
+  mutating func makeLoad(
+    _ source: Operand, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeLoad(source, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MarkState.swift
+++ b/Sources/IR/Operands/Instruction/MarkState.swift
@@ -39,13 +39,21 @@ extension MarkState: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `mark_state` instruction anchored at `site` that marks `storage` has being fully
   /// initialized if `initialized` is `true` or fully uninitialized otherwise.
-  func makeMarkState(_ storage: Operand, initialized: Bool, in f: Function.ID, at site: SourceRange) -> MarkState {
-    precondition(self[f].type(of: storage).isAddress)
+  func makeMarkState(_ storage: Operand, initialized: Bool, at site: SourceRange) -> MarkState {
+    precondition(type(of: storage).isAddress)
     return .init(storage: storage, initialized: initialized, site: site)
+  }
+
+  /// Creates a `mark_state` instruction anchored at `site` that marks `storage` has being fully
+  /// initialized if `initialized` is `true` or fully uninitialized otherwise, inserting it at `p`.
+  mutating func makeMarkState(
+    _ storage: Operand, initialized: Bool, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeMarkState(storage, initialized: initialized, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MemoryCopy.swift
+++ b/Sources/IR/Operands/Instruction/MemoryCopy.swift
@@ -27,17 +27,28 @@ public struct MemoryCopy: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `memory_copy` anchored at `site` that copies the memory representation of the
   /// value stored at `source` to `target`.
   ///
   /// - Requires: `source` is a `let`-capable access and `target` is a `set`-capable access.
   ///   `source` and `target` have the same type.
-  func makeMemoryCopy(_ source: Operand, _ target: Operand, in f: Function.ID, at site: SourceRange) -> MemoryCopy {
-    let s = self[f].type(of: source)
-    precondition(s.isAddress && (s == self[f].type(of: target)))
+  func makeMemoryCopy(_ source: Operand, _ target: Operand, at site: SourceRange) -> MemoryCopy {
+    let s = type(of: source)
+    precondition(s.isAddress && (s == type(of: target)))
     return .init(source: source, target: target, site: site)
+  }
+
+  /// Creates an `memory_copy` anchored at `site` that copies the memory representation of the
+  /// value stored at `source` to `target`, inserting it at `p`.
+  ///
+  /// - Requires: `source` is a `let`-capable access and `target` is a `set`-capable access.
+  ///   `source` and `target` have the same type.
+  mutating func makeMemoryCopy(
+    _ source: Operand, _ target: Operand, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeMemoryCopy(source, target, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Move.swift
+++ b/Sources/IR/Operands/Instruction/Move.swift
@@ -40,7 +40,7 @@ public struct Move: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `move` anchored at `site` that moves `value` into `storage` using the move
   /// operations defined by `movable`.
@@ -53,11 +53,27 @@ extension Module {
   ///   - storage: The location to initialize or assign. Must have an address type.
   func makeMove(
     _ value: Operand, to storage: Operand, usingConformance movable: FrontEnd.Conformance,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> Move {
-    precondition(self[f].type(of: value).isAddress)
-    precondition(self[f].type(of: storage).isAddress)
+    precondition(type(of: value).isAddress)
+    precondition(type(of: storage).isAddress)
     return .init(object: value, target: storage, movable: movable, site: site)
+  }
+
+  /// Creates a `move` anchored at `site` that moves `value` into `storage` using the move
+  /// operations defined by `movable`, inserting it at `p`.
+  ///
+  /// This instruction is replaced during IR transformation by either the initialization or
+  /// assignment of `storage`, depending on its initialization state.
+  ///
+  /// - Parameters:
+  ///   - value: The object to move. Must have an address type.
+  ///   - storage: The location to initialize or assign. Must have an address type.
+  mutating func makeMove(
+    _ value: Operand, to storage: Operand, usingConformance movable: FrontEnd.Conformance,
+    at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeMove(value, to: storage, usingConformance: movable, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/OpenCapture.swift
+++ b/Sources/IR/Operands/Instruction/OpenCapture.swift
@@ -33,12 +33,17 @@ public struct OpenCapture: RegionEntry {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `open_capture` anchored at `site` that loads the address stored at `source`.
-  func makeOpenCapture(_ source: Operand, in f: Function.ID, at site: SourceRange) -> OpenCapture {
-    let t = RemoteType(self[f].type(of: source).ast) ?? preconditionFailure()
+  func makeOpenCapture(_ source: Operand, at site: SourceRange) -> OpenCapture {
+    let t = RemoteType(type(of: source).ast) ?? preconditionFailure()
     return .init(result: .address(t.bareType), source: source, site: site)
+  }
+
+  /// Creates an `open_capture` anchored at `site` that loads the address stored at `source`, inserting it at `p`.
+  mutating func makeOpenCapture(_ source: Operand, at site: SourceRange, insertingAt p: InsertionPoint) -> InstructionID {
+    insert(makeOpenCapture(source, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/OpenUnion.swift
+++ b/Sources/IR/Operands/Instruction/OpenUnion.swift
@@ -62,7 +62,7 @@ extension OpenUnion: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `open_union` anchored at `site` that projects the address of `container`'s payload
   /// viewed as an instance of `payload`.
@@ -72,15 +72,30 @@ extension Module {
   func makeOpenUnion(
     _ container: Operand, as payload: AnyType,
     forInitialization isUsedForInitialization: Bool = false,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> OpenUnion {
-    precondition(self[f].type(of: container).isAddress)
+    precondition(type(of: container).isAddress)
     precondition(payload.isCanonical)
     return .init(
       container: container,
       payloadType: payload,
       isUsedForInitialization: isUsedForInitialization,
       site: site)
+  }
+
+  /// Creates an `open_union` anchored at `site` that projects the address of `container`'s payload
+  /// viewed as an instance of `payload`, inserting it at `p`.
+  ///
+  /// If the bits of the union's discriminator are hidden in its storage, this function removes
+  /// them before projecting the address unless `isUsedForInitialization` is `true`.
+  mutating func makeOpenUnion(
+    _ container: Operand, as payload: AnyType,
+    forInitialization isUsedForInitialization: Bool = false,
+    at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(
+      makeOpenUnion(container, as: payload, forInitialization: isUsedForInitialization, at: site),
+      at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/PointerToAddress.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddress.swift
@@ -45,7 +45,7 @@ extension PointerToAddress: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `pointer_to_address` anchored at `site` that converts `source`, which is a
   /// built-in pointer value, to an address of type `target`.
@@ -54,6 +54,14 @@ extension Module {
   ) -> PointerToAddress {
     precondition(target.access != .yielded)
     return .init(source: source, target: target, site: site)
+  }
+
+  /// Creates a `pointer_to_address` anchored at `site` that converts `source`, which is a
+  /// built-in pointer value, to an address of type `target`, inserting it at `p`.
+  mutating func makePointerToAddress(
+    _ source: Operand, to target: RemoteType, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makePointerToAddress(source, to: target, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Project.swift
+++ b/Sources/IR/Operands/Instruction/Project.swift
@@ -61,7 +61,7 @@ extension Project: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
   /// which is a reference to a lowered subscript, on `arguments`.
@@ -80,6 +80,24 @@ extension Module {
     to arguments: [Operand], at site: SourceRange
   ) -> Project {
     .init(projection: t, callee: s, specialization: z, operands: arguments, site: site)
+  }
+
+  /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
+  /// which is a reference to a lowered subscript, on `arguments`, inserting it at `p`.
+  mutating func makeProject(
+    _ t: RemoteType, applying s: FunctionReference, to arguments: [Operand], at site: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeProject(t, applying: s, to: arguments, at: site), at: p)
+  }
+
+  /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
+  /// which is a lowered subscript, specialized by `z`, on `arguments`, inserting it at `p`.
+  mutating func makeProject(
+    _ t: RemoteType, applying s: Function.ID, specializedBy z: GenericArguments,
+    to arguments: [Operand], at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeProject(t, applying: s, specializedBy: z, to: arguments, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/RegionExit.swift
+++ b/Sources/IR/Operands/Instruction/RegionExit.swift
@@ -43,13 +43,13 @@ extension RegionExit: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a region exit anchored at `site` marking an exit of the regions started by `start`.
   func makeRegionExit<Entry: RegionEntry>(
-    _ start: Operand, in f: Function.ID, at anchor: SourceRange
+    _ start: Operand, at anchor: SourceRange
   ) -> RegionExit<Entry> {
-    precondition(start.instruction.map({ self[$0, in: f] is Entry }) ?? false)
+    precondition(start.instruction.map({ self[$0] is Entry }) ?? false)
     return .init(start: start, site: anchor)
   }
 

--- a/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
+++ b/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
@@ -25,13 +25,21 @@ public struct ReleaseCaptures: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `release_capture` anchored at `site` that releases the accesses previously captured
   /// in `container`.
-  func makeReleaseCapture(_ container: Operand, in f: Function.ID, at site: SourceRange) -> ReleaseCaptures {
-    precondition(container.instruction.map({ self[$0, in: f] is AllocStack }) ?? false)
+  func makeReleaseCapture(_ container: Operand, at site: SourceRange) -> ReleaseCaptures {
+    precondition(container.instruction.map({ self[$0] is AllocStack }) ?? false)
     return .init(container: container, site: site)
+  }
+
+  /// Creates a `release_capture` anchored at `site` that releases the accesses previously captured
+  /// in `container`, inserting it at `p`.
+  mutating func makeReleaseCapture(
+    _ container: Operand, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeReleaseCapture(container, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Return.swift
+++ b/Sources/IR/Operands/Instruction/Return.swift
@@ -23,11 +23,16 @@ public struct Return: Terminator {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `return` anchored at `site`.
   func makeReturn(at site: SourceRange) -> Return {
     .init(site: site)
+  }
+
+  /// Creates a `return` anchored at `site`, inserting it at `p`.
+  mutating func makeReturn(at site: SourceRange, insertingAt p: InsertionPoint) -> InstructionID {
+    insert(makeReturn(at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Store.swift
+++ b/Sources/IR/Operands/Instruction/Store.swift
@@ -34,17 +34,26 @@ public struct Store: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `record` anchored at `site` that stores `object` at `target.
   ///
   /// - Parameters:
   ///   - object: The object to store. Must have an object type.
   ///   - target: The location at which `object` is stored. Must have an address type.
-  func makeStore(_ object: Operand, at target: Operand, in f: Function.ID, at site: SourceRange) -> Store {
-    precondition(self[f].type(of: object).isObject)
-    precondition(self[f].type(of: target).isAddress)
+  func makeStore(_ object: Operand, at target: Operand, at site: SourceRange) -> Store {
+    precondition(type(of: object).isObject)
+    precondition(type(of: target).isAddress)
     return .init(object: object, at: target, site: site)
+  }
+
+  /// Creates a `record` anchored at `site` that stores `object` at `target, inserting it at `p`.
+  ///
+  /// - Parameters:
+  ///   - object: The object to store. Must have an object type.
+  ///   - target: The location at which `object` is stored. Must have an address type.
+  mutating func makeStore(_ object: Operand, at target: Operand, at site: SourceRange, insertingAt p: InsertionPoint) -> InstructionID {
+    insert(makeStore(object, at: target, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/SubfieldView.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldView.swift
@@ -53,24 +53,35 @@ extension SubfieldView: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
-  /// Creates a `subfield_view` anchored at `site` computing the address of the given `subfield` of
+  /// Creates a `subfield_view` anchored at `site` computing the address of the given `subfield` of type `t`
   /// some record at `recordAddress`.
   ///
   /// - Note: `base` is returned unchanged if `elementPath` is empty.
   func makeSubfieldView(
-    of recordAddress: Operand, subfield elementPath: RecordPath, in f: Function.ID, at site: SourceRange
+    of recordAddress: Operand, subfield elementPath: RecordPath, resultType t: AnyType,
+    at site: SourceRange
   ) -> SubfieldView {
-    precondition(self[f].type(of: recordAddress).isAddress)
-    let l = AbstractTypeLayout(of: self[f].type(of: recordAddress).ast, definedIn: program)
-    let t = l[elementPath].type
+    precondition(type(of: recordAddress).isAddress)
 
     return .init(
       base: recordAddress,
       subfield: elementPath,
       subfieldType: .address(t),
       site: site)
+  }
+
+  /// Creates a `subfield_view` anchored at `site` computing the address of the given `subfield` of type `t`
+  /// some record at `recordAddress`.
+  ///
+  /// - Note: `base` is returned unchanged if `elementPath` is empty.
+  mutating func makeSubfieldView(
+    of recordAddress: Operand, subfield elementPath: RecordPath, resultType t: AnyType,
+    at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(
+      makeSubfieldView(of: recordAddress, subfield: elementPath, resultType: t, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Switch.swift
+++ b/Sources/IR/Operands/Instruction/Switch.swift
@@ -48,20 +48,31 @@ extension Switch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `switch` anchored at `site` that jumps to `successors[i]`.
   ///
   /// - Requires: `i` is a valid index in `successors`, expressed as a built-in integer, and
   ///   `successors` is not empty.
   func makeSwitch(
-    on index: Operand, toOneOf successors: [Block.ID], in f: Function.ID, at site: SourceRange
+    on index: Operand, toOneOf successors: [Block.ID], at site: SourceRange
   ) -> Switch {
-    let t = self[f].type(of: index)
+    let t = type(of: index)
     precondition(t.isObject && t.ast.isBuiltinInteger)
     precondition(!successors.isEmpty)
 
     return .init(index: index, successors: successors, site: site)
+  }
+
+  /// Creates a `switch` anchored at `site` that jumps to `successors[i]`, inserting it at `p`.
+  ///
+  /// - Requires: `i` is a valid index in `successors`, expressed as a built-in integer, and
+  ///   `successors` is not empty.
+  mutating func makeSwitch(
+    on index: Operand, toOneOf successors: [Block.ID], at site: SourceRange,
+    insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeSwitch(on: index, toOneOf: successors, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
+++ b/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
@@ -30,15 +30,21 @@ public struct UnionDiscriminator: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `union_discriminator` anchored at `site` that returns the discriminator of the
   /// element stored in `container`.
-  func makeUnionDiscriminator(
-    _ container: Operand, in f: Function.ID, at site: SourceRange
-  ) -> UnionDiscriminator {
-    precondition(self[f].type(of: container).isAddress)
+  func makeUnionDiscriminator(_ container: Operand, at site: SourceRange) -> UnionDiscriminator {
+    precondition(type(of: container).isAddress)
     return .init(container: container, site: site)
+  }
+
+  /// Creates a `union_discriminator` anchored at `site` that returns the discriminator of the
+  /// element stored in `container`, inserting it at `p`.
+  mutating func makeUnionDiscriminator(
+    _ container: Operand, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeUnionDiscriminator(container, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/UnionSwitch.swift
+++ b/Sources/IR/Operands/Instruction/UnionSwitch.swift
@@ -63,7 +63,7 @@ extension UnionSwitch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `union_switch` anchored at `site` that switches over `discriminator`, which is the
   /// discriminator of a container of type `union`, jumping to corresponding block in `target`.
@@ -74,12 +74,27 @@ extension Module {
   /// - Requires: `targets` has a key defined for each of `union`.
   func makeUnionSwitch(
     over discriminator: Operand, of union: UnionType, toOneOf targets: UnionSwitch.Targets,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> UnionSwitch {
-    let t = self[f].type(of: discriminator)
+    let t = type(of: discriminator)
     precondition(t.isObject && t.ast.isBuiltinInteger)
     precondition(union.elements.allSatisfy({ (e) in targets[e] != nil }))
     return .init(discriminator: discriminator, union: union, targets: targets, site: site)
+  }
+
+  /// Creates a `union_switch` anchored at `site` that switches over `discriminator`, which is the
+  /// discriminator of a container of type `union`, jumping to corresponding block in `target`,
+  /// inserting it at `p`.
+  ///
+  /// If `union` is generic, `discriminator` should be the result of `union_discriminator` rather
+  /// than a constant.
+  ///
+  /// - Requires: `targets` has a key defined for each of `union`.
+  mutating func makeUnionSwitch(
+    over discriminator: Operand, of union: UnionType, toOneOf targets: UnionSwitch.Targets,
+    at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeUnionSwitch(over: discriminator, of: union, toOneOf: targets, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Unreachable.swift
+++ b/Sources/IR/Operands/Instruction/Unreachable.swift
@@ -28,11 +28,17 @@ public struct Unreachable: Terminator {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `unreachable` anchored at `site` that marks the execution path unreachable.
   func makeUnreachable(at site: SourceRange) -> Unreachable {
     .init(site: site)
+  }
+
+  /// Creates an `unreachable` anchored at `site` that marks the execution path unreachable, inserting it at `p`.
+  @discardableResult
+  mutating func makeUnreachable(at site: SourceRange, insertingAt p: InsertionPoint) -> InstructionID {
+    insert(makeUnreachable(at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
@@ -51,7 +51,7 @@ extension WrapExistentialAddr: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `wrap_existential_addr` anchored at `site` that creates an existential container of
   /// type `interface` wrapping `witness` and `table`.
@@ -62,10 +62,24 @@ extension Module {
   ///   - table: The witness table of the wrapped value. Must be a pointer to a witness table.
   func makeWrapExistentialAddr(
     _ witness: Operand, _ table: Operand, as interface: ExistentialType,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> WrapExistentialAddr {
-    precondition(self[f].type(of: witness).isAddress)
+    precondition(type(of: witness).isAddress)
     return .init(witness: witness, table: table, interface: .address(interface), site: site)
+  }
+
+  /// Creates a `wrap_existential_addr` anchored at `site` that creates an existential container of
+  /// type `interface` wrapping `witness` and `table`, inserting it at `p`.
+  ///
+  /// - Parameters:
+  ///   - witness: The address of the object wrapped in the container.
+  ///   - interface: The type of the container.
+  ///   - table: The witness table of the wrapped value. Must be a pointer to a witness table.
+  mutating func makeWrapExistentialAddr(
+    _ witness: Operand, _ table: Operand, as interface: ExistentialType,
+    at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeWrapExistentialAddr(witness, table, as: interface, at: site), at: p)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Yield.swift
+++ b/Sources/IR/Operands/Instruction/Yield.swift
@@ -36,12 +36,19 @@ public struct Yield: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `yield` anchored at `site` that projects `a` with capability `c`.
-  func makeYield(_ c: AccessEffect, _ a: Operand, in f: Function.ID, at site: SourceRange) -> Yield {
-    precondition(self[f].type(of: a).isAddress)
+  func makeYield(_ c: AccessEffect, _ a: Operand, at site: SourceRange) -> Yield {
+    precondition(type(of: a).isAddress)
     return .init(capability: c, projection: a, site: site)
+  }
+
+  /// Creates a `yield` anchored at `site` that projects `a` with capability `c`, inserting it at `p`.
+  mutating func makeYield(
+    _ c: AccessEffect, _ a: Operand, at site: SourceRange, insertingAt p: InsertionPoint
+  ) -> InstructionID {
+    insert(makeYield(c, a, at: site), at: p)
   }
 
 }


### PR DESCRIPTION
Move creation of IR instructions in `Function`.

Additional changes:
- add another method that allows the instruction to be inserted directly
in the function
- some refactoring (Module+CallBoundleReification, DeadCodeElimination)
to work directly inside `Function`
- remove `Module` access from `SubfieldView`, `CallBundle` and
`ProjectBundle`