### PR TITLE
Interpreter: Make empty program run successfully

### DIFF
--- a/Sources/Interpreter/Interpreter.swift
+++ b/Sources/Interpreter/Interpreter.swift
@@ -326,8 +326,8 @@ public struct Interpreter {
       a)
   }
 
-  /// Removes topmost stackframe and points `programCounter` to next instruction
-  /// of any previous stackframe, or stops the program if the stack is now empty.
+  /// Removes topmost stack frame and points `programCounter` to next instruction
+  /// of any previous stack frame, or stops the program if the stack is now empty.
   ///
   /// - Precondition: the program is running.
   mutating func popStackFrame() {

--- a/Tests/InterpreterTests/InterpreterTests.swift
+++ b/Tests/InterpreterTests/InterpreterTests.swift
@@ -16,8 +16,8 @@ import Utils
     let module = try input.loweredToIRAsMainWithHostedStandardLibrary();
     let program = IR.Program.init(syntax: module.program, modules: [module.id: module]);
     var executor = Interpreter(program);
-    #expect(throws: Never.self) {
-      while executor.isRunning { try executor.step() }
+    while executor.isRunning {
+      try executor.step()
     }
   }
 


### PR DESCRIPTION
**Formatting changes are from swift-formatter.**

The PR does the following changes:
1. Make program with empty main method run successfully.
2. Fixes stack.pop implementation.
3. add convenient `executor(for: )` method in InterpreterTests to create interpreter for raw programs.
4. Replace print program with empty program in test, will add back print when function calls will be supported.
5. Used swift-testing for interpreter tests for running program.

~Was experimenting a little with swift-testing. It worked fine for all purposes except, it seems to not produce any binary for debugging purposes, hence stayed with XCTest.~
