### PR TITLE
Remove the `makeXXX` functions from `Module` that create IR instructions.

### DIFF
--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -131,7 +131,12 @@ extension Module {
     // Nothing to do if the request set is already a singleton.
     if s.capabilities == [k] { return }
 
-    let reified = makeAccess([k], from: s.source, correspondingTo: s.binding, in: f, at: s.site)
+    let reified = Access(
+      capabilities: [k],
+      accessedType: self[f].type(of: s.source),
+      source: s.source,
+      binding: s.binding,
+      site: s.site)
     self[f].replace(i, with: reified)
   }
 
@@ -143,13 +148,17 @@ extension Module {
     // Generate the proper instructions to prepare the projection's arguments.
     var arguments = s.operands
     for a in arguments.indices where s.parameters[a].access == .yielded {
-      let b = makeAccess([k], from: arguments[a], in: f, at: s.site)
+      let b = Access(
+        capabilities: [k],
+        accessedType: self[f].type(of: arguments[a]),
+        source: arguments[a],
+        site: s.site)
       arguments[a] = .register(self[f].insert(b, at: .before(i)))
     }
 
     let o = RemoteType(k, s.projection)
-    let reified = makeProject(
-      o, applying: s.variants[k]!, specializedBy: s.bundle.arguments, to: arguments, at: s.site)
+    let reified = Project(
+      projection: o, callee: s.variants[k]!, specialization: s.bundle.arguments, operands: arguments, site: s.site)
     self[f].replace(i, with: reified)
   }
 

--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -148,9 +148,11 @@ extension Module {
     // Generate the proper instructions to prepare the projection's arguments.
     var arguments = s.operands
     for a in arguments.indices where s.parameters[a].access == .yielded {
+      let t = self[f].type(of: arguments[a])
+      precondition(t.isAddress)
       let b = Access(
         capabilities: [k],
-        accessedType: self[f].type(of: arguments[a]),
+        accessedType: t,
         source: arguments[a],
         site: s.site)
       arguments[a] = .register(self[f].insert(b, at: .before(i)))

--- a/Sources/IR/Analysis/Module+CallBundleReification.swift
+++ b/Sources/IR/Analysis/Module+CallBundleReification.swift
@@ -17,15 +17,19 @@ extension Module {
     let k = s.capabilities.weakest!
 
     var arguments = Array(s.arguments)
-    let r = makeAccess([k], from: arguments[0], in: f, at: s.site)
+    let r = Access(
+      capabilities: [k],
+      accessedType: self[f].type(of: arguments[0]),
+      source: arguments[0],
+      site: s.site)
     arguments[0] = .register(self[f].insert(r, at: .before(i)))
 
     let b = Block.ID(containing: i)
     let x = FunctionReference(
       to: s.variants[k]!, in: self, specializedBy: s.bundle.arguments, in: self[b, in: f].scope)
 
-    let reified = makeCall(
-      applying: .constant(x), to: arguments, writingResultTo: s.output, in: f, at: s.site)
+    let reified = Call(
+      callee: .constant(x), output: s.output, arguments: arguments, site: s.site)
     self[f].replace(i, with: reified)
   }
 

--- a/Sources/IR/Analysis/Module+CallBundleReification.swift
+++ b/Sources/IR/Analysis/Module+CallBundleReification.swift
@@ -17,9 +17,11 @@ extension Module {
     let k = s.capabilities.weakest!
 
     var arguments = Array(s.arguments)
+    let t = self[f].type(of: arguments[0])
+    precondition(t.isAddress)
     let r = Access(
       capabilities: [k],
-      accessedType: self[f].type(of: arguments[0]),
+      accessedType: t,
       source: arguments[0],
       site: s.site)
     arguments[0] = .register(self[f].insert(r, at: .before(i)))

--- a/Sources/IR/Analysis/Module+CloseBorrows.swift
+++ b/Sources/IR/Analysis/Module+CloseBorrows.swift
@@ -32,25 +32,25 @@ extension Module {
       }
 
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeEndAccess(.register(i), in: f, at: site)
+        EndAccess(start: .register(i), site: site)
       }
 
     case is OpenCapture:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeCloseCapture(.register(i), in: f, at: site)
+        CloseCapture(start: .register(i), site: site)
       }
 
     case is OpenUnion:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeCloseUnion(.register(i), in: f, at: site)
+        CloseUnion(start: .register(i), site: site)
       }
 
     case is Project:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeEndProject(.register(i), in: f, at: site)
+        EndProject(start: .register(i), site: site)
       }
 
     default:

--- a/Sources/IR/Analysis/Module+DeadCodeElimination.swift
+++ b/Sources/IR/Analysis/Module+DeadCodeElimination.swift
@@ -64,7 +64,7 @@ extension Module {
     for b in self[f].blockIDs {
       if let i = self[f].instructions(in: b).first(where: { returnsNever($0, in: f) }) {
         self[f].removeAllInstructions(after: i)
-        self[f].insert(makeUnreachable(at: self[i, in: f].site), at: .after(i))
+        self[f].insert(Unreachable(site: self[i, in: f].site), at: .after(i))
       }
     }
   }

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -62,8 +62,8 @@ extension IR.Program {
 
     let g = monomorphize(callee, usedIn: modules[m]![f].scope(containing: i))
     let r = FunctionReference(to: g, in: modules[m]!)
-    let new = modules[m]!.makeCall(
-      applying: .constant(r), to: Array(s.arguments), writingResultTo: s.output, in: f, at: s.site)
+    let new = Call(
+      callee: .constant(r), output: s.output, arguments: Array(s.arguments), site: s.site)
     modules[m]![f].replace(i, with: new)
   }
 
@@ -79,8 +79,8 @@ extension IR.Program {
 
     let z = base.canonical(s.specialization, in: modules[m]![f].scope(containing: i))
     let g = monomorphize(s.callee, for: z, usedIn: modules[m]![f].scope(containing: i))
-    let new = modules[m]!.makeProject(
-      s.projection, applying: g, specializedBy: .empty, to: s.operands, at: s.site)
+    let new = Project(
+      projection: s.projection, callee: g, specialization: .empty, operands: s.operands, site: s.site)
     modules[m]![f].replace(i, with: new)
   }
 
@@ -181,9 +181,9 @@ extension IR.Program {
       let s = modules[source]![i, in: f] as! Return
       let j = modify(&modules[target]!) { (m) in
         for i in rewrittenGenericValue.values.reversed() {
-          m[result].insert(m.makeDeallocStack(for: .register(i), in: result, at: s.site), at: .end(of: b))
+          m[result].insert(DeallocStack(location: .register(i), site: s.site), at: .end(of: b))
         }
-        return m[result].insert(m.makeReturn(at: s.site), at: .end(of: b))
+        return m[result].insert(Return(site: s.site), at: .end(of: b))
       }
       monomorphizer.rewrittenInstruction[i] = j
     }
@@ -297,7 +297,7 @@ extension Module {
         UNIMPLEMENTED("arbitrary compile-time values")
       }
 
-      let s = self[monomorphized].insert(makeAllocStack(^program.ast.coreType("Int")!, at: insertionSite), at: .end(of: entry))
+      let s = self[monomorphized].insert(AllocStack(allocatedType: ^program.ast.coreType("Int")!, site: insertionSite), at: .end(of: entry))
 
       var log = DiagnosticSet()
       Emitter.withInstance(insertingIn: &self, reportingDiagnosticsTo: &log) { (e) in

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -62,6 +62,10 @@ extension IR.Program {
 
     let g = monomorphize(callee, usedIn: modules[m]![f].scope(containing: i))
     let r = FunctionReference(to: g, in: modules[m]!)
+    let t = ArrowType(r.type.ast)!.strippingEnvironment
+    precondition(t.inputs.count == s.arguments.count)
+    precondition(s.arguments.allSatisfy({ modules[m]![f][register: $0] is Access }))
+    precondition(modules[m]![f].isBorrowSet(s.output))
     let new = Call(
       callee: .constant(r), output: s.output, arguments: Array(s.arguments), site: s.site)
     modules[m]![f].replace(i, with: new)
@@ -181,6 +185,7 @@ extension IR.Program {
       let s = modules[source]![i, in: f] as! Return
       let j = modify(&modules[target]!) { (m) in
         for i in rewrittenGenericValue.values.reversed() {
+          precondition(m[i, in: result] is AllocStack)
           m[result].insert(DeallocStack(location: .register(i), site: s.site), at: .end(of: b))
         }
         return m[result].insert(Return(site: s.site), at: .end(of: b))

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -89,6 +89,12 @@ struct Emitter: Sendable {
     program.ast
   }
 
+  /// The IR in which we are currently inserting.
+  private var insertionIR: Function? {
+    guard let f = insertionFunction else { return nil }
+    return module[f]
+  }
+
   /// The basic block in which new instructions are currently inserted.
   private var insertionBlock: Block.ID? {
     insertionPoint?.block
@@ -130,7 +136,7 @@ struct Emitter: Sendable {
   @discardableResult
   private mutating func insert<I: Instruction>(_ newInstruction: I) -> Operand? {
     let i = module[insertionFunction!].insert(newInstruction, at: insertionPoint!)
-    return module[insertionFunction!].result(of: i)
+    return insertionIR!.result(of: i)
   }
 
   // MARK: Top-level entry points
@@ -668,7 +674,7 @@ struct Emitter: Sendable {
   private mutating func assignProjections(of rhs: Operand, to d: BindingPattern.ID) {
     precondition(!program[d].introducer.value.isConsuming)
     let k = AccessEffect(program[d].introducer.value)
-    let request: AccessEffectSet = module[insertionFunction!].isSink(rhs) ? [k, .sink] : [k]
+    let request: AccessEffectSet = insertionIR!.isSink(rhs) ? [k, .sink] : [k]
 
     for (path, name) in ast.names(in: program[d].subpattern) {
       var part = lowering(program[name].decl) {
@@ -744,7 +750,7 @@ struct Emitter: Sendable {
   private mutating func _emitMoveInitRecordParts(
     of receiver: Operand, consuming argument: Operand
   ) {
-    let layout = AbstractTypeLayout(of: module[insertionFunction!].type(of: receiver).ast, definedIn: program)
+    let layout = AbstractTypeLayout(of: insertionIR!.type(of: receiver).ast, definedIn: program)
 
     // If the object is empty, simply mark it initialized.
     if layout.properties.isEmpty {
@@ -768,7 +774,7 @@ struct Emitter: Sendable {
   private mutating func _emitMoveInitUnionPayload(
     of receiver: Operand, consuming argument: Operand
   ) {
-    let t = UnionType(module[insertionFunction!].type(of: receiver).ast)!
+    let t = UnionType(insertionIR!.type(of: receiver).ast)!
 
     // If union is empty, simply mark it initialized.
     if t.elements.isEmpty {
@@ -903,7 +909,7 @@ struct Emitter: Sendable {
   private mutating func _emitCopyRecordParts(
     from source: Operand, to target: Operand
   ) {
-    let layout = AbstractTypeLayout(of: module[insertionFunction!].type(of: source).ast, definedIn: program)
+    let layout = AbstractTypeLayout(of: insertionIR!.type(of: source).ast, definedIn: program)
 
     // If the object is empty, simply mark the target as initialized.
     if layout.properties.isEmpty {
@@ -923,7 +929,7 @@ struct Emitter: Sendable {
   private mutating func _emitCopyUnionPayload(
     from source: Operand, to target: Operand
   ) {
-    let t = UnionType(module[insertionFunction!].type(of: source).ast)!
+    let t = UnionType(insertionIR!.type(of: source).ast)!
 
     // If union is empty, simply mark the target as initialized.
     if t.elements.isEmpty {
@@ -1442,7 +1448,7 @@ struct Emitter: Sendable {
 
   /// Inserts the IR for `s`, returning its effect on control flow.
   private mutating func _emit(returnStmt s: ReturnStmt.ID) -> ControlFlow {
-    if module[insertionFunction!].isSubscript {
+    if insertionIR!.isSubscript {
       report(.error(returnInSubscript: s, in: ast))
       return .next
     }
@@ -1647,7 +1653,7 @@ struct Emitter: Sendable {
     let u = canonical(program[e].type)
     let movable = program.ast.core.movable.type
     if !program.conforms(u, to: movable, in: insertionScope!) {
-      report(.error(module[insertionFunction!].type(of: x0).ast, doesNotConformTo: movable, at: ast[e].site))
+      report(.error(insertionIR!.type(of: x0).ast, doesNotConformTo: movable, at: ast[e].site))
       return
     }
 
@@ -1859,7 +1865,7 @@ struct Emitter: Sendable {
     convertingIfNecessary e: T,
     to storage: Operand
   ) {
-    let lhsType = module[insertionFunction!].type(of: storage).ast
+    let lhsType = insertionIR!.type(of: storage).ast
     let rhsType = canonical(program[e].type)
 
     if program.areEquivalent(lhsType, rhsType, in: program[e].scope) {
@@ -1982,7 +1988,7 @@ struct Emitter: Sendable {
   private mutating func _emitStore(
     access a: Operand, to storage: Operand
   ) {
-    guard let s = module[insertionFunction!].provenances(storage).uniqueElement, module[s, in: insertionFunction!] is AllocStack else {
+    guard let s = insertionIR!.provenances(storage).uniqueElement, module[s, in: insertionFunction!] is AllocStack else {
       report(.error(cannotCaptureAccessAt: currentSource))
       return
     }
@@ -2327,7 +2333,7 @@ struct Emitter: Sendable {
     requested = requested.isEmpty ? available : requested
 
     let entityToCall = module.memberCallee(
-      referringTo: d, memberOf: module[insertionFunction!].type(of: r).ast, accessedWith: requested,
+      referringTo: d, memberOf: insertionIR!.type(of: r).ast, accessedWith: requested,
       specializedBy: a, usedIn: scopeOfUse)
 
     if case .bundle(let b) = entityToCall {
@@ -2507,7 +2513,7 @@ struct Emitter: Sendable {
 
     assert(program[lhs].introducer.value.isConsuming || (storage == nil))
 
-    if module[insertionFunction!].type(of: rhs).ast.base is UnionType {
+    if insertionIR!.type(of: rhs).ast.base is UnionType {
       return emitUnionNarrowing(
         from: rhs, to: lhs, typed: lhsType,
         movingConsumedValuesTo: storage, branchingOnFailureTo: failure,
@@ -2530,7 +2536,7 @@ struct Emitter: Sendable {
     branchingOnFailureTo failure: Block.ID,
     in scope: AnyScopeID
   ) -> Block.ID {
-    let rhsType = UnionType(module[insertionFunction!].type(of: rhs).ast)!
+    let rhsType = UnionType(insertionIR!.type(of: rhs).ast)!
     precondition(rhsType.elements.contains(lhsType), "recursive narrowing is unimplemented")
 
     let next = appendBlock(in: scope)
@@ -2572,7 +2578,7 @@ struct Emitter: Sendable {
 
   /// Inserts the IR for extracting the built-in value stored in an instance of `Hylo.Bool`.
   private mutating func _emitLoadBuiltinBool(_ wrapper: Operand) -> Operand {
-    precondition(module[insertionFunction!].type(of: wrapper) == .address(ast.coreType("Bool")!))
+    precondition(insertionIR!.type(of: wrapper) == .address(ast.coreType("Bool")!))
     let x0 = _subfield_view(wrapper, at: [0])
     let x1 = _access(.sink, from: x0)
     let x2 = _load(x1)
@@ -2583,7 +2589,7 @@ struct Emitter: Sendable {
   /// If `s` has a remote type, returns the result of an instruction exposing the captured access;
   /// otherwise, returns `s`.
   private mutating func _unwrapCapture(_ s: Operand) -> Operand {
-    if module[insertionFunction!].type(of: s).ast.base is RemoteType {
+    if insertionIR!.type(of: s).ast.base is RemoteType {
       return _open_capture(s)
     } else {
       return s
@@ -2595,7 +2601,7 @@ struct Emitter: Sendable {
   /// `source` is returned unchanged if it stores an instance of `target`. Otherwise, the IR
   /// producing an address of type `target` is inserted, consuming `source` if necessary.
   private mutating func _emitCoerce(_ source: Operand, to target: AnyType) -> Operand {
-    let lhs = module[insertionFunction!].type(of: source).ast
+    let lhs = insertionIR!.type(of: source).ast
     let rhs = program.canonical(target, in: insertionScope!)
 
     if program.areEquivalent(lhs, rhs, in: insertionScope!) {
@@ -2625,7 +2631,7 @@ struct Emitter: Sendable {
   private mutating func _emitCoerce(
     _ source: Operand, to target: ExistentialType
   ) -> Operand {
-    let t = module[insertionFunction!].type(of: source).ast
+    let t = insertionIR!.type(of: source).ast
     if t.base is ExistentialType {
       return source
     }
@@ -2639,7 +2645,7 @@ struct Emitter: Sendable {
   private mutating func _emitCoerce(
     _ source: Operand, to target: ArrowType
   ) -> Operand {
-    let t = module[insertionFunction!].type(of: source).ast
+    let t = insertionIR!.type(of: source).ast
     guard let lhs = ArrowType(t) else {
       unexpectedCoercion(from: t, to: ^target)
     }
@@ -2665,7 +2671,7 @@ struct Emitter: Sendable {
   private mutating func _emitCoerce(
     _ source: Operand, to target: UnionType
   ) -> Operand {
-    let lhs = module[insertionFunction!].type(of: source).ast
+    let lhs = insertionIR!.type(of: source).ast
 
     let x0 = _alloc_stack(^target)
     let x1 = _open_union(x0, as: lhs, .forInitialization)
@@ -2683,7 +2689,7 @@ struct Emitter: Sendable {
 
   /// Inserts the IR for converting `foreign` to a value of type `ir`.
   private mutating func _emitConvert(foreign: Operand, to ir: AnyType) -> Operand {
-    precondition(module[insertionFunction!].type(of: foreign).isObject)
+    precondition(insertionIR!.type(of: foreign).isObject)
 
     let foreignConvertible = ast.core.foreignConvertible.type
     let foreignConvertibleConformance = program.conformance(
@@ -2694,7 +2700,7 @@ struct Emitter: Sendable {
     // TODO: Handle cases where the foreign representation of `t` is not built-in.
 
     // Store the foreign representation in memory to call the converter.
-    let source = _alloc_stack(module[insertionFunction!].type(of: foreign).ast)
+    let source = _alloc_stack(insertionIR!.type(of: foreign).ast)
     _emitInitialize(storage: source, to: foreign)
 
     switch foreignConvertibleConformance.implementations[r]! {
@@ -2724,7 +2730,7 @@ struct Emitter: Sendable {
   ///
   /// The returned operand is the result of a `load` instruction.
   private mutating func _emitConvertToForeign(_ o: Operand) -> Operand {
-    let t = module[insertionFunction!].type(of: o)
+    let t = insertionIR!.type(of: o)
     precondition(t.isAddress)
 
     let foreignConvertible = ast.core.foreignConvertible.type
@@ -2760,7 +2766,7 @@ struct Emitter: Sendable {
   private mutating func _emitExistential(
     _ t: ExistentialType, wrapping witness: Operand
   ) -> Operand {
-    let w = module[insertionFunction!].type(of: witness).ast
+    let w = insertionIR!.type(of: witness).ast
     let table = Operand.constant(module.demandWitnessTable(w, in: insertionScope!))
     return _wrap_existential_addr(witness, table, as: t)
   }
@@ -2927,7 +2933,7 @@ struct Emitter: Sendable {
         boundTo: r, declaredByBundle: .init(d)!, specializedBy: z)
 
     case VarDecl.self:
-      let l = AbstractTypeLayout(of: module[insertionFunction!].type(of: r).ast, definedIn: program)
+      let l = AbstractTypeLayout(of: insertionIR!.type(of: r).ast, definedIn: program)
       let i = l.offset(of: ast[VarDecl.ID(d)!].baseName)!
       return _subfield_view(r, at: [i])
 
@@ -3003,8 +3009,8 @@ struct Emitter: Sendable {
     _ semantics: AccessEffectSet, _ value: Operand, to storage: Operand
   ) {
     precondition(!semantics.isEmpty && semantics.isSubset(of: [.set, .inout]))
-    let model = module[insertionFunction!].type(of: value).ast
-    precondition(model == module[insertionFunction!].type(of: storage).ast)
+    let model = insertionIR!.type(of: value).ast
+    precondition(model == insertionIR!.type(of: storage).ast)
 
     // Built-in types are handled as a special case.
     if model.isBuiltin {
@@ -3082,8 +3088,8 @@ struct Emitter: Sendable {
   private mutating func _emitCopy(
     _ source: Operand, to target: Operand
   ) {
-    let model = module[insertionFunction!].type(of: source).ast
-    precondition(model == module[insertionFunction!].type(of: target).ast)
+    let model = insertionIR!.type(of: source).ast
+    precondition(model == insertionIR!.type(of: target).ast)
 
     // Built-in types are handled as a special case.
     if model.isBuiltin {
@@ -3123,7 +3129,7 @@ struct Emitter: Sendable {
   /// Let `T` be the type of `storage`, `storage` is deinitializable iff `T` has a deinitializer
   /// exposed to `self.insertionScope`.
   mutating func _emitDeinit(_ storage: Operand) {
-    let m = module[insertionFunction!].type(of: storage).ast
+    let m = insertionIR!.type(of: storage).ast
     let d = program.ast.core.deinitializable.type
 
     if m.base is RemoteType {
@@ -3161,7 +3167,7 @@ struct Emitter: Sendable {
   /// If `storage` is deinitializable in `self.insertionScope`, inserts the IR for deinitializing
   /// it; reports a diagnostic for each part that isn't deinitializable otherwise.
   mutating func _emitDeinitParts(of storage: Operand) {
-    let t = module[insertionFunction!].type(of: storage).ast
+    let t = insertionIR!.type(of: storage).ast
 
     if program.isTriviallyDeinitializable(t, in: insertionScope!) {
       _mark_state(.uninitialized, storage)
@@ -3180,7 +3186,7 @@ struct Emitter: Sendable {
   ///
   /// - Requires: the type of `storage` has a record layout.
   private mutating func _emitDeinitRecordParts(of storage: Operand) {
-    let t = module[insertionFunction!].type(of: storage).ast
+    let t = insertionIR!.type(of: storage).ast
     precondition(t.hasRecordLayout)
 
     let layout = AbstractTypeLayout(of: t, definedIn: module.program)
@@ -3204,7 +3210,7 @@ struct Emitter: Sendable {
   ///
   /// - Requires: the type of `storage` is a union.
   private mutating func _emitDeinitUnionPayload(of storage: Operand) {
-    let t = UnionType(module[insertionFunction!].type(of: storage).ast)!
+    let t = UnionType(insertionIR!.type(of: storage).ast)!
 
     // If union is empty, simply mark it uninitialized.
     if t.elements.isEmpty {
@@ -3246,7 +3252,7 @@ struct Emitter: Sendable {
   // MARK: Equality
 
   private mutating func _emitStoreEquality(_ lhs: Operand, _ rhs: Operand, to target: Operand) {
-    let m = module[insertionFunction!].type(of: lhs).ast
+    let m = insertionIR!.type(of: lhs).ast
     let d = program.ast.core.equatable.type
 
     if let equatable = program.conformance(of: m, to: d, exposedTo: insertionScope!) {
@@ -3271,7 +3277,7 @@ struct Emitter: Sendable {
     to target: Operand
   ) {
     let layout = AbstractTypeLayout(
-      of: module[insertionFunction!].type(of: lhs).ast, definedIn: module.program)
+      of: insertionIR!.type(of: lhs).ast, definedIn: module.program)
 
     // If the object is empty, return true.
     var parts = layout.properties[...]
@@ -3304,7 +3310,7 @@ struct Emitter: Sendable {
   private mutating func _emitStoreUnionPayloadEquality(
     _ lhs: Operand, _ rhs: Operand, to target: Operand
   ) {
-    let union = UnionType(module[insertionFunction!].type(of: lhs).ast)!
+    let union = UnionType(insertionIR!.type(of: lhs).ast)!
 
     // If the union is empty, return true.
     if union.elements.isEmpty {
@@ -3426,7 +3432,7 @@ struct Emitter: Sendable {
       elementPath = subfield
       address = recordAddress
     }
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(ir.type(of: address).isAddress)
     let l = AbstractTypeLayout(of: ir.type(of: address).ast, definedIn: program)
     let t = l[elementPath].type
@@ -3450,7 +3456,7 @@ struct Emitter: Sendable {
   private mutating func _emitUnionSwitch(
     on scrutinee: Operand, toOneOf targets: UnionSwitch.Targets
   ) {
-    let u = UnionType(module[insertionFunction!].type(of: scrutinee).ast)!
+    let u = UnionType(insertionIR!.type(of: scrutinee).ast)!
     let i = _emitUnionDiscriminator(scrutinee)
     _union_switch(case: i, of: u, targets)
   }
@@ -3502,7 +3508,7 @@ struct Emitter: Sendable {
   mutating func _cond_branch(if condition: Operand, then targetIfTrue: Block.ID, else targetIfFalse: Block.ID) {
     checkEntryStack(targetIfTrue)
     checkEntryStack(targetIfFalse)
-    precondition(module[insertionFunction!].type(of: condition) == .object(BuiltinType.i(1)))
+    precondition(insertionIR!.type(of: condition) == .object(BuiltinType.i(1)))
     insert(CondBranch(
       condition: condition,
       targetIfTrue: targetIfTrue,
@@ -3728,12 +3734,12 @@ extension Emitter {
 extension Emitter {
 
   fileprivate mutating func _mark_state(_ x: InitializationState, _ op: Operand?) {
-    precondition(module[insertionFunction!].type(of: op!).isAddress)
+    precondition(insertionIR!.type(of: op!).isAddress)
     insert(MarkState(storage: op!, initialized: x == .initialized, site: currentSource))
   }
 
   fileprivate mutating func _call_ffi<T: TypeProtocol>(_ foreignName: String, on arguments: [Operand], returning returnType: T) -> Operand {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(arguments.allSatisfy({ ir[register: $0] is Load }))
     return insert(
       CallFFI(
@@ -3753,20 +3759,20 @@ extension Emitter {
   ) -> Operand {
     insert(Access(
       capabilities: capabilities,
-      accessedType: module[insertionFunction!].type(of: s),
+      accessedType: insertionIR!.type(of: s),
       source: s,
       binding: binding,
       site: currentSource))!
   }
 
   fileprivate mutating func _end_access(_ x: Operand) {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(x.instruction.map({ ir[$0] is Access }) ?? false)
     insert(EndAccess(start: x, site: currentSource))
   }
 
   fileprivate mutating func _yield(_ c: AccessEffect, _ a: Operand) {
-    precondition(module[insertionFunction!].type(of: a).isAddress)
+    precondition(insertionIR!.type(of: a).isAddress)
     _ = insert(Yield(capability: c, projection: a, site: currentSource))
   }
 
@@ -3779,7 +3785,7 @@ extension Emitter {
     _ container: Operand, as payload: AnyType,
     _ option: OpenUnionOption = .notForInitialization
   ) -> Operand {
-    precondition(module[insertionFunction!].type(of: container).isAddress)
+    precondition(insertionIR!.type(of: container).isAddress)
     precondition(payload.isCanonical)
     return insert(
       OpenUnion(
@@ -3790,7 +3796,7 @@ extension Emitter {
   }
 
   fileprivate mutating func _close_union(_ x: Operand  ) {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(x.instruction.map({ ir[$0] is OpenUnion }) ?? false)
     insert(CloseUnion(start: x, site: currentSource))
   }
@@ -3804,7 +3810,7 @@ extension Emitter {
   }
 
   fileprivate mutating func _store(_ source: Operand, _ target: Operand) {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(ir.type(of: source).isObject)
     precondition(ir.type(of: target).isAddress)
     insert(Store(object: source, at: target, site: currentSource))
@@ -3812,7 +3818,7 @@ extension Emitter {
 
   /// Inserts a `load` instruction reading from `source`.
   fileprivate mutating func _load(_ source: Operand) -> Operand {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(ir[register: source] is Access)
     return insert(Load(objectType: .object(ir.type(of: source).ast), from: source, site: currentSource))!
   }
@@ -3825,7 +3831,7 @@ extension Emitter {
   fileprivate mutating func _call_builtin(
     _ f: BuiltinFunction, _ arguments: [Operand]
   ) -> Operand {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(
       arguments.allSatisfy { (o) in
         let t = ir.type(of: o)
@@ -3857,18 +3863,18 @@ extension Emitter {
   }
 
   fileprivate mutating func _open_capture(_ s: Operand) -> Operand {
-    let t = RemoteType(module[insertionFunction!].type(of: s).ast) ?? preconditionFailure()
+    let t = RemoteType(insertionIR!.type(of: s).ast) ?? preconditionFailure()
     return insert(OpenCapture(result: .address(t.bareType), source: s, site: currentSource))!
   }
 
   fileprivate mutating func _release_capture(_ source: Operand) {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(source.instruction.map({ ir[$0] is AllocStack }) ?? false)
     insert(ReleaseCaptures(container: source, site: currentSource))
   }
 
   fileprivate mutating func _advanced(_ source: Operand, byStrides n: Int) -> Operand {
-    let s = module[insertionFunction!].type(of: source)
+    let s = insertionIR!.type(of: source)
     if !s.isAddress {
       preconditionFailure("source must be the address of a buffer")
     }
@@ -3882,7 +3888,7 @@ extension Emitter {
   }
 
   fileprivate mutating func _capture(_ source: Operand, in target: Operand) {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(ir.type(of: source).isAddress)
     precondition(ir.type(of: target).isAddress)
     insert(CaptureIn(source: source, target: target, site: currentSource))
@@ -3891,7 +3897,7 @@ extension Emitter {
   fileprivate mutating func _call(
     _ callee: Operand, _ arguments: [Operand], to output: Operand
   ) {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     let t = ArrowType(ir.type(of: callee).ast)!.strippingEnvironment
     precondition(t.inputs.count == arguments.count)
     precondition(arguments.allSatisfy({ ir[register: $0] is Access }))
@@ -3914,7 +3920,7 @@ extension Emitter {
 
     precondition(variants.count > 1)
 
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     let t = MethodType(
       program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!
     precondition((t.inputs.count + 1) == a.count)
@@ -3928,7 +3934,7 @@ extension Emitter {
   fileprivate mutating func _wrap_existential_addr(
     _ witness: Operand, _ table: Operand, as interface: ExistentialType
   ) -> Operand {
-    precondition(module[insertionFunction!].type(of: witness).isAddress)
+    precondition(insertionIR!.type(of: witness).isAddress)
     return insert(WrapExistentialAddr(witness: witness, table: table, interface: .address(interface), site: currentSource))!
   }
 
@@ -3947,26 +3953,26 @@ extension Emitter {
   }
 
   fileprivate mutating func _memory_copy(_ source: Operand, _ target: Operand) {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     let s = ir.type(of: source)
     precondition(s.isAddress && (s == ir.type(of: target)))
     insert(MemoryCopy(source: source, target: target, site: currentSource))
   }
 
   fileprivate mutating func _move(_ source: Operand, _ target: Operand, via movability: FrontEnd.Conformance) {
-    let ir = module[insertionFunction!]
+    let ir = insertionIR!
     precondition(ir.type(of: source).isAddress)
     precondition(ir.type(of: target).isAddress)
     insert(Move(object: source, target: target, movable: movability, site: currentSource))
   }
 
   fileprivate mutating func _union_discriminator(_ x: Operand) -> Operand {
-    precondition(module[insertionFunction!].type(of: x).isAddress)
+    precondition(insertionIR!.type(of: x).isAddress)
     return insert(UnionDiscriminator(container: x, site: currentSource))!
   }
 
   fileprivate mutating func _union_switch(case discriminator: Operand, of u: UnionType, _ targets: UnionSwitch.Targets) {
-    let t = module[insertionFunction!].type(of: discriminator)
+    let t = insertionIR!.type(of: discriminator)
     precondition(t.isObject && t.ast.isBuiltinInteger)
     precondition(u.elements.allSatisfy({ (e) in targets[e] != nil }))
     insert(UnionSwitch(discriminator: discriminator, union: u, targets: targets, site: currentSource))

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -3839,6 +3839,11 @@ extension Emitter {
   fileprivate mutating func _project_bundle(
     applying b: BundleReference<SubscriptDecl>, to arguments: [Operand]
   ) -> Operand {
+    insert(makeProjectBundle(applying: b, to: arguments))!
+  }
+
+  /// Returns a `ProjectBundle` instruction for projecting `b` applied to `arguments`.
+  private mutating func makeProjectBundle(applying b: BundleReference<SubscriptDecl>, to arguments: [Operand]) -> ProjectBundle {
     var variants: [AccessEffect: Function.ID] = [:]
     for v in program[b.bundle].impls {
       let i = program[v].introducer.value
@@ -3851,11 +3856,11 @@ extension Emitter {
     let t = SubscriptType(
       program.canonicalType(of: b.bundle, specializedBy: b.arguments, in: insertionScope!))!.pure
 
-    return insert(ProjectBundle(
+    return .init(
       bundle: b, variants: variants,
       parameters: t.inputs.lazy.map({ ParameterType($0.type)! }),
       projection: RemoteType(t.output)!.bareType,
-      operands: arguments, site: currentSource))!
+      operands: arguments, site: currentSource)
   }
 
   fileprivate mutating func _open_capture(_ s: Operand) -> Operand {

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -3411,7 +3411,7 @@ struct Emitter: Sendable {
     if a.mayHoldCaptures {
       _release_capture(a.source)
     }
-    precondition(source.instruction.map({ module[$0, in: insertionFunction!] is AllocStack }) ?? false)
+    precondition(source.instruction.satisfies({ module[$0, in: insertionFunction!] is AllocStack }))
     insert(DeallocStack(location: source, site: currentSource))
   }
 
@@ -3764,7 +3764,7 @@ extension Emitter {
   }
 
   fileprivate mutating func _end_access(_ x: Operand) {
-    precondition(x.instruction.map({ module[insertionFunction!][$0] is Access }) ?? false)
+    precondition(x.instruction.satisfies({ module[insertionFunction!][$0] is Access }))
     insert(EndAccess(start: x, site: currentSource))
   }
 
@@ -3793,7 +3793,7 @@ extension Emitter {
   }
 
   fileprivate mutating func _close_union(_ x: Operand  ) {
-    precondition(x.instruction.map({ module[insertionFunction!][$0] is OpenUnion }) ?? false)
+    precondition(x.instruction.satisfies({ module[insertionFunction!][$0] is OpenUnion }))
     insert(CloseUnion(start: x, site: currentSource))
   }
 
@@ -3862,7 +3862,7 @@ extension Emitter {
   }
 
   fileprivate mutating func _release_capture(_ source: Operand) {
-    precondition(source.instruction.map({ module[insertionFunction!][$0] is AllocStack }) ?? false)
+    precondition(source.instruction.satisfies({ module[insertionFunction!][$0] is AllocStack }))
     insert(ReleaseCaptures(container: source, site: currentSource))
   }
 

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -105,7 +105,7 @@ extension IR.Program {
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
         let ir = target[g]
-        precondition(x0.instruction.map({ ir[$0] is OpenCapture }) ?? false)
+        precondition(x0.instruction.satisfies({ ir[$0] is OpenCapture }))
         return CloseCapture(start: x0, site: s.site)
       }
 

--- a/Sources/IR/Operands/Instruction/Access.swift
+++ b/Sources/IR/Operands/Instruction/Access.swift
@@ -30,15 +30,17 @@ public struct Access: RegionEntry {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     capabilities: AccessEffectSet,
-    accessedType: AnyType,
+    accessedType: IR.`Type`,
     source: Operand,
-    binding: VarDecl.ID?,
+    binding: VarDecl.ID? = nil,
     site: SourceRange
   ) {
+    precondition(!capabilities.isEmpty)
+    precondition(accessedType.isAddress)
     self.capabilities = capabilities
-    self.accessedType = accessedType
+    self.accessedType = accessedType.ast
     self.source = source
     self.binding = binding
     self.site = site
@@ -63,27 +65,6 @@ extension Access: CustomStringConvertible {
 
   public var description: String {
     "access \(capabilities) \(source)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `access` anchored at `site` that may take any of `capabilities` from `source`,
-  /// optionally associated with a variable declaration in the AST.
-  func makeAccess(
-    _ capabilities: AccessEffectSet, from source: Operand,
-    correspondingTo binding: VarDecl.ID? = nil,
-    in f: Function.ID, at site: SourceRange
-  ) -> Access {
-    precondition(!capabilities.isEmpty)
-    precondition(self[f].type(of: source).isAddress)
-    return .init(
-      capabilities: capabilities,
-      accessedType: self[f].type(of: source).ast,
-      source: source,
-      binding: binding,
-      site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AddressToPointer.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointer.swift
@@ -13,7 +13,7 @@ public struct AddressToPointer: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(source: Operand, site: SourceRange) {
+  init(source: Operand, site: SourceRange) {
     self.source = source
     self.site = site
   }
@@ -29,16 +29,6 @@ public struct AddressToPointer: Instruction {
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     precondition(i == 0)
     source = new
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `address_to_pointer` anchored at `site` that converts `source` to a built-in
-  /// pointer value.
-  func makeAddressToPointer(_ source: Operand, at site: SourceRange) -> AddressToPointer {
-    .init(source: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
@@ -13,7 +13,7 @@ public struct AdvancedByBytes: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     source: Operand,
     offset: Operand,
     site: SourceRange
@@ -42,23 +42,6 @@ extension AdvancedByBytes: CustomStringConvertible {
 
   public var description: String {
     "\(base) advanced by \(byteOffset) bytes"
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `advanced by bytes` instruction anchored at `site` computing the `source` address
-  /// value advanced by `offset` bytes.
-  func makeAdvancedByBytes(
-    source: Operand, offset: Operand, in f: Function.ID, at site: SourceRange
-  ) -> AdvancedByBytes {
-    precondition(self[f].type(of: source).isAddress)
-    precondition(self[f].type(of: offset).isAddress)
-    return .init(
-      source: source,
-      offset: offset,
-      site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
@@ -19,7 +19,7 @@ public struct AdvancedByStrides: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     source: Operand,
     offset: Int,
     result: IR.`Type`,
@@ -46,32 +46,6 @@ extension AdvancedByStrides: CustomStringConvertible {
 
   public var description: String {
     "\(base) advanced by \(offset) strides"
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `advanced by strides` instruction anchored at `site` computing the `source`
-  /// address advanced by `n` strides of its referred type.
-  func makeAdvanced(
-    _ source: Operand, byStrides n: Int, in f: Function.ID, at site: SourceRange
-  ) -> AdvancedByStrides {
-    guard let b = sourceType(source, in: f) else {
-      preconditionFailure("source must be the address of a buffer")
-    }
-
-    return .init(source: source, offset: n, result: .address(b.element), site: site)
-  }
-
-  /// Returns the AST type of `source` iff it is the address of a buffer.
-  private func sourceType(_ source: Operand, in f: Function.ID) -> BufferType? {
-    let s = self[f].type(of: source)
-    if s.isAddress {
-      return BufferType(s.ast)
-    } else {
-      return nil
-    }
   }
 
 }

--- a/Sources/IR/Operands/Instruction/AllocStack.swift
+++ b/Sources/IR/Operands/Instruction/AllocStack.swift
@@ -10,7 +10,8 @@ public struct AllocStack: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(allocatedType: AnyType, site: SourceRange) {
+  init(allocatedType: AnyType, site: SourceRange) {
+    precondition(allocatedType.isCanonical)
     self.allocatedType = allocatedType
     self.site = site
   }
@@ -29,18 +30,6 @@ extension AllocStack: CustomStringConvertible {
 
   public var description: String {
     "alloc_stack \(allocatedType)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `alloc_stack` anchored at `site` that allocates storage of type `t`.
-  ///
-  /// - Requires: `t` is canonical.
-  func makeAllocStack(_ t: AnyType, at site: SourceRange) -> AllocStack {
-    precondition(t.isCanonical)
-    return .init(allocatedType: t, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Branch.swift
+++ b/Sources/IR/Operands/Instruction/Branch.swift
@@ -10,7 +10,7 @@ public struct Branch: Terminator {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(target: Block.ID, site: SourceRange) {
+  init(target: Block.ID, site: SourceRange) {
     self.target = target
     self.site = site
   }
@@ -36,18 +36,6 @@ extension Branch: CustomStringConvertible {
 
   public var description: String {
     "branch \(target)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `branch` anchored at `site` that unconditionally jumps at the start of a block.
-  ///
-  /// - Parameters:
-  ///   - target: The block in which control flow jumps.
-  func makeBranch(to target: Block.ID, at anchor: SourceRange) -> Branch {
-    .init(target: target, site: anchor)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Call.swift
+++ b/Sources/IR/Operands/Instruction/Call.swift
@@ -14,7 +14,7 @@ public struct Call: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     callee: Operand,
     output: Operand,
     arguments: [Operand],
@@ -52,29 +52,6 @@ extension Call: CustomStringConvertible {
 
   public var description: String {
     "call \(callee)(\(list: arguments)) to \(output)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `call` anchored at `site` that applies `callee` on `arguments` and writes its
-  /// result to `output`.
-  ///
-  /// - Parameters:
-  ///   - callee: The function to call.
-  ///   - output: The location at which the result of `callee` is stored.
-  ///   - arguments: The arguments of the call; one for each input of `callee`'s type.
-  func makeCall(
-    applying callee: Operand, to arguments: [Operand], writingResultTo output: Operand,
-    in f: Function.ID, at site: SourceRange
-  ) -> Call {
-    let t = ArrowType(self[f].type(of: callee).ast)!.strippingEnvironment
-    precondition(t.inputs.count == arguments.count)
-    precondition(arguments.allSatisfy({ self[$0, in: f] is Access }))
-    precondition(self[f].isBorrowSet(output))
-
-    return .init(callee: callee, output: output, arguments: arguments, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallBuiltinFunction.swift
+++ b/Sources/IR/Operands/Instruction/CallBuiltinFunction.swift
@@ -13,7 +13,7 @@ public struct CallBuiltinFunction: Instruction {
   public let site: SourceRange
 
   /// An instance with the given properties.
-  fileprivate init(applying s: BuiltinFunction, to operands: [Operand], site: SourceRange) {
+  init(applying s: BuiltinFunction, to operands: [Operand], site: SourceRange) {
     self.callee = s
     self.operands = operands
     self.site = site
@@ -33,27 +33,6 @@ extension CallBuiltinFunction: CustomStringConvertible {
 
   public var description: String {
     operands.isEmpty ? "\(callee)" : "\(callee) \(list: operands)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates an instruction anchored at `site` that applies `f` to `operands`.
-  ///
-  /// - Parameters:
-  ///   - f: A built-in function.
-  ///   - operands: A collection of built-in objects.
-  func makeCallBuiltin(
-    applying s: BuiltinFunction, to operands: [Operand], in f: Function.ID, at site: SourceRange
-  ) -> CallBuiltinFunction {
-    precondition(
-      operands.allSatisfy { (o) in
-        let t = self[f].type(of: o)
-        return t.isObject && (t.ast.base is BuiltinType)
-      })
-
-    return .init(applying: s, to: operands, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallBundle.swift
+++ b/Sources/IR/Operands/Instruction/CallBundle.swift
@@ -20,7 +20,7 @@ public struct CallBundle: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     bundle: BundleReference<MethodDecl>,
     bundleType: MethodType,
     variants: [AccessEffect: Function.ID],
@@ -56,38 +56,6 @@ extension CallBundle: CustomStringConvertible {
 
   public var description: String {
     "call_bundle \(capabilities) \(bundle)(\(list: arguments)) to \(output)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `call_bundle` anchored at `site` that applies one of the variants defined in `m` to
-  /// arguments `a`, canonicalizing types in `scopeOfUse`.
-  mutating func makeCallBundle(
-    applying m: BundleReference<MethodDecl>, to a: [Operand],
-    writingResultTo o: Operand,
-    in f: Function.ID,
-    at site: SourceRange,
-    canonicalizingTypesIn scopeOfUse: AnyScopeID
-  ) -> CallBundle {
-    var variants: [AccessEffect: Function.ID] = [:]
-    for v in program[m.bundle].impls {
-      let i = program[v].introducer.value
-      if m.capabilities.contains(i) {
-        variants[program[v].introducer.value] = demandDeclaration(lowering: v)
-      }
-    }
-
-    precondition(variants.count > 1)
-
-    let t = MethodType(
-      program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!
-    precondition((t.inputs.count + 1) == a.count)
-    precondition(a.allSatisfy({ self[$0, in: f] is Access }))
-    precondition(self[f].isBorrowSet(o))
-
-    return .init(bundle: m, bundleType: t, variants: variants, output: o, arguments: a, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CallFFI.swift
+++ b/Sources/IR/Operands/Instruction/CallFFI.swift
@@ -17,7 +17,7 @@ public struct CallFFI: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     returnType: IR.`Type`,
     callee: String,
     arguments: [Operand],
@@ -44,26 +44,6 @@ extension CallFFI: CustomStringConvertible {
   public var description: String {
     let s = "call_ffi \(callee)"
     return operands.isEmpty ? s : "\(s), \(list: operands)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `call_ffi` anchored at `site` that applies `callee` on `arguments` using to return
-  /// and returns a value of `returnType`.
-  ///
-  /// - Parameters:
-  ///   - returnType: The return type of the callee.
-  ///   - callee: The name of the foreign function to call
-  ///   - arguments: The arguments of the call.
-  func makeCallFFI(
-    returning returnType: IR.`Type`, applying callee: String, to arguments: [Operand],
-    in f: Function.ID, at site: SourceRange
-  ) -> CallFFI {
-    precondition(returnType.isObject)
-    precondition(arguments.allSatisfy({ self[$0, in: f] is Load }))
-    return .init(returnType: returnType, callee: callee, arguments: arguments, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CaptureIn.swift
+++ b/Sources/IR/Operands/Instruction/CaptureIn.swift
@@ -16,7 +16,7 @@ public struct CaptureIn: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(source: Operand, target: Operand, site: SourceRange) {
+  init(source: Operand, target: Operand, site: SourceRange) {
     self.operands = [source, target]
     self.site = site
   }
@@ -37,18 +37,6 @@ extension CaptureIn: CustomStringConvertible {
 
   public var description: String {
     "capture \(source) in \(target)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `capture ... in` anchored at `site` that captures `source`, which is an access, and
-  /// stores it in `target`.
-  func makeCapture(_ source: Operand, in target: Operand, in f: Function.ID, at site: SourceRange) -> CaptureIn {
-    precondition(self[f].type(of: source).isAddress)
-    precondition(self[f].type(of: target).isAddress)
-    return .init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CloseCapture.swift
+++ b/Sources/IR/Operands/Instruction/CloseCapture.swift
@@ -2,12 +2,3 @@ import FrontEnd
 
 /// Ends the lifetime of a projection.
 public typealias CloseCapture = RegionExit<OpenCapture>
-
-extension Module {
-
-  /// Creates a `close_capture` anchored at `site` that ends the exposition of a captured access.
-  func makeCloseCapture(_ start: Operand, in f: Function.ID, at site: SourceRange) -> CloseCapture {
-    makeRegionExit(start, in: f, at: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/CloseUnion.swift
+++ b/Sources/IR/Operands/Instruction/CloseUnion.swift
@@ -2,13 +2,3 @@ import FrontEnd
 
 /// Ends the lifetime of a projection.
 public typealias CloseUnion = RegionExit<OpenUnion>
-
-extension Module {
-
-  /// Creates an `close_union` anchored at `site` that ends an access to the payload of a union
-  /// opened previously by `start`.
-  func makeCloseUnion(_ start: Operand, in f: Function.ID, at site: SourceRange) -> CloseUnion {
-    makeRegionExit(start, in: f, at: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/CondBranch.swift
+++ b/Sources/IR/Operands/Instruction/CondBranch.swift
@@ -16,7 +16,7 @@ public struct CondBranch: Terminator {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     condition: Operand,
     targetIfTrue: Block.ID,
     targetIfFalse: Block.ID,
@@ -57,33 +57,6 @@ extension CondBranch: CustomStringConvertible {
 
   public var description: String {
     "cond_branch \(condition), \(targetIfTrue), \(targetIfFalse)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `cond_branch` anchored at `site` that jumps to `targetIfTrue` if `condition` is
-  /// true or `targetIfFalse` otherwise.
-  ///
-  /// - Parameters:
-  ///   - condition: The condition tested to select the jump destination. Must a built-in `i1`
-  ///     object.
-  ///   - targetIfTrue: The block in which control flow jumps if `condition` is true.
-  ///   - targetIfFalse: The block in which control flow jumps if `condition` is false.
-  func makeCondBranch(
-    if condition: Operand,
-    then targetIfTrue: Block.ID,
-    else targetIfFalse: Block.ID,
-    in f: Function.ID,
-    at site: SourceRange
-  ) -> CondBranch {
-    precondition(self[f].type(of: condition) == .object(BuiltinType.i(1)))
-    return .init(
-      condition: condition,
-      targetIfTrue: targetIfTrue,
-      targetIfFalse: targetIfFalse,
-      site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/ConstantString.swift
+++ b/Sources/IR/Operands/Instruction/ConstantString.swift
@@ -13,7 +13,7 @@ public struct ConstantString: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(value: Data, site: SourceRange) {
+  init(value: Data, site: SourceRange) {
     self.value = value
     self.site = site
   }
@@ -34,16 +34,6 @@ extension ConstantString: CustomStringConvertible {
 
   public var description: String {
     "constant_string \(String(data: value, encoding: .utf8)!.debugDescription)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `constant_string` anchored at `site` that returns a  string with given `value`,
-  /// encoded in UTF8.
-  func makeConstantString(utf8 value: Data, at site: SourceRange) -> ConstantString {
-    .init(value: value, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/DeallocStack.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStack.swift
@@ -10,7 +10,7 @@ public struct DeallocStack: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(location: Operand, site: SourceRange) {
+  init(location: Operand, site: SourceRange) {
     self.location = location
     self.site = site
   }
@@ -22,19 +22,6 @@ public struct DeallocStack: Instruction {
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     precondition(i == 0)
     location = new
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `dealloc_stack` anchored at `site` that deallocates memory allocated by `alloc`.
-  ///
-  /// - Parameters:
-  ///   - alloc: The address of the memory to deallocate. Must be the result of `alloc`.
-  func makeDeallocStack(for alloc: Operand, in f: Function.ID, at site: SourceRange) -> DeallocStack {
-    precondition(alloc.instruction.map({ self[$0, in: f] is AllocStack }) ?? false)
-    return .init(location: alloc, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/EndAccess.swift
+++ b/Sources/IR/Operands/Instruction/EndAccess.swift
@@ -2,12 +2,3 @@ import FrontEnd
 
 /// Ends the lifetime of a projection.
 public typealias EndAccess = RegionExit<Access>
-
-extension Module {
-
-  /// Creates an `end_access` anchored at `site` that ends the projection created by `start`.
-  func makeEndAccess(_ start: Operand, in f: Function.ID, at site: SourceRange) -> EndAccess {
-    makeRegionExit(start, in: f, at: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/EndProject.swift
+++ b/Sources/IR/Operands/Instruction/EndProject.swift
@@ -2,12 +2,3 @@ import FrontEnd
 
 /// Ends the lifetime of a projection.
 public typealias EndProject = RegionExit<Project>
-
-extension Module {
-
-  /// Creates an `end_project` anchored at `site` that ends the projection created by `start`.
-  func makeEndProject(_ start: Operand, in f: Function.ID, at site: SourceRange) -> EndProject {
-    makeRegionExit(start, in: f, at: site)
-  }
-
-}

--- a/Sources/IR/Operands/Instruction/GenericParameter.swift
+++ b/Sources/IR/Operands/Instruction/GenericParameter.swift
@@ -13,7 +13,7 @@ public struct GenericParameter: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     parameter: GenericParameterDecl.ID,
     result: IR.`Type`,
     site: SourceRange
@@ -33,18 +33,6 @@ extension GenericParameter: CustomStringConvertible {
 
   public var description: String {
     "generic_parameter @\(parameter)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `generic_parameter` anchored at `site` that returns the address of the generic
-  /// argument passed to `p`.
-  func makeGenericParameter(
-    passedTo p: GenericParameterDecl.ID, at site: SourceRange
-  ) -> GenericParameter {
-    .init(parameter: p, result: .address(program[p].type), site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/GlobalAddr.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddr.swift
@@ -13,7 +13,7 @@ public struct GlobalAddr: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     binding: BindingDecl.ID,
     valueType: AnyType,
     site: SourceRange
@@ -37,16 +37,6 @@ extension GlobalAddr: CustomStringConvertible {
 
   public var description: String {
     "global_addr @\(binding)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `global_addr` anchored at `site` that returns the address of `binding`.
-  func makeGlobalAddr(of binding: BindingDecl.ID, at anchor: SourceRange) -> GlobalAddr {
-    let t = program.canonical(program[binding].type, in: program[binding].scope)
-    return .init(binding: binding, valueType: t, site: anchor)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Load.swift
+++ b/Sources/IR/Operands/Instruction/Load.swift
@@ -13,7 +13,7 @@ public struct Load: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(objectType: IR.`Type`, from source: Operand, site: SourceRange) {
+  init(objectType: IR.`Type`, from source: Operand, site: SourceRange) {
     self.objectType = objectType
     self.source = source
     self.site = site
@@ -30,20 +30,6 @@ public struct Load: Instruction {
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     precondition(i == 0)
     source = new
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `load` anchored at `site` that loads the object at `source`.
-  ///
-  /// - Parameters:
-  ///   - source: The location from which the object is loaded. Must be the result of an `access`
-  ///     instruction requesting a `sink` capability.
-  func makeLoad(_ source: Operand, in f: Function.ID, at site: SourceRange) -> Load {
-    precondition(self[source, in: f] is Access)
-    return .init(objectType: .object(self[f].type(of: source).ast), from: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MarkState.swift
+++ b/Sources/IR/Operands/Instruction/MarkState.swift
@@ -13,7 +13,7 @@ public struct MarkState: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(storage: Operand, initialized: Bool, site: SourceRange) {
+  init(storage: Operand, initialized: Bool, site: SourceRange) {
     self.storage = storage
     self.initialized = initialized
     self.site = site
@@ -35,17 +35,6 @@ extension MarkState: CustomStringConvertible {
   public var description: String {
     let s = initialized ? "initialized" : "deinitialized"
     return "mark_state \(s) \(storage)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `mark_state` instruction anchored at `site` that marks `storage` has being fully
-  /// initialized if `initialized` is `true` or fully uninitialized otherwise.
-  func makeMarkState(_ storage: Operand, initialized: Bool, in f: Function.ID, at site: SourceRange) -> MarkState {
-    precondition(self[f].type(of: storage).isAddress)
-    return .init(storage: storage, initialized: initialized, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MemoryCopy.swift
+++ b/Sources/IR/Operands/Instruction/MemoryCopy.swift
@@ -10,7 +10,7 @@ public struct MemoryCopy: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(source: Operand, target: Operand, site: SourceRange) {
+  init(source: Operand, target: Operand, site: SourceRange) {
     self.operands = [source, target]
     self.site = site
   }
@@ -23,21 +23,6 @@ public struct MemoryCopy: Instruction {
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `memory_copy` anchored at `site` that copies the memory representation of the
-  /// value stored at `source` to `target`.
-  ///
-  /// - Requires: `source` is a `let`-capable access and `target` is a `set`-capable access.
-  ///   `source` and `target` have the same type.
-  func makeMemoryCopy(_ source: Operand, _ target: Operand, in f: Function.ID, at site: SourceRange) -> MemoryCopy {
-    let s = self[f].type(of: source)
-    precondition(s.isAddress && (s == self[f].type(of: target)))
-    return .init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Move.swift
+++ b/Sources/IR/Operands/Instruction/Move.swift
@@ -16,9 +16,7 @@ public struct Move: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
-    object: Operand, target: Operand, movable: FrontEnd.Conformance, site: SourceRange
-  ) {
+  init(object: Operand, target: Operand, movable: FrontEnd.Conformance, site: SourceRange) {
     self.object = object
     self.target = target
     self.movable = movable
@@ -36,28 +34,6 @@ public struct Move: Instruction {
     default:
       preconditionFailure()
     }
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `move` anchored at `site` that moves `value` into `storage` using the move
-  /// operations defined by `movable`.
-  ///
-  /// This instruction is replaced during IR transformation by either the initialization or
-  /// assignment of `storage`, depending on its initialization state.
-  ///
-  /// - Parameters:
-  ///   - value: The object to move. Must have an address type.
-  ///   - storage: The location to initialize or assign. Must have an address type.
-  func makeMove(
-    _ value: Operand, to storage: Operand, usingConformance movable: FrontEnd.Conformance,
-    in f: Function.ID, at site: SourceRange
-  ) -> Move {
-    precondition(self[f].type(of: value).isAddress)
-    precondition(self[f].type(of: storage).isAddress)
-    return .init(object: value, target: storage, movable: movable, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/OpenCapture.swift
+++ b/Sources/IR/Operands/Instruction/OpenCapture.swift
@@ -16,7 +16,7 @@ public struct OpenCapture: RegionEntry {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(result: IR.`Type`, source: Operand, site: SourceRange) {
+  init(result: IR.`Type`, source: Operand, site: SourceRange) {
     self.result = result
     self.operands = [source]
     self.site = site
@@ -29,16 +29,6 @@ public struct OpenCapture: RegionEntry {
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[0] = new
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `open_capture` anchored at `site` that loads the address stored at `source`.
-  func makeOpenCapture(_ source: Operand, in f: Function.ID, at site: SourceRange) -> OpenCapture {
-    let t = RemoteType(self[f].type(of: source).ast) ?? preconditionFailure()
-    return .init(result: .address(t.bareType), source: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/OpenUnion.swift
+++ b/Sources/IR/Operands/Instruction/OpenUnion.swift
@@ -26,7 +26,7 @@ public struct OpenUnion: RegionEntry {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     container: Operand, payloadType: AnyType, isUsedForInitialization: Bool, site: SourceRange
   ) {
     self.container = container
@@ -58,29 +58,6 @@ extension OpenUnion: CustomStringConvertible {
     } else {
       return "open_union \(container) as \(payloadType)"
     }
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `open_union` anchored at `site` that projects the address of `container`'s payload
-  /// viewed as an instance of `payload`.
-  ///
-  /// If the bits of the union's discriminator are hidden in its storage, this function removes
-  /// them before projecting the address unless `isUsedForInitialization` is `true`.
-  func makeOpenUnion(
-    _ container: Operand, as payload: AnyType,
-    forInitialization isUsedForInitialization: Bool = false,
-    in f: Function.ID, at site: SourceRange
-  ) -> OpenUnion {
-    precondition(self[f].type(of: container).isAddress)
-    precondition(payload.isCanonical)
-    return .init(
-      container: container,
-      payloadType: payload,
-      isUsedForInitialization: isUsedForInitialization,
-      site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/PointerToAddress.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddress.swift
@@ -16,7 +16,7 @@ public struct PointerToAddress: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(source: Operand, target: RemoteType, site: SourceRange) {
+  init(source: Operand, target: RemoteType, site: SourceRange) {
     self.source = source
     self.target = target
     self.site = site
@@ -41,19 +41,6 @@ extension PointerToAddress: CustomStringConvertible {
 
   public var description: String {
     "pointer_to_address \(source) as \(target)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `pointer_to_address` anchored at `site` that converts `source`, which is a
-  /// built-in pointer value, to an address of type `target`.
-  func makePointerToAddress(
-    _ source: Operand, to target: RemoteType, at site: SourceRange
-  ) -> PointerToAddress {
-    precondition(target.access != .yielded)
-    return .init(source: source, target: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Project.swift
+++ b/Sources/IR/Operands/Instruction/Project.swift
@@ -24,7 +24,7 @@ public struct Project: RegionEntry {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     projection: RemoteType,
     callee: Function.ID,
     specialization: GenericArguments,
@@ -57,29 +57,6 @@ extension Project: CustomStringConvertible {
     } else {
       return "project \(callee), \(list: operands)"
     }
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
-  /// which is a reference to a lowered subscript, on `arguments`.
-  func makeProject(
-    _ t: RemoteType, applying s: FunctionReference, to arguments: [Operand], at site: SourceRange
-  ) -> Project {
-    .init(
-      projection: t, callee: s.function, specialization: s.specialization,
-      operands: arguments, site: site)
-  }
-
-  /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
-  /// which is a lowered subscript, specialized by `z`, on `arguments`.
-  func makeProject(
-    _ t: RemoteType, applying s: Function.ID, specializedBy z: GenericArguments,
-    to arguments: [Operand], at site: SourceRange
-  ) -> Project {
-    .init(projection: t, callee: s, specialization: z, operands: arguments, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/ProjectBundle.swift
+++ b/Sources/IR/Operands/Instruction/ProjectBundle.swift
@@ -25,7 +25,7 @@ public struct ProjectBundle: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     bundle: BundleReference<SubscriptDecl>,
     variants: [AccessEffect: Function.ID],
     parameters: [ParameterType],
@@ -65,36 +65,6 @@ extension ProjectBundle: CustomStringConvertible {
     } else {
       return "project_bundle \(capabilities) \(bundle), \(list: operands)"
     }
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `project_bundle` anchored at `site` that applies one of the variants defined in `m`
-  /// to arguments `a`, canonicalizing types in `scopeOfUse`.
-  mutating func makeProjectBundle(
-    applying m: BundleReference<SubscriptDecl>, to a: [Operand],
-    at site: SourceRange,
-    canonicalizingTypesIn scopeOfUse: AnyScopeID
-  ) -> ProjectBundle {
-    var variants: [AccessEffect: Function.ID] = [:]
-    for v in program[m.bundle].impls {
-      let i = program[v].introducer.value
-      if m.capabilities.contains(i) {
-        variants[program[v].introducer.value] = demandDeclaration(lowering: v)
-      }
-    }
-    precondition(!variants.isEmpty)
-
-    let t = SubscriptType(
-      program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!.pure
-
-    return .init(
-      bundle: m, variants: variants,
-      parameters: t.inputs.lazy.map({ ParameterType($0.type)! }),
-      projection: RemoteType(t.output)!.bareType,
-      operands: a, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/RegionExit.swift
+++ b/Sources/IR/Operands/Instruction/RegionExit.swift
@@ -10,7 +10,7 @@ public struct RegionExit<Entry: RegionEntry> {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(start: Operand, site: SourceRange) {
+  init(start: Operand, site: SourceRange) {
     self.operands = [start]
     self.site = site
   }
@@ -41,18 +41,6 @@ extension RegionExit: CustomStringConvertible {
     default:
       return "end_region \(start)"
     }
-  }
-
-}
-
-extension Module {
-
-  /// Creates a region exit anchored at `site` marking an exit of the regions started by `start`.
-  func makeRegionExit<Entry: RegionEntry>(
-    _ start: Operand, in f: Function.ID, at anchor: SourceRange
-  ) -> RegionExit<Entry> {
-    precondition(start.instruction.map({ self[$0, in: f] is Entry }) ?? false)
-    return .init(start: start, site: anchor)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
+++ b/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
@@ -11,7 +11,7 @@ public struct ReleaseCaptures: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(container: Operand, site: SourceRange) {
+  init(container: Operand, site: SourceRange) {
     self.operands = [container]
     self.site = site
   }
@@ -21,17 +21,6 @@ public struct ReleaseCaptures: Instruction {
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `release_capture` anchored at `site` that releases the accesses previously captured
-  /// in `container`.
-  func makeReleaseCapture(_ container: Operand, in f: Function.ID, at site: SourceRange) -> ReleaseCaptures {
-    precondition(container.instruction.map({ self[$0, in: f] is AllocStack }) ?? false)
-    return .init(container: container, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Return.swift
+++ b/Sources/IR/Operands/Instruction/Return.swift
@@ -7,7 +7,7 @@ public struct Return: Terminator {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(site: SourceRange) {
+  init(site: SourceRange) {
     self.site = site
   }
 
@@ -19,15 +19,6 @@ public struct Return: Terminator {
 
   func replaceSuccessor(_ old: Block.ID, with new: Block.ID) -> Bool {
     false
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `return` anchored at `site`.
-  func makeReturn(at site: SourceRange) -> Return {
-    .init(site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Store.swift
+++ b/Sources/IR/Operands/Instruction/Store.swift
@@ -13,7 +13,7 @@ public struct Store: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(object: Operand, at target: Operand, site: SourceRange) {
+  init(object: Operand, at target: Operand, site: SourceRange) {
     self.object = object
     self.target = target
     self.site = site
@@ -30,21 +30,6 @@ public struct Store: Instruction {
     default:
       preconditionFailure()
     }
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `record` anchored at `site` that stores `object` at `target.
-  ///
-  /// - Parameters:
-  ///   - object: The object to store. Must have an object type.
-  ///   - target: The location at which `object` is stored. Must have an address type.
-  func makeStore(_ object: Operand, at target: Operand, in f: Function.ID, at site: SourceRange) -> Store {
-    precondition(self[f].type(of: object).isObject)
-    precondition(self[f].type(of: target).isAddress)
-    return .init(object: object, at: target, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/SubfieldView.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldView.swift
@@ -18,7 +18,7 @@ public struct SubfieldView: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(
+  init(
     base: Operand,
     subfield: RecordPath,
     subfieldType: IR.`Type`,
@@ -49,28 +49,6 @@ extension SubfieldView: CustomStringConvertible {
 
   public var description: String {
     "subfield_view \(recordAddress)\(subfield.isEmpty ? "" : ", ")\(list: subfield)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `subfield_view` anchored at `site` computing the address of the given `subfield` of
-  /// some record at `recordAddress`.
-  ///
-  /// - Note: `base` is returned unchanged if `elementPath` is empty.
-  func makeSubfieldView(
-    of recordAddress: Operand, subfield elementPath: RecordPath, in f: Function.ID, at site: SourceRange
-  ) -> SubfieldView {
-    precondition(self[f].type(of: recordAddress).isAddress)
-    let l = AbstractTypeLayout(of: self[f].type(of: recordAddress).ast, definedIn: program)
-    let t = l[elementPath].type
-
-    return .init(
-      base: recordAddress,
-      subfield: elementPath,
-      subfieldType: .address(t),
-      site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Switch.swift
+++ b/Sources/IR/Operands/Instruction/Switch.swift
@@ -13,7 +13,7 @@ public struct Switch: Terminator {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(index: Operand, successors: [Block.ID], site: SourceRange) {
+  init(index: Operand, successors: [Block.ID], site: SourceRange) {
     self.index = index
     self.successors = successors
     self.site = site
@@ -44,24 +44,6 @@ extension Switch: CustomStringConvertible {
 
   public var description: String {
     "switch \(index), \(list: successors)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `switch` anchored at `site` that jumps to `successors[i]`.
-  ///
-  /// - Requires: `i` is a valid index in `successors`, expressed as a built-in integer, and
-  ///   `successors` is not empty.
-  func makeSwitch(
-    on index: Operand, toOneOf successors: [Block.ID], in f: Function.ID, at site: SourceRange
-  ) -> Switch {
-    let t = self[f].type(of: index)
-    precondition(t.isObject && t.ast.isBuiltinInteger)
-    precondition(!successors.isEmpty)
-
-    return .init(index: index, successors: successors, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
+++ b/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
@@ -10,7 +10,7 @@ public struct UnionDiscriminator: Instruction {
   public var site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(container: Operand, site: SourceRange) {
+  init(container: Operand, site: SourceRange) {
     self.container = container
     self.site = site
   }
@@ -26,19 +26,6 @@ public struct UnionDiscriminator: Instruction {
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     precondition(i == 0)
     container = new
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `union_discriminator` anchored at `site` that returns the discriminator of the
-  /// element stored in `container`.
-  func makeUnionDiscriminator(
-    _ container: Operand, in f: Function.ID, at site: SourceRange
-  ) -> UnionDiscriminator {
-    precondition(self[f].type(of: container).isAddress)
-    return .init(container: container, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/UnionSwitch.swift
+++ b/Sources/IR/Operands/Instruction/UnionSwitch.swift
@@ -20,7 +20,7 @@ public struct UnionSwitch: Terminator {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(discriminator: Operand, union: UnionType, targets: Targets, site: SourceRange) {
+  init(discriminator: Operand, union: UnionType, targets: Targets, site: SourceRange) {
     self.discriminator = discriminator
     self.union = union
     self.targets = targets
@@ -59,27 +59,6 @@ extension UnionSwitch: CustomStringConvertible {
       s.write(", \(t) => \(b)")
     }
     return s
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `union_switch` anchored at `site` that switches over `discriminator`, which is the
-  /// discriminator of a container of type `union`, jumping to corresponding block in `target`.
-  ///
-  /// If `union` is generic, `discriminator` should be the result of `union_discriminator` rather
-  /// than a constant.
-  ///
-  /// - Requires: `targets` has a key defined for each of `union`.
-  func makeUnionSwitch(
-    over discriminator: Operand, of union: UnionType, toOneOf targets: UnionSwitch.Targets,
-    in f: Function.ID, at site: SourceRange
-  ) -> UnionSwitch {
-    let t = self[f].type(of: discriminator)
-    precondition(t.isObject && t.ast.isBuiltinInteger)
-    precondition(union.elements.allSatisfy({ (e) in targets[e] != nil }))
-    return .init(discriminator: discriminator, union: union, targets: targets, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Unreachable.swift
+++ b/Sources/IR/Operands/Instruction/Unreachable.swift
@@ -7,7 +7,7 @@ public struct Unreachable: Terminator {
   public var site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(site: SourceRange) {
+  init(site: SourceRange) {
     self.site = site
   }
 
@@ -24,15 +24,6 @@ public struct Unreachable: Terminator {
 
   func replaceSuccessor(_ old: Block.ID, with new: Block.ID) -> Bool {
     false
-  }
-
-}
-
-extension Module {
-
-  /// Creates an `unreachable` anchored at `site` that marks the execution path unreachable.
-  func makeUnreachable(at site: SourceRange) -> Unreachable {
-    .init(site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
@@ -17,7 +17,7 @@ public struct WrapExistentialAddr: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(witness: Operand, table: Operand, interface: IR.`Type`, site: SourceRange) {
+  init(witness: Operand, table: Operand, interface: IR.`Type`, site: SourceRange) {
     self.witness = witness
     self.table = table
     self.interface = interface
@@ -47,25 +47,6 @@ extension WrapExistentialAddr: CustomStringConvertible {
 
   public var description: String {
     "wrap_existential_addr \(witness), \(table) as \(interface)"
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `wrap_existential_addr` anchored at `site` that creates an existential container of
-  /// type `interface` wrapping `witness` and `table`.
-  ///
-  /// - Parameters:
-  ///   - witness: The address of the object wrapped in the container.
-  ///   - interface: The type of the container.
-  ///   - table: The witness table of the wrapped value. Must be a pointer to a witness table.
-  func makeWrapExistentialAddr(
-    _ witness: Operand, _ table: Operand, as interface: ExistentialType,
-    in f: Function.ID, at site: SourceRange
-  ) -> WrapExistentialAddr {
-    precondition(self[f].type(of: witness).isAddress)
-    return .init(witness: witness, table: table, interface: .address(interface), site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/Yield.swift
+++ b/Sources/IR/Operands/Instruction/Yield.swift
@@ -13,7 +13,7 @@ public struct Yield: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(capability: AccessEffect, projection: Operand, site: SourceRange) {
+  init(capability: AccessEffect, projection: Operand, site: SourceRange) {
     self.capability = capability
     self.projection = projection
     self.site = site
@@ -32,16 +32,6 @@ public struct Yield: Instruction {
 
   func replaceSuccessor(_ old: Block.ID, _ new: Block.ID) -> Bool {
     false
-  }
-
-}
-
-extension Module {
-
-  /// Creates a `yield` anchored at `site` that projects `a` with capability `c`.
-  func makeYield(_ c: AccessEffect, _ a: Operand, in f: Function.ID, at site: SourceRange) -> Yield {
-    precondition(self[f].type(of: a).isAddress)
-    return .init(capability: c, projection: a, site: site)
   }
 
 }

--- a/Sources/Utils/Optional+Extensions.swift
+++ b/Sources/Utils/Optional+Extensions.swift
@@ -25,4 +25,9 @@ extension Optional {
     map(transform) ?? defaultValue()
   }
 
+  /// Returns the result of `predicate` applied to the wrapped value if `self` is not `nil`;
+  /// returns `false` otherwise.
+  public func satisfies(_ predicate: (Wrapped) throws -> Bool) rethrows -> Bool {
+    if let w = self { try predicate(w) } else { false }
+  }
 }


### PR DESCRIPTION
Remove the `makeXXX` functions from `Module` that create IR instructions.

Replaced them with direct constructor access.
It is envisioned that most of the IR instruction creation is done through
`Emitter`.