### PR TITLE
Improve `DominatorTree` and `ControlFlowGraph`

### DIFF
--- a/Sources/IR/Analysis/AbstractInterpreter.swift
+++ b/Sources/IR/Analysis/AbstractInterpreter.swift
@@ -100,7 +100,7 @@ struct AbstractInterpreter<Domain: AbstractDomain> {
         changed = true
       }
 
-      if !changed && (sources.count == cfg.predecessors(of: blockToProcess.address).count) {
+      if !changed && (sources.count == cfg.predecessors(of: blockToProcess).count) {
         done.insert(blockToProcess)
       } else {
         work.append(blockToProcess)
@@ -122,8 +122,8 @@ struct AbstractInterpreter<Domain: AbstractDomain> {
   private func isVisitable(_ b: Block.ID) -> Bool {
     if let d = dominatorTree.immediateDominator(of: b) {
       return visited(d)
-        && cfg.predecessors(of: b.address).allSatisfy({ (p) in
-          visited(Block.ID(p)) || dominatorTree.dominates(b, Block.ID(p))
+        && cfg.predecessors(of: b).allSatisfy({ (p) in
+          visited(p) || dominatorTree.dominates(b, p)
         })
     } else {
       // No predecessor.
@@ -141,7 +141,7 @@ struct AbstractInterpreter<Domain: AbstractDomain> {
       return ([], state[b]!.before)
     }
 
-    let sources = Set(cfg.predecessors(of: b.address).lazy.filter({ state[Block.ID($0)] != nil }).map( Block.ID.init ))
+    let sources = Set(cfg.predecessors(of: b).filter({ state[$0] != nil }))
     return (sources, .init(merging: sources.lazy.map({ state[$0]!.after })))
   }
 

--- a/Sources/IR/Analysis/AbstractInterpreter.swift
+++ b/Sources/IR/Analysis/AbstractInterpreter.swift
@@ -41,7 +41,7 @@ struct AbstractInterpreter<Domain: AbstractDomain> {
   ) {
     self.subject = f
     self.cfg = m[f].cfg()
-    self.dominatorTree = DominatorTree(function: f, cfg: cfg, in: m)
+    self.dominatorTree = DominatorTree(function: m[f], cfg: cfg)
     self.state = [m[f].entry!.address: (sources: [], before: entryContext, after: Context())]
     self.work = Deque(dominatorTree.bfs.dropFirst())
     self.done = []
@@ -53,7 +53,7 @@ struct AbstractInterpreter<Domain: AbstractDomain> {
   /// abstract interpretation.
   mutating func recomputeControlFlow(_ m: Module) {
     cfg = m[subject].cfg()
-    dominatorTree = .init(function: subject, cfg: cfg, in: m)
+    dominatorTree = .init(function: m[subject], cfg: cfg)
   }
 
   /// Removes `b` from the work list.

--- a/Sources/IR/Analysis/ControlFlowGraph.swift
+++ b/Sources/IR/Analysis/ControlFlowGraph.swift
@@ -8,7 +8,7 @@ import Utils
 struct ControlFlowGraph {
 
   /// A node in the graph.
-  typealias Vertex = Function.Blocks.Address
+  typealias Vertex = Block.ID
 
   /// An control edge label.
   enum Label {

--- a/Sources/IR/Analysis/DominatorTree.swift
+++ b/Sources/IR/Analysis/DominatorTree.swift
@@ -22,11 +22,6 @@ struct DominatorTree {
   /// The immediate dominators of each basic block.
   private var immediateDominators: [Node: Node?]
 
-  /// Creates the dominator tree of `f`, which is in `m`, using the given `cfg`.
-  init(function f: Function.ID, cfg: ControlFlowGraph, in m: Module) {
-    self.init(function: m[f], cfg: cfg)
-  }
-
   /// Creates the dominator tree of `f`, using the given `cfg`.
   init(function f: Function, cfg: ControlFlowGraph) {
     // The following is an implementation of Cooper et al.'s fast dominance iterative algorithm

--- a/Sources/IR/Analysis/DominatorTree.swift
+++ b/Sources/IR/Analysis/DominatorTree.swift
@@ -36,8 +36,8 @@ struct DominatorTree {
     while changed {
       changed = false
       for v in f.blockIDs {
-        for u in cfg.predecessors(of: v.address) where t.parent(v) != Block.ID(u) {
-          let lca = t.lowestCommonAncestor(Block.ID(u), t.parent(v)!)
+        for u in cfg.predecessors(of: v) where t.parent(v) != u {
+          let lca = t.lowestCommonAncestor(u, t.parent(v)!)
           if lca != t.parent(v) {
             t.setParent(lca, forChild: v)
             changed = true
@@ -150,8 +150,8 @@ private struct SpanningTree {
     var work: [(vertex: Node, parent: Node??)] = [(root, .some(nil))]
     while let (v, parent) = work.popLast() {
       parents[v] = parent
-      let children = cfg.successors(of: v.address).filter({ parents[Block.ID($0)] == nil })
-      work.append(contentsOf: children.map({ (Block.ID($0), .some(v)) }))
+      let children = cfg.successors(of: v).filter({ parents[$0] == nil })
+      work.append(contentsOf: children.map({ ($0, .some(v)) }))
     }
   }
 

--- a/Sources/IR/Analysis/Lifetime.swift
+++ b/Sources/IR/Analysis/Lifetime.swift
@@ -9,7 +9,7 @@ import Utils
 /// - Note: The definition of an operand `o` isn't part of `o`'s lifetime.
 struct Lifetime {
 
-  fileprivate typealias Coverage = [Function.Blocks.Address: BlockCoverage]
+  fileprivate typealias Coverage = [Block.ID: BlockCoverage]
 
   /// A data structure encoding how a block covers the lifetime.
   enum BlockCoverage {
@@ -71,7 +71,7 @@ struct Lifetime {
     coverage.lazy.compactMap { (b, c) -> InsertionPoint? in
       switch c {
       case .liveIn(let use):
-        return use.map({ .after($0.user) }) ?? .start(of: Block.ID(b))
+        return use.map({ .after($0.user) }) ?? .start(of: b)
       case .closed(let use):
         return use.map({ .after($0.user) }) ?? .after(operand.instruction!)
       case .liveInAndOut, .liveOut:
@@ -95,17 +95,17 @@ extension Module {
 
     // Find all blocks in which the operand is being used.
     var occurrences = functions[f]!.uses[operand, default: []].reduce(
-      into: Set<Function.Blocks.Address>(),
-      { (blocks, use) in blocks.insert(functions[f]!.block(of: use.user).address) })
+      into: Set<Block.ID>(),
+      { (blocks, use) in blocks.insert(functions[f]!.block(of: use.user)) })
 
     // Propagate liveness starting from the blocks in which the operand is being used.
     let cfg = functions[f]!.cfg()
-    var approximateCoverage: [Function.Blocks.Address: (isLiveIn: Bool, isLiveOut: Bool)] = [:]
+    var approximateCoverage: [Block.ID: (isLiveIn: Bool, isLiveOut: Bool)] = [:]
     while true {
       guard let occurrence = occurrences.popFirst() else { break }
 
       // `occurrence` is the defining block.
-      if site.address == occurrence { continue }
+      if site == occurrence { continue }
 
       // We already propagated liveness to the block's live-in set.
       if approximateCoverage[occurrence]?.isLiveIn ?? false { continue }
@@ -122,12 +122,12 @@ extension Module {
 
     // If the operand isn't live out of its defining block, its last use is in that block.
     if approximateCoverage.isEmpty {
-      coverage[site.address] = .closed(lastUse: lastUse(of: operand, in: site, from: f))
+      coverage[site] = .closed(lastUse: lastUse(of: operand, in: site, from: f))
       return Lifetime(operand: operand, coverage: coverage)
     }
 
     // Find the last use in each block for which the operand is not live out.
-    var successors: Set<Function.Blocks.Address> = []
+    var successors: Set<Block.ID> = []
     for (block, bounds) in approximateCoverage {
       switch bounds {
       case (true, true):
@@ -137,7 +137,7 @@ extension Module {
         coverage[block] = .liveOut
         successors.formUnion(cfg.successors(of: block))
       case (true, false):
-        coverage[block] = .liveIn(lastUse: lastUse(of: operand, in: Block.ID(block), from: f))
+        coverage[block] = .liveIn(lastUse: lastUse(of: operand, in: block, from: f))
       case (false, false):
         continue
       }
@@ -156,11 +156,11 @@ extension Module {
   /// - Requires: The definition of `l` dominates `u`.
   func extend(lifetime l: Lifetime, toInclude u: Use, in f: Function.ID) -> Lifetime {
     var coverage = l.coverage
-    switch coverage[functions[f]!.block(of: u.user).address] {
+    switch coverage[functions[f]!.block(of: u.user)] {
     case .closed(let lastUser):
-      coverage[functions[f]!.block(of: u.user).address] = .closed(lastUse: last(lastUser, u, in: f))
+      coverage[functions[f]!.block(of: u.user)] = .closed(lastUse: last(lastUser, u, in: f))
     case .liveIn(let lastUser):
-      coverage[functions[f]!.block(of: u.user).address] = .liveIn(lastUse: last(lastUser, u, in: f))
+      coverage[functions[f]!.block(of: u.user)] = .liveIn(lastUse: last(lastUser, u, in: f))
     default:
       break
     }

--- a/Sources/IR/Analysis/Module+DeadCodeElimination.swift
+++ b/Sources/IR/Analysis/Module+DeadCodeElimination.swift
@@ -41,7 +41,7 @@ extension Function {
     if blocks.count < 2 { return }
 
     // Process all blocks except the entry.
-    var work = Array(blocks.addresses.dropFirst())
+    var work = Array(blockIDs.dropFirst())
     var e = work.count
     var changed = true
     while changed {
@@ -52,7 +52,7 @@ extension Function {
       var i = 0
       while i < e {
         if cfg.predecessors(of: work[i]).isEmpty {
-          removeBlock(Block.ID(work[i]))
+          removeBlock(work[i])
           work.swapAt(i, e - 1)
           changed = true
           e -= 1

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -326,10 +326,9 @@ extension Function {
     let cfg = m[f].cfg()
     let sourceBlocks = DominatorTree(function: m[f], cfg: cfg).bfs
     for b in sourceBlocks {
-      let s = Block.ID(b)
-      let t = rewrittenBlock[s]!
+      let t = rewrittenBlock[b]!
 
-      for i in m[f].instructions(in: s) {
+      for i in m[f].instructions(in: b) {
         switch m[i, in: f] {
         case is GenericParameter:
           rewrite(genericParameter: i)

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -324,7 +324,7 @@ extension Function {
     // Iterate over the basic blocks of the source function in a way that guarantees we always
     // visit definitions before their uses.
     let cfg = m[f].cfg()
-    let sourceBlocks = DominatorTree(function: f, cfg: cfg, in: m).bfs
+    let sourceBlocks = DominatorTree(function: m[f], cfg: cfg).bfs
     for b in sourceBlocks {
       let s = Block.ID(b)
       let t = rewrittenBlock[s]!

--- a/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
+++ b/Sources/IR/Analysis/Module+NormalizeObjectStates.swift
@@ -16,8 +16,7 @@ extension Module {
 
     // Verify that object states are properly initialized/deinitialized in `b` given `context`,
     // updating `self` as necessary and reporting violations in `diagnostics`.
-    machine.fixedPoint { (blockAddress, context) in
-      let b = Block.ID(blockAddress)
+    machine.fixedPoint { (b, context) in
       var pc = self[f].firstInstruction(in: b)?.address
       while let a = pc {
         let user = InstructionID(a)

--- a/Sources/IR/Analysis/Module+Ownership.swift
+++ b/Sources/IR/Analysis/Module+Ownership.swift
@@ -14,7 +14,7 @@ extension Module {
     // Verify that access instructions in `b` satisfy the Law of Exclusivity given `context`,
     // reporting violations of exclusivity in `diagnostics`.
     machine.fixedPoint { (b, context) in
-      for user in self[f].instructions(in: Block.ID(b)) {
+      for user in self[f].instructions(in: b) {
         switch self[f][user] {
         case is Access:
           interpret(access: user, from: f, in: &context)

--- a/Sources/IR/Function+Inspection.swift
+++ b/Sources/IR/Function+Inspection.swift
@@ -127,7 +127,7 @@ extension Function {
 
     // Slow path: use the dominator tree.
     let d = DominatorTree(function: self, cfg: cfg())
-    return d.dominates(blockForInstruction[lhs]!.address, blockForInstruction[rhs]!.address)
+    return d.dominates(blockForInstruction[lhs]!, blockForInstruction[rhs]!)
   }
 
   /// Returns `true` iff `lhs` is sequenced before `rhs` in the block of `lhs`.

--- a/Sources/IR/Function.swift
+++ b/Sources/IR/Function.swift
@@ -63,10 +63,10 @@ public struct Function {
   /// Returns the control flow graph of `self`.
   func cfg() -> ControlFlowGraph {
     var result = ControlFlowGraph()
-    for source in blocks.indices {
-      guard let s = self[blocks[source].last!] as? Terminator else { continue }
+    for source in blockIDs {
+      guard let s = self[blocks[source.address].last!] as? Terminator else { continue }
       for target in s.successors {
-        result.define(source.address, predecessorOf: target.address)
+        result.define(source, predecessorOf: target)
       }
     }
 


### PR DESCRIPTION
`DominatorTree` shall not depend on module anymore.
Use `Block.ID` instead of addresses in `DominatorTree` and `ControlFlowGraph`.