### PR TITLE
Fix CMake testing issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ project(Hylo
   LANGUAGES C CXX Swift
 )
 enable_testing()
-include(CTest)
+if(BUILD_TESTING)
+  include(CTest)
+endif()
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0")
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ file for LLVM.
     (on Windows substitute your shell's line continuation character
     for `\` or just remove the line breaks and backslashes).
     
-    If you want to run tests, add `-DBUILD_TESTING=1`.
+    If you want to run tests, add `-D BUILD_TESTING=1`.
     
-    **Note:** on macOS, if you are not using your Xcode's default
-    toolchain, [you may need `-D
-    CMAKE_Swift_COMPILER=swiftc`](https://gitlab.kitware.com/cmake/cmake/-/issues/25750)
-    to prevent CMake from using Xcode's default `swift`.
+    **Note:** on macOS,
+    - To run tests, you also need `-D CMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path)`.
+    - if you are not using your Xcode's default toolchain, [you may need `-D
+      CMAKE_Swift_COMPILER=swiftc`](https://gitlab.kitware.com/cmake/cmake/-/issues/25750) to
+      prevent CMake from using Xcode's default `swift`.
     
     If this command fails it could be because you have an LLVM without
     CMake support installed; we suggest you try one of
@@ -92,7 +93,11 @@ You will need CMake 3.3.0-rc1 or newer.
       -G Xcode -S . -B <build-directory>
     ```
 
-    If you want to run tests, add `-DBUILD_TESTING=1`.
+    If you want to run tests, add
+
+    ```
+    -D BUILD_TESTING=1 -D CMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path)
+    ```
 
 2. **Profit**: open the `.xcodeproj` file in the *build-directory* and
    use Xcode's UI to build and test.


### PR DESCRIPTION
1. include(CTest) will set BUILD_TESTING=1 if it isn't already set, so only include CTest conditionally.

2. Update instructions to account for missing CMAKE_OSX_SYSROOT