### PR TITLE
Simplify `InstructionTransformer`

### DIFF
--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -1664,7 +1664,7 @@ extension SwiftyLLVM.Module {
 
       // All arguments are passed by reference.
       var arguments: [SwiftyLLVM.IRValue] = [x0]
-      for a in s.operands {
+      for a in s.arguments {
         if context.source[f].type(of: a).isObject {
           let t = context.ir.llvm(s.result!.ast, in: &self)
           let l = insertAlloca(t, atEntryOf: transpilation)
@@ -1676,7 +1676,7 @@ extension SwiftyLLVM.Module {
       }
 
       // %1 = call ptr @llvm.coro.prepare.retcon(ptr @s)
-      let (_, ff) = declareSubscript(transpiledFrom: s.callee, in: &context)
+      let (_, ff) = declareSubscript(transpiledFrom: s.functionReference.function, in: &context)
       let prepare = intrinsic(named: Intrinsic.llvm.coro.prepare.retcon)!
       let x1 = insertCall(SwiftyLLVM.Function(prepare)!, on: [ff], at: insertionPoint)
 

--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -148,8 +148,12 @@ extension Module {
     }
 
     let o = RemoteType(k, s.projection)
+    let r = FunctionReference(
+      to: s.variants[k]!, in: self, specializedBy: s.bundle.arguments,
+      in: self[f].scope(containing: i)
+    )
     let reified = self[f].makeProject(
-      o, applying: s.variants[k]!, specializedBy: s.bundle.arguments, to: arguments, at: s.site)
+      o, applying: r, to: arguments, at: s.site)
     self[f].replace(i, with: reified)
   }
 

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -343,7 +343,7 @@ extension Function {
 
     /// Rewrites `i`, which is in `source`, at the end of `b`, which is in `self`.
     func rewrite(_ i: InstructionID, to b: Block.ID) {
-      let j = self.rewrite(i, in: f, from: m, transformedBy: &t, at: .end(of: b))
+      let j = self.rewrite(i, in: m[f], transformedBy: &t, at: .end(of: b))
       t.rewrittenInstruction[i] = j
     }
 

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -38,9 +38,9 @@ extension IR.Program {
     for i in modules[m]![f].instructionIDs {
       switch modules[m]![i, in: f] {
       case is Call:
-        depolymorphize(call: i, from:f, definedIn: m)
+        depolymorphize(call: i, from: f, definedIn: m)
       case is Project:
-        depolymorphize(project: i, from:f, definedIn: m)
+        depolymorphize(project: i, from: f, definedIn: m)
       default:
         continue
       }
@@ -51,7 +51,9 @@ extension IR.Program {
   /// depolymorphized version of its callee.
   ///
   /// - Requires: `i` identifies a `CallInstruction`
-  private mutating func depolymorphize(call i: InstructionID, from f: Function.ID, definedIn m: Module.ID) {
+  private mutating func depolymorphize(
+    call i: InstructionID, from f: Function.ID, definedIn m: Module.ID
+  ) {
     let s = modules[m]![i, in: f] as! Call
     guard
       let callee = s.callee.constant as? FunctionReference,
@@ -71,7 +73,9 @@ extension IR.Program {
   /// a depolymorphized version of its callee.
   ///
   /// - Requires: `i` identifies a `ProjectInstruction`
-  private mutating func depolymorphize(project i: InstructionID, from f: Function.ID, definedIn m: Module.ID) {
+  private mutating func depolymorphize(
+    project i: InstructionID, from f: Function.ID, definedIn m: Module.ID
+  ) {
     let s = modules[m]![i, in: f] as! Project
     let r = s.functionReference
     guard !r.specialization.isEmpty else { return }
@@ -121,6 +125,7 @@ extension IR.Program {
     _ f: Function.ID, for z: GenericArguments, usedIn scopeOfUse: AnyScopeID
   ) -> Function.ID {
     precondition(z.allSatisfy(\.value.isCanonical))
+
     let result = demandMonomorphizedDeclaration(of: f, for: z, usedIn: scopeOfUse)
 
     let target = base.module(containing: scopeOfUse)
@@ -128,7 +133,26 @@ extension IR.Program {
       return result
     }
 
+    // First, collect the types and function references used in the function.
     let source = module(defining: f)
+    var observer = MonomorphizationObserver()
+    var ff = modules[source]![f]
+    ff.observe(ff.instructionIDs, with: &observer)
+
+    // Monomorphize the types.
+    var transformedTypes: [AnyType: AnyType] = [:]
+    for t in observer.types {
+      transformedTypes[t] = monomorphize(t, for: z, usedIn: scopeOfUse)
+    }
+
+    // Monomorphize the function references.
+    var transformedFunctions: [FunctionReference: FunctionReference] = [:]
+    for c in observer.functionsToMonomorphize {
+      let s = base.module(containing: scopeOfUse)
+      let f = monomorphize(c.function, specializedBy: c.specialization, for: z, usedIn: scopeOfUse)
+      transformedFunctions[c] = FunctionReference(to: f, in: modules[s]!)
+    }
+
     var rewrittenBlock: [Block.ID: Block.ID] = [:]
     for b in modules[source]![f].blockIDs {
       rewrittenBlock[b] = modules[target]![result].appendBlock(in: modules[source]![b, in: f].scope)
@@ -136,8 +160,10 @@ extension IR.Program {
 
     let rewrittenGenericValue = modules[target]!.defineGenericValueArguments(z, in: result)
     var monomorphizer = Monomorphizer(
-      source: f, target: result, specialization: z, scopeOfUse: scopeOfUse,
-      rewrittenGenericValue: rewrittenGenericValue, rewrittenBlock: rewrittenBlock)
+      scopeOfUse: scopeOfUse,
+      transformedTypes: transformedTypes, transformedFunctions: transformedFunctions,
+      rewrittenBlock: rewrittenBlock
+    )
 
     // Iterate over the basic blocks of the source function in a way that guarantees we always
     // visit definitions before their uses.
@@ -172,7 +198,7 @@ extension IR.Program {
     /// Rewrites `i`, which is in `source`, at the end of `b`, which is in `target`.
     func rewrite(genericParameter i: InstructionID) {
       let s = modules[source]![i, in: f] as! GenericParameter
-      monomorphizer.rewrittenInstruction[i] = monomorphizer.rewrittenGenericValue[s.parameter]!
+      monomorphizer.rewrittenInstruction[i] = rewrittenGenericValue[s.parameter]!
     }
 
     /// Rewrites `i`, which is in `source`, at the end of `b`, which is in `target`.
@@ -185,6 +211,24 @@ extension IR.Program {
         return f.makeReturn(at: s.site, insertingAt: .end(of: b))
       }
       monomorphizer.rewrittenInstruction[i] = j
+    }
+  }
+
+  /// Returns a monomorphized copy of `f` specialized by `z` for use in `scopeOfUse`.
+  ///
+  /// If `f` is a trait requirement, the result is a monomorphized version of that requirement's
+  /// implementation, using `a` to identify the requirement's receiver. Otherwise, the result is
+  /// a monomorphized copy of `f`.
+  private mutating func monomorphize(
+    _ f: Function.ID, specializedBy z: GenericArguments, for specialization: GenericArguments,
+    usedIn scopeOfUse: AnyScopeID
+  ) -> Function.ID {
+    let p = base.specialize(z, for: specialization, in: scopeOfUse)
+    let q = base.canonical(p, in: scopeOfUse)
+    if let m = base.requirementDeclaring(memberReferredBy: f) {
+      return monomorphize(m.decl, requiredBy: m.trait, for: q, usedIn: scopeOfUse)
+    } else {
+      return monomorphize(f, for: q, usedIn: scopeOfUse)
     }
   }
 
@@ -229,14 +273,6 @@ extension IR.Program {
   ) -> AnyType {
     let u = base.specialize(t, for: z, in: scopeOfUse)
     return base.canonical(u, in: scopeOfUse)
-  }
-
-  /// Returns `generic` specialized for specialization `z` in `scopeOfUse`.
-  private func monomorphize(
-    _ t: IR.`Type`, for z: GenericArguments, usedIn scopeOfUse: AnyScopeID
-  ) -> IR.`Type` {
-    let u = monomorphize(t.ast, for: z, usedIn: scopeOfUse)
-    return .init(ast: u, isAddress: t.isAddress)
   }
 
   /// Returns the IR function monomorphizing `f` for specialization `z` in `scopeOfUse`.
@@ -296,7 +332,8 @@ extension Module {
         UNIMPLEMENTED("arbitrary compile-time values")
       }
 
-      let s = self[monomorphized].makeAllocStack(^program.ast.coreType("Int")!, at: insertionSite, insertingAt: .end(of: entry))
+      let s = self[monomorphized].makeAllocStack(
+        ^program.ast.coreType("Int")!, at: insertionSite, insertingAt: .end(of: entry))
 
       var log = DiagnosticSet()
       Emitter.withInstance(insertingIn: &self, reportingDiagnosticsTo: &log) { (e) in
@@ -316,27 +353,66 @@ extension Module {
 
 }
 
+/// Observer that collects the types and function references that need monomorphization.
+private struct MonomorphizationObserver: InstructionObserver {
+
+  /// The used types, which might be changed by monomorphization.
+  private(set) var types: Set<AnyType> = []
+
+  /// The set of functions that need monomorphization.
+  private(set) var functionsToMonomorphize: Set<FunctionReference> = []
+
+  /// Collect `t` for possible monomorphization.
+  mutating func observe(_ t: AnyType) {
+    types.insert(t)
+  }
+
+  /// Checks monomorphization functions/types in `c`.
+  mutating func observe(_ o: Operand) {
+    if let c = o.constant {
+      observe(c)
+    }
+  }
+
+  /// Nothing to observe for a block.
+  func observe(_ b: Block.ID) {}
+
+  /// Collects monomorphization functions/types in `c`.
+  private mutating func observe(_ c: any Constant) {
+    switch c {
+    case let r as FunctionReference:
+      observe(r)
+      break
+    case let t as MetatypeType:
+      observe(^t)
+      break
+    default:
+      break
+    }
+  }
+
+  /// Collects `c` if it needs to be monomorphized.
+  private mutating func observe(_ c: FunctionReference) {
+    // Unspecialized references cannot refer to trait members, which are specialized for the
+    // implicit `Self` parameter.
+    if !c.specialization.isEmpty {
+      functionsToMonomorphize.insert(c)
+    }
+  }
+
+}
+
 /// The monomorphization of a function.
 private struct Monomorphizer: InstructionTransformer {
-
-  /// The source function.
-  let source: Function.ID
-
-  /// The target function.
-  let target: Function.ID
-
-  /// The arguments for which instructions are monomorphized.
-  let specialization: GenericArguments
 
   /// The scope in which instructions are monomorphized.
   let scopeOfUse: AnyScopeID
 
-  /// A table from generic value parameter to the allocation of the storage containing its value.
-  ///
-  /// Generic value parameters are rewritten as local variables initialized at the beginning of
-  /// the monomorphized function. Generic value arguments don't require deinitialization. Their
-  /// local storage is deallocated before each rewritten return instruction.
-  let rewrittenGenericValue: OrderedDictionary<GenericParameterDecl.ID, InstructionID>
+  /// The transformed types that should be used in the monomorphized function.
+  var transformedTypes: [AnyType: AnyType] = [:]
+
+  /// The transformed function references that should be used in the monomorphized function.
+  var transformedFunctions: [FunctionReference: FunctionReference] = [:]
 
   /// A map from basic block in `source` to its corresponding block in `result`.
   let rewrittenBlock: [Block.ID: Block.ID]
@@ -346,7 +422,10 @@ private struct Monomorphizer: InstructionTransformer {
 
   /// Returns the canonical, monomorphized form of `t`.
   func transform(_ t: AnyType, in ir: inout IR.Program) -> AnyType {
-    ir.monomorphize(^t, for: specialization, usedIn: scopeOfUse)
+    precondition(
+      transformedTypes[t] != nil, "Type \(t) was not transformed; check if it was properly observed"
+    )
+    return transformedTypes[t]!
   }
 
   /// Returns a monomorphized copy of `o`.
@@ -386,26 +465,7 @@ private struct Monomorphizer: InstructionTransformer {
       return c
     }
 
-    let s = ir.base.module(containing: scopeOfUse)
-    let f = transform(c.function, specializedBy: c.specialization, in: &ir)
-    return FunctionReference(to: f, in: ir.modules[s]!)
-  }
-
-  /// Returns a monomorphized copy of `f` specialized by `z` for use in `scopeOfUse`.
-  ///
-  /// If `f` is a trait requirement, the result is a monomorphized version of that requirement's
-  /// implementation, using `a` to identify the requirement's receiver. Otherwise, the result is
-  /// a monomorphized copy of `f`.
-  private func transform(
-    _ f: Function.ID, specializedBy z: GenericArguments, in ir: inout IR.Program
-  ) -> Function.ID {
-    let p = ir.base.specialize(z, for: specialization, in: scopeOfUse)
-    let q = ir.base.canonical(p, in: scopeOfUse)
-    if let m = ir.base.requirementDeclaring(memberReferredBy: f) {
-      return ir.monomorphize(m.decl, requiredBy: m.trait, for: q, usedIn: scopeOfUse)
-    } else {
-      return ir.monomorphize(f, for: q, usedIn: scopeOfUse)
-    }
+    return transformedFunctions[c]!
   }
 
 }

--- a/Sources/IR/Analysis/Module+Inlining.swift
+++ b/Sources/IR/Analysis/Module+Inlining.swift
@@ -81,7 +81,7 @@ extension IR.Program {
 
       for j in modules[source]![callee.function].instructions(in: e) {
         if modules[source]![j, in: callee.function] is Terminator { break }
-        let k = modules[m]![f].rewrite(j, in: callee.function, from: modules[source]!, transformedBy: &translation, at: .before(i))
+        let k = modules[m]![f].rewrite(j, in: modules[source]![callee.function], transformedBy: &translation, at: .before(i))
         translation.rewrittenOperand[.register(j)] = .register(k)
       }
 

--- a/Sources/IR/Analysis/Module+Inlining.swift
+++ b/Sources/IR/Analysis/Module+Inlining.swift
@@ -81,7 +81,7 @@ extension IR.Program {
 
       for j in modules[source]![callee.function].instructions(in: e) {
         if modules[source]![j, in: callee.function] is Terminator { break }
-        let k = self.rewrite(j, in: callee.function, from: source, transformedBy: &translation, at: .before(i), targeting: f, in: m)
+        let k = modules[m]![f].rewrite(j, in: callee.function, from: modules[source]!, transformedBy: &translation, at: .before(i))
         translation.rewrittenOperand[.register(j)] = .register(k)
       }
 
@@ -104,17 +104,17 @@ private struct InliningTranslation: InstructionTransformer {
   var rewrittenOperand: [Operand: Operand] = [:]
 
   /// Returns `t`.
-  func transform(_ t: AnyType, in ir: inout Program) -> AnyType {
+  func transform(_ t: AnyType) -> AnyType {
     t
   }
 
   /// Returns a transformed copy of `o` for use in `ir`.
-  func transform(_ o: Operand, in ir: inout IR.Program) -> Operand {
+  func transform(_ o: Operand) -> Operand {
     o.isConstant ? o : rewrittenOperand[o]!
   }
 
   /// Returns a transformed copy of `b` for use in `ir`.
-  func transform(_ b: Block.ID, in ir: inout IR.Program) -> Block.ID {
+  func transform(_ b: Block.ID) -> Block.ID {
     rewrittenBlock[b]!
   }
 

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -3764,8 +3764,9 @@ extension Emitter {
     _ t: RemoteType, applying s: Function.ID, specializedBy z: GenericArguments,
     to arguments: [Operand]
   ) -> Operand {
-    insert(
-      insertionIR.makeProject(t, applying: s, specializedBy: z, to: arguments, at: currentSource))!
+    let r = FunctionReference(to: s, in: module, specializedBy: z, in: insertionScope!)
+    return insert(
+      insertionIR.makeProject(t, applying: r, to: arguments, at: currentSource))!
   }
 
   fileprivate mutating func _store(_ source: Operand, _ target: Operand) {

--- a/Sources/IR/Function+Inspection.swift
+++ b/Sources/IR/Function+Inspection.swift
@@ -241,7 +241,7 @@ extension Function {
     case let s as Access:
       return provenances(s.source)
     case let s as Project:
-      return s.operands.reduce(into: []) { (p, o) in
+      return s.arguments.reduce(into: []) { (p, o) in
         if type(of: o).isAddress { p.formUnion(provenances(o)) }
       }
     case let s as SubfieldView:

--- a/Sources/IR/InstructionObserver.swift
+++ b/Sources/IR/InstructionObserver.swift
@@ -1,0 +1,207 @@
+import FrontEnd
+import Utils
+
+/// A type that observes the parts of IR instructions.
+protocol InstructionObserver {
+
+  /// Observes `t`.
+  mutating func observe(_ t: AnyType)
+
+  /// Observes `o`.
+  mutating func observe(_ o: Operand)
+
+  /// Observes `b`.
+  mutating func observe(_ b: Block.ID)
+
+}
+
+extension InstructionObserver {
+
+  /// Observes `t`.
+  mutating func observe(_ t: IR.`Type`) {
+    observe(t.ast)
+  }
+
+  /// Observes the elements in `s`.
+  mutating func observe<S: Sequence<Operand>>(_ s: S) {
+    for a in s {
+      observe(a)
+    }
+  }
+
+}
+
+extension Function {
+
+  /// Observes the parts of `i` with `o`.
+  mutating func observe<T: InstructionObserver>(_ i: InstructionID, with o: inout T) {
+    switch self[i] {
+    case let s as Access:
+      o.observe(s.source)
+      break
+
+    case let s as AddressToPointer:
+      o.observe(s.source)
+      break
+
+    case let s as AdvancedByBytes:
+      o.observe(s.base)
+      o.observe(s.byteOffset)
+      break
+
+    case let s as AdvancedByStrides:
+      o.observe(s.base)
+      break
+
+    case let s as AllocStack:
+      o.observe(s.allocatedType)
+      break
+
+    case let s as Branch:
+      o.observe(s.target)
+      break
+
+    case let s as Call:
+      o.observe(s.callee)
+      o.observe(s.arguments)
+      o.observe(s.output)
+      break
+
+    case let s as CallFFI:
+      o.observe(s.returnType)
+      o.observe(s.operands)
+      break
+
+    case let s as CaptureIn:
+      o.observe(s.source)
+      o.observe(s.target)
+      break
+
+    case let s as CloseCapture:
+      o.observe(s.start)
+      break
+
+    case let s as CloseUnion:
+      o.observe(s.start)
+      break
+
+    case let s as CondBranch:
+      o.observe(s.condition)
+      o.observe(s.targetIfTrue)
+      o.observe(s.targetIfFalse)
+      break
+
+    case _ as ConstantString:
+      break
+
+    case let s as DeallocStack:
+      o.observe(s.location)
+      break
+
+    case let s as EndAccess:
+      o.observe(s.start)
+      break
+
+    case let s as EndProject:
+      o.observe(s.start)
+      break
+
+    case _ as GenericParameter:
+      break
+
+    case _ as GlobalAddr:
+      break
+
+    case let s as CallBuiltinFunction:
+      o.observe(s.operands)
+      break
+
+    case let s as MarkState:
+      o.observe(s.storage)
+      break
+
+    case let s as MemoryCopy:
+      o.observe(s.source)
+      o.observe(s.target)
+      break
+
+    case let s as Load:
+      o.observe(s.source)
+      break
+
+    case let s as OpenCapture:
+      o.observe(s.source)
+      break
+
+    case let s as OpenUnion:
+      o.observe(s.container)
+      o.observe(s.payloadType)
+      break
+
+    case let s as PointerToAddress:
+      o.observe(s.source)
+      o.observe(^s.target)
+      break
+
+    case let s as Project:
+      o.observe(^s.projection)
+      o.observe(s.operands)
+      break
+
+    case let s as ReleaseCaptures:
+      o.observe(s.container)
+      break
+
+    case _ as Return:
+      break
+
+    case let s as Store:
+      o.observe(s.object)
+      o.observe(s.target)
+      break
+
+    case let s as SubfieldView:
+      o.observe(s.recordAddress)
+      break
+
+    case let s as Switch:
+      o.observe(s.index)
+      for b in s.successors {
+        o.observe(b)
+      }
+      break
+
+    case let s as UnionDiscriminator:
+      o.observe(s.container)
+      break
+
+    case let s as UnionSwitch:
+      o.observe(s.discriminator)
+      o.observe(^s.union)
+      for (key, value) in s.targets {
+        o.observe(key)
+        o.observe(value)
+      }
+      break
+
+    case _ as Unreachable:
+      break
+
+    case let s as Yield:
+      o.observe(s.projection)
+      break
+
+    default:
+      unreachable()
+    }
+  }
+
+  /// Observes the parts of instructions in `s` with `o`.
+  mutating func observe<T: InstructionObserver, S: Sequence<InstructionID>>(_ s: S, with o: inout T)
+  {
+    for i in s {
+      observe(i, with: &o)
+    }
+  }
+
+}

--- a/Sources/IR/InstructionObserver.swift
+++ b/Sources/IR/InstructionObserver.swift
@@ -162,6 +162,7 @@ extension Function {
 
     case let s as SubfieldView:
       o.observe(s.recordAddress)
+      o.observe(s.resultType)
       break
 
     case let s as Switch:

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -5,211 +5,200 @@ import Utils
 protocol InstructionTransformer {
 
   /// Returns a transformed copy of `t` for use in `ir`.
-  func transform(_ t: AnyType, in ir: inout IR.Program) -> AnyType
+  func transform(_ t: AnyType) -> AnyType
 
   /// Returns a transformed copy of `o` for use in `ir`.
-  func transform(_ o: Operand, in ir: inout IR.Program) -> Operand
+  func transform(_ o: Operand) -> Operand
 
   /// Returns a transformed copy of `b` for use in `ir`.
-  func transform(_ b: Block.ID, in ir: inout IR.Program) -> Block.ID
+  func transform(_ b: Block.ID) -> Block.ID
 
 }
 
 extension InstructionTransformer {
 
   /// Returns a transformed copy of `t` for use in `ir`.
-  func transform(_ t: IR.`Type`, in ir: inout IR.Program) -> IR.`Type` {
-    .init(ast: transform(t.ast, in: &ir), isAddress: t.isAddress)
+  func transform(_ t: IR.`Type`) -> IR.`Type` {
+    .init(ast: transform(t.ast), isAddress: t.isAddress)
   }
 
   /// Returns a transformed copy of the elements in `s` for use in `ir`.
-  func transform<S: Sequence<Operand>>(_ s: S, in ir: inout IR.Program) -> [Operand] {
-    s.map({ (a) in transform(a, in: &ir) })
+  func transform<S: Sequence<Operand>>(_ s: S) -> [Operand] {
+    s.map({ (a) in transform(a) })
   }
 
 }
 
-extension IR.Program {
+extension Function {
 
-  /// Inserts a copy of `i`, which is in `m`, at `p`, which is in `n`, transforming its parts with
-  /// `t` and returning its identifier.
+  /// Inserts a copy of `i`, which is in `f`/`m`, at `p` inside `self`, transforming its parts with
+  /// `t` and returning the identifier of the new instruction.
   mutating func rewrite<T: InstructionTransformer>(
-    _ i: InstructionID, in f: Function.ID, from m: Module.ID, transformedBy t: inout T,
-    at p: InsertionPoint, targeting g: Function.ID, in n: Module.ID
+    _ i: InstructionID, in f: Function.ID, from m: Module, transformedBy t: inout T,
+    at p: InsertionPoint
   ) -> InstructionID {
-    switch modules[m]![i, in: f] {
+    switch m[i, in: f] {
     case let s as Access:
-      let x0 = t.transform(s.source, in: &self)
-      return modules[n]![g].makeAccess(s.capabilities, from: x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.source)
+      return makeAccess(s.capabilities, from: x0, at: s.site, insertingAt: p)
 
     case let s as AddressToPointer:
-      let x0 = t.transform(s.source, in: &self)
-      return modules[n]![g].makeAddressToPointer(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.source)
+      return makeAddressToPointer(x0, at: s.site, insertingAt: p)
 
     case let s as AdvancedByBytes:
-      let x0 = t.transform(s.base, in: &self)
-      let x1 = t.transform(s.byteOffset, in: &self)
-      return modules[n]![g].makeAdvancedByBytes(source: x0, offset: x1, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.base)
+      let x1 = t.transform(s.byteOffset)
+      return makeAdvancedByBytes(source: x0, offset: x1, at: s.site, insertingAt: p)
 
     case let s as AdvancedByStrides:
-      let x0 = t.transform(s.base, in: &self)
-      return modules[n]![g].makeAdvanced(x0, byStrides: s.offset, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.base)
+      return makeAdvanced(x0, byStrides: s.offset, at: s.site, insertingAt: p)
 
     case let s as AllocStack:
-      let x0 = t.transform(s.allocatedType, in: &self)
-      return modules[n]![g].makeAllocStack(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.allocatedType)
+      return makeAllocStack(x0, at: s.site, insertingAt: p)
 
     case let s as Branch:
-      let x0 = t.transform(s.target, in: &self)
-      return modules[n]![g].makeBranch(to: x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.target)
+      return makeBranch(to: x0, at: s.site, insertingAt: p)
 
     case let s as Call:
-      let x0 = t.transform(s.callee, in: &self)
-      let x1 = t.transform(s.arguments, in: &self)
-      let x2 = t.transform(s.output, in: &self)
-      return modules[n]![g].makeCall(applying: x0, to: x1, writingResultTo: x2, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.callee)
+      let x1 = t.transform(s.arguments)
+      let x2 = t.transform(s.output)
+      return makeCall(applying: x0, to: x1, writingResultTo: x2, at: s.site, insertingAt: p)
 
     case let s as CallFFI:
-      let x0 = t.transform(s.returnType, in: &self)
-      let x1 = t.transform(s.operands, in: &self)
-      return modules[n]![g].makeCallFFI(returning: x0, applying: s.callee, to: x1, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.returnType)
+      let x1 = t.transform(s.operands)
+      return makeCallFFI(returning: x0, applying: s.callee, to: x1, at: s.site, insertingAt: p)
 
     case let s as CaptureIn:
-      let x0 = t.transform(s.source, in: &self)
-      let x1 = t.transform(s.target, in: &self)
-      return modules[n]![g].makeCapture(x0, in: x1, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.source)
+      let x1 = t.transform(s.target)
+      return makeCapture(x0, in: x1, at: s.site, insertingAt: p)
 
     case let s as CloseCapture:
-      let x0 = t.transform(s.start, in: &self)
-      return modules[n]![g].makeCloseCapture(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.start)
+      return makeCloseCapture(x0, at: s.site, insertingAt: p)
 
     case let s as CloseUnion:
-      let x0 = t.transform(s.start, in: &self)
-      return modules[n]![g].makeCloseUnion(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.start)
+      return makeCloseUnion(x0, at: s.site, insertingAt: p)
 
     case let s as CondBranch:
-      let x0 = t.transform(s.condition, in: &self)
-      let x1 = t.transform(s.targetIfTrue, in: &self)
-      let x2 = t.transform(s.targetIfFalse, in: &self)
-      return modules[n]![g].makeCondBranch(if: x0, then: x1, else: x2, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.condition)
+      let x1 = t.transform(s.targetIfTrue)
+      let x2 = t.transform(s.targetIfFalse)
+      return makeCondBranch(if: x0, then: x1, else: x2, at: s.site, insertingAt: p)
 
     case let s as ConstantString:
-      return modules[n]![g].insert(s, at: p)
+      return insert(s, at: p)
 
     case let s as DeallocStack:
-      let x0 = t.transform(s.location, in: &self)
-      return modules[n]![g].makeDeallocStack(for: x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.location)
+      return makeDeallocStack(for: x0, at: s.site, insertingAt: p)
 
     case let s as EndAccess:
-      let x0 = t.transform(s.start, in: &self)
-      return modules[n]![g].makeEndAccess(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.start)
+      return makeEndAccess(x0, at: s.site, insertingAt: p)
 
     case let s as EndProject:
-      let x0 = t.transform(s.start, in: &self)
-      return modules[n]![g].makeEndProject(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.start)
+      return makeEndProject(x0, at: s.site, insertingAt: p)
 
     case let s as GenericParameter:
-      return modules[n]![g].insert(s, at: p)
+      return insert(s, at: p)
 
     case let s as GlobalAddr:
-      return modules[n]![g].insert(s, at: p)
+      return insert(s, at: p)
 
     case let s as CallBuiltinFunction:
-      let x0 = t.transform(s.operands, in: &self)
-      return modules[n]![g].makeCallBuiltin(applying: s.callee, to: x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.operands)
+      return makeCallBuiltin(applying: s.callee, to: x0, at: s.site, insertingAt: p)
 
     case let s as MarkState:
-      let x0 = t.transform(s.storage, in: &self)
-      return modules[n]![g].makeMarkState(x0, initialized: s.initialized, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.storage)
+      return makeMarkState(x0, initialized: s.initialized, at: s.site, insertingAt: p)
 
     case let s as MemoryCopy:
-      let x0 = t.transform(s.source, in: &self)
-      let x1 = t.transform(s.target, in: &self)
-      return modules[n]![g].makeMemoryCopy(x0, x1, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.source)
+      let x1 = t.transform(s.target)
+      return makeMemoryCopy(x0, x1, at: s.site, insertingAt: p)
 
     case let s as Load:
-      let x0 = t.transform(s.source, in: &self)
-      return modules[n]![g].makeLoad(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.source)
+      return makeLoad(x0, at: s.site, insertingAt: p)
 
     case let s as OpenCapture:
-      let x0 = t.transform(s.source, in: &self)
-      return modules[n]![g].makeOpenCapture(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.source)
+      return makeOpenCapture(x0, at: s.site, insertingAt: p)
 
     case let s as OpenUnion:
-      let x0 = t.transform(s.container, in: &self)
-      let x1 = t.transform(s.payloadType, in: &self)
-      return modules[n]![g].makeOpenUnion(x0, as: x1, forInitialization: s.isUsedForInitialization, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.container)
+      let x1 = t.transform(s.payloadType)
+      return makeOpenUnion(x0, as: x1, forInitialization: s.isUsedForInitialization, at: s.site, insertingAt: p)
 
     case let s as PointerToAddress:
-      let x0 = t.transform(s.source, in: &self)
-      let x1 = RemoteType(t.transform(^s.target, in: &self))!
-      return modules[n]![g].makePointerToAddress(x0, to: x1, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.source)
+      let x1 = RemoteType(t.transform(^s.target))!
+      return makePointerToAddress(x0, to: x1, at: s.site, insertingAt: p)
 
     case let s as Project:
-      let x0 = RemoteType(t.transform(^s.projection, in: &self))!
-      let x1 = t.transform(s.callee, in: &self)
-      let x2 = t.transform(s.arguments, in: &self)
-      return modules[n]![g].makeProject(
+      let x0 = RemoteType(t.transform(^s.projection))!
+      let x1 = t.transform(s.callee)
+      let x2 = t.transform(s.arguments)
+      return makeProject(
         x0, applying: x1, to: x2,
         at: s.site, insertingAt: p
       )
 
     case let s as ReleaseCaptures:
-      let x0 = t.transform(s.container, in: &self)
-      return modules[n]![g].makeReleaseCapture(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.container)
+      return makeReleaseCapture(x0, at: s.site, insertingAt: p)
 
     case let s as Return:
-      return modules[n]![g].insert(s, at: p)
+      return insert(s, at: p)
 
     case let s as Store:
-      let x0 = t.transform(s.object, in: &self)
-      let x1 = t.transform(s.target, in: &self)
-      return modules[n]![g].makeStore(x0, at: x1, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.object)
+      let x1 = t.transform(s.target)
+      return makeStore(x0, at: x1, at: s.site, insertingAt: p)
 
     case let s as SubfieldView:
-      let x0 = t.transform(s.recordAddress, in: &self)
-      let l = AbstractTypeLayout(of: modules[n]![g].type(of: x0).ast, definedIn: modules[n]!.program)
-      let t = l[s.subfield].type
-      return modules[n]![g].makeSubfieldView(
+      let x0 = t.transform(s.recordAddress)
+      let t = t.transform(s.resultType.ast)
+      return makeSubfieldView(
         of: x0, subfield: s.subfield, resultType: t, at: s.site, insertingAt: p
       )
 
     case let s as Switch:
-      let x0 = t.transform(s.index, in: &self)
-      let x1 = s.successors.map({ (b) in t.transform(b, in: &self) })
-      return modules[n]![g].makeSwitch(on: x0, toOneOf: x1, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.index)
+      let x1 = s.successors.map({ (b) in t.transform(b) })
+      return makeSwitch(on: x0, toOneOf: x1, at: s.site, insertingAt: p)
 
     case let s as UnionDiscriminator:
-      let x0 = t.transform(s.container, in: &self)
-      return modules[n]![g].makeUnionDiscriminator(x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.container)
+      return makeUnionDiscriminator(x0, at: s.site, insertingAt: p)
 
     case let s as UnionSwitch:
-      let x0 = t.transform(s.discriminator, in: &self)
-      let x1 = UnionType(t.transform(^s.union, in: &self))!
+      let x0 = t.transform(s.discriminator)
+      let x1 = UnionType(t.transform(^s.union))!
       let x2 = s.targets.reduce(into: UnionSwitch.Targets()) { (d, kv) in
-        _ = d[t.transform(kv.key, in: &self)].setIfNil(t.transform(kv.value, in: &self))
+        _ = d[t.transform(kv.key)].setIfNil(t.transform(kv.value))
       }
-      return modules[n]![g].makeUnionSwitch(over: x0, of: x1, toOneOf: x2, at: s.site, insertingAt: p)
+      return makeUnionSwitch(over: x0, of: x1, toOneOf: x2, at: s.site, insertingAt: p)
 
     case let s as Unreachable:
-      return modules[n]![g].insert(s, at: p)
+      return insert(s, at: p)
 
     case let s as Yield:
-      let x0 = t.transform(s.projection, in: &self)
-      return modules[n]![g].makeYield(s.capability, x0, at: s.site, insertingAt: p)
+      let x0 = t.transform(s.projection)
+      return makeYield(s.capability, x0, at: s.site, insertingAt: p)
 
     default:
       unreachable()
-    }
-  }
-
-  /// Inserts the result of `makeInstruction` at `p`, which is in `m`.
-  private mutating func insert<T: Instruction>(
-    at p: InsertionPoint, in f: Function.ID, in m: Module.ID, _ makeInstruction: (inout Module) -> T
-  ) -> InstructionID {
-    modify(&modules[m]!) { (x) in
-      let s = makeInstruction(&x)
-      return x[f].insert(s, at: p)
     }
   }
 

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -31,13 +31,12 @@ extension InstructionTransformer {
 
 extension Function {
 
-  /// Inserts a copy of `i`, which is in `f`/`m`, at `p` inside `self`, transforming its parts with
+  /// Inserts a copy of `i`, which is in `source`, at `p` inside `self`, transforming its parts with
   /// `t` and returning the identifier of the new instruction.
   mutating func rewrite<T: InstructionTransformer>(
-    _ i: InstructionID, in f: Function.ID, from m: Module, transformedBy t: inout T,
-    at p: InsertionPoint
+    _ i: InstructionID, in source: Function, transformedBy t: inout T, at p: InsertionPoint
   ) -> InstructionID {
-    switch m[i, in: f] {
+    switch source[i] {
     case let s as Access:
       let x0 = t.transform(s.source)
       return makeAccess(s.capabilities, from: x0, at: s.site, insertingAt: p)

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -146,16 +146,11 @@ extension IR.Program {
       return modules[n]![g].makePointerToAddress(x0, to: x1, at: s.site, insertingAt: p)
 
     case let s as Project:
-      let r = FunctionReference(
-        to: s.callee, in: modules[m]!,
-        specializedBy: s.specialization, in: modules[m]![f].scope(containing: i))
-      let oldCallee = Operand.constant(r)
-      let newCallee = t.transform(oldCallee, in: &self).constant as! FunctionReference
-
       let x0 = RemoteType(t.transform(^s.projection, in: &self))!
-      let x1 = t.transform(s.operands, in: &self)
+      let x1 = t.transform(s.callee, in: &self)
+      let x2 = t.transform(s.arguments, in: &self)
       return modules[n]![g].makeProject(
-        x0, applying: newCallee.function, specializedBy: newCallee.specialization, to: x1,
+        x0, applying: x1, to: x2,
         at: s.site, insertingAt: p
       )
 


### PR DESCRIPTION
`InstructionTransformer` doesn't need to be in a module anymore.

Moved the main `rewrite` function from `Module` to `Function`. In order to do so, we needed to make sure we are not accessing the module while rewriting -- and the depolymorhization process was doing just that.

We split the processing in depolymorhization in three phases:
1. observation -- check all the types and function references we have
in a function
2. monomorphization -- transform the types / function references (using
information from the modile)
3. instruction transformation -- just transforms instructions making
sure that previous made monomorphization is applied

To support step 1, we added `InstructionObserver` that corresponds to
`InstructionTransfomer`, but it only observes the parts of instructions
in a function, without making any transformation.
