### PR TITLE
Move the `makeXXX` functions from `Module` to `Function`.

### DIFF
--- a/Sources/IR/Analysis/Module+AccessReification.swift
+++ b/Sources/IR/Analysis/Module+AccessReification.swift
@@ -131,7 +131,7 @@ extension Module {
     // Nothing to do if the request set is already a singleton.
     if s.capabilities == [k] { return }
 
-    let reified = makeAccess([k], from: s.source, correspondingTo: s.binding, in: f, at: s.site)
+    let reified = self[f].makeAccess([k], from: s.source, correspondingTo: s.binding, at: s.site)
     self[f].replace(i, with: reified)
   }
 
@@ -143,12 +143,12 @@ extension Module {
     // Generate the proper instructions to prepare the projection's arguments.
     var arguments = s.operands
     for a in arguments.indices where s.parameters[a].access == .yielded {
-      let b = makeAccess([k], from: arguments[a], in: f, at: s.site)
+      let b = self[f].makeAccess([k], from: arguments[a], at: s.site)
       arguments[a] = .register(self[f].insert(b, at: .before(i)))
     }
 
     let o = RemoteType(k, s.projection)
-    let reified = makeProject(
+    let reified = self[f].makeProject(
       o, applying: s.variants[k]!, specializedBy: s.bundle.arguments, to: arguments, at: s.site)
     self[f].replace(i, with: reified)
   }

--- a/Sources/IR/Analysis/Module+CallBundleReification.swift
+++ b/Sources/IR/Analysis/Module+CallBundleReification.swift
@@ -17,15 +17,15 @@ extension Module {
     let k = s.capabilities.weakest!
 
     var arguments = Array(s.arguments)
-    let r = makeAccess([k], from: arguments[0], in: f, at: s.site)
+    let r = self[f].makeAccess([k], from: arguments[0], at: s.site)
     arguments[0] = .register(self[f].insert(r, at: .before(i)))
 
     let b = Block.ID(containing: i)
     let x = FunctionReference(
       to: s.variants[k]!, in: self, specializedBy: s.bundle.arguments, in: self[b, in: f].scope)
 
-    let reified = makeCall(
-      applying: .constant(x), to: arguments, writingResultTo: s.output, in: f, at: s.site)
+    let reified = self[f].makeCall(
+      applying: .constant(x), to: arguments, writingResultTo: s.output, at: s.site)
     self[f].replace(i, with: reified)
   }
 

--- a/Sources/IR/Analysis/Module+CloseBorrows.swift
+++ b/Sources/IR/Analysis/Module+CloseBorrows.swift
@@ -32,25 +32,25 @@ extension Module {
       }
 
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeEndAccess(.register(i), in: f, at: site)
+        this[f].makeEndAccess(.register(i), at: site)
       }
 
     case is OpenCapture:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeCloseCapture(.register(i), in: f, at: site)
+        this[f].makeCloseCapture(.register(i), at: site)
       }
 
     case is OpenUnion:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeCloseUnion(.register(i), in: f, at: site)
+        this[f].makeCloseUnion(.register(i), at: site)
       }
 
     case is Project:
       let region = extendedLiveRange(of: .register(i), in: f)
       insertClose(i, in: f, atBoundariesOf: region) { (this, site) in
-        this.makeEndProject(.register(i), in: f, at: site)
+        this[f].makeEndProject(.register(i), at: site)
       }
 
     default:

--- a/Sources/IR/Analysis/Module+DeadCodeElimination.swift
+++ b/Sources/IR/Analysis/Module+DeadCodeElimination.swift
@@ -64,7 +64,7 @@ extension Module {
     for b in self[f].blockIDs {
       if let i = self[f].instructions(in: b).first(where: { returnsNever($0, in: f) }) {
         self[f].removeAllInstructions(after: i)
-        self[f].insert(makeUnreachable(at: self[i, in: f].site), at: .after(i))
+        self[f].insert(self[f].makeUnreachable(at: self[i, in: f].site), at: .after(i))
       }
     }
   }

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -41,38 +41,38 @@ extension IR.Program {
     case let s as Access:
       let x0 = t.transform(s.source, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeAccess(s.capabilities, from: x0, in: g, at: s.site)
+        target[g].makeAccess(s.capabilities, from: x0, at: s.site)
       }
 
     case let s as AddressToPointer:
       let x0 = t.transform(s.source, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeAddressToPointer(x0, at: s.site)
+        target[g].makeAddressToPointer(x0, at: s.site)
       }
 
     case let s as AdvancedByBytes:
       let x0 = t.transform(s.base, in: &self)
       let x1 = t.transform(s.byteOffset, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeAdvancedByBytes(source: x0, offset: x1, in: g, at: s.site)
+        target[g].makeAdvancedByBytes(source: x0, offset: x1, at: s.site)
       }
 
     case let s as AdvancedByStrides:
       let x0 = t.transform(s.base, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeAdvanced(x0, byStrides: s.offset, in: g, at: s.site)
+        target[g].makeAdvanced(x0, byStrides: s.offset, at: s.site)
       }
 
     case let s as AllocStack:
       let x0 = t.transform(s.allocatedType, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeAllocStack(x0, at: s.site)
+        target[g].makeAllocStack(x0, at: s.site)
       }
 
     case let s as Branch:
       let x0 = t.transform(s.target, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeBranch(to: x0, at: s.site)
+        target[g].makeBranch(to: x0, at: s.site)
       }
 
     case let s as Call:
@@ -80,33 +80,33 @@ extension IR.Program {
       let x1 = t.transform(s.arguments, in: &self)
       let x2 = t.transform(s.output, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeCall(applying: x0, to: x1, writingResultTo: x2, in: g, at: s.site)
+        target[g].makeCall(applying: x0, to: x1, writingResultTo: x2, at: s.site)
       }
 
     case let s as CallFFI:
       let x0 = t.transform(s.returnType, in: &self)
       let x1 = t.transform(s.operands, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeCallFFI(returning: x0, applying: s.callee, to: x1, in: g, at: s.site)
+        target[g].makeCallFFI(returning: x0, applying: s.callee, to: x1, at: s.site)
       }
 
     case let s as CaptureIn:
       let x0 = t.transform(s.source, in: &self)
       let x1 = t.transform(s.target, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeCapture(x0, in: x1, in: g, at: s.site)
+        target[g].makeCapture(x0, in: x1, at: s.site)
       }
 
     case let s as CloseCapture:
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeCloseCapture(x0, in: g, at: s.site)
+        target[g].makeCloseCapture(x0, at: s.site)
       }
 
     case let s as CloseUnion:
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeCloseUnion(x0, in: g, at: s.site)
+        target[g].makeCloseUnion(x0, at: s.site)
       }
 
     case let s as CondBranch:
@@ -114,7 +114,7 @@ extension IR.Program {
       let x1 = t.transform(s.targetIfTrue, in: &self)
       let x2 = t.transform(s.targetIfFalse, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeCondBranch(if: x0, then: x1, else: x2, in: g, at: s.site)
+        target[g].makeCondBranch(if: x0, then: x1, else: x2, at: s.site)
       }
 
     case let s as ConstantString:
@@ -123,19 +123,19 @@ extension IR.Program {
     case let s as DeallocStack:
       let x0 = t.transform(s.location, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeDeallocStack(for: x0, in: g, at: s.site)
+        target[g].makeDeallocStack(for: x0, at: s.site)
       }
 
     case let s as EndAccess:
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeEndAccess(x0, in: g, at: s.site)
+        target[g].makeEndAccess(x0, at: s.site)
       }
 
     case let s as EndProject:
       let x0 = t.transform(s.start, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeEndProject(x0, in: g, at: s.site)
+        target[g].makeEndProject(x0, at: s.site)
       }
 
     case let s as GenericParameter:
@@ -147,46 +147,46 @@ extension IR.Program {
     case let s as CallBuiltinFunction:
       let x0 = t.transform(s.operands, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeCallBuiltin(applying: s.callee, to: x0, in: g, at: s.site)
+        target[g].makeCallBuiltin(applying: s.callee, to: x0, at: s.site)
       }
 
     case let s as MarkState:
       let x0 = t.transform(s.storage, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeMarkState(x0, initialized: s.initialized, in: g, at: s.site)
+        target[g].makeMarkState(x0, initialized: s.initialized, at: s.site)
       }
 
     case let s as MemoryCopy:
       let x0 = t.transform(s.source, in: &self)
       let x1 = t.transform(s.target, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeMemoryCopy(x0, x1, in: g, at: s.site)
+        target[g].makeMemoryCopy(x0, x1, at: s.site)
       }
 
     case let s as Load:
       let x0 = t.transform(s.source, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeLoad(x0, in: g, at: s.site)
+        target[g].makeLoad(x0, at: s.site)
       }
 
     case let s as OpenCapture:
       let x0 = t.transform(s.source, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeOpenCapture(x0, in: g, at: s.site)
+        target[g].makeOpenCapture(x0, at: s.site)
       }
 
     case let s as OpenUnion:
       let x0 = t.transform(s.container, in: &self)
       let x1 = t.transform(s.payloadType, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeOpenUnion(x0, as: x1, forInitialization: s.isUsedForInitialization, in: g, at: s.site)
+        target[g].makeOpenUnion(x0, as: x1, forInitialization: s.isUsedForInitialization, at: s.site)
       }
 
     case let s as PointerToAddress:
       let x0 = t.transform(s.source, in: &self)
       let x1 = RemoteType(t.transform(^s.target, in: &self))!
       return insert(at: p, in: g, in: n) { (target) in
-        target.makePointerToAddress(x0, to: x1, at: s.site)
+        target[g].makePointerToAddress(x0, to: x1, at: s.site)
       }
 
     case let s as Project:
@@ -199,7 +199,7 @@ extension IR.Program {
       let x0 = RemoteType(t.transform(^s.projection, in: &self))!
       let x1 = t.transform(s.operands, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeProject(
+        target[g].makeProject(
           x0, applying: newCallee.function, specializedBy: newCallee.specialization, to: x1,
           at: s.site)
       }
@@ -207,7 +207,7 @@ extension IR.Program {
     case let s as ReleaseCaptures:
       let x0 = t.transform(s.container, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeReleaseCapture(x0, in: g, at: s.site)
+        target[g].makeReleaseCapture(x0, at: s.site)
       }
 
     case let s as Return:
@@ -217,26 +217,27 @@ extension IR.Program {
       let x0 = t.transform(s.object, in: &self)
       let x1 = t.transform(s.target, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeStore(x0, at: x1, in: g, at: s.site)
+        target[g].makeStore(x0, at: x1, at: s.site)
       }
 
     case let s as SubfieldView:
       let x0 = t.transform(s.recordAddress, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeSubfieldView(of: x0, subfield: s.subfield, in: g, at: s.site)
+        let l = AbstractTypeLayout(of: target[g].type(of: x0).ast, definedIn: target.program)
+        return target[g].makeSubfieldView(of: x0, subfield: s.subfield, layout: l, at: s.site)
       }
 
     case let s as Switch:
       let x0 = t.transform(s.index, in: &self)
       let x1 = s.successors.map({ (b) in t.transform(b, in: &self) })
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeSwitch(on: x0, toOneOf: x1, in: g, at: s.site)
+        target[g].makeSwitch(on: x0, toOneOf: x1, at: s.site)
       }
 
     case let s as UnionDiscriminator:
       let x0 = t.transform(s.container, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeUnionDiscriminator(x0, in: g, at: s.site)
+        target[g].makeUnionDiscriminator(x0, at: s.site)
       }
 
     case let s as UnionSwitch:
@@ -246,7 +247,7 @@ extension IR.Program {
         _ = d[t.transform(kv.key, in: &self)].setIfNil(t.transform(kv.value, in: &self))
       }
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeUnionSwitch(over: x0, of: x1, toOneOf: x2, in: g, at: s.site)
+        target[g].makeUnionSwitch(over: x0, of: x1, toOneOf: x2, at: s.site)
       }
 
     case let s as Unreachable:
@@ -255,7 +256,7 @@ extension IR.Program {
     case let s as Yield:
       let x0 = t.transform(s.projection, in: &self)
       return insert(at: p, in: g, in: n) { (target) in
-        target.makeYield(s.capability, x0, in: g, at: s.site)
+        target[g].makeYield(s.capability, x0, at: s.site)
       }
 
     default:

--- a/Sources/IR/Operands/Instruction/Access.swift
+++ b/Sources/IR/Operands/Instruction/Access.swift
@@ -67,20 +67,20 @@ extension Access: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `access` anchored at `site` that may take any of `capabilities` from `source`,
   /// optionally associated with a variable declaration in the AST.
   func makeAccess(
     _ capabilities: AccessEffectSet, from source: Operand,
     correspondingTo binding: VarDecl.ID? = nil,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> Access {
     precondition(!capabilities.isEmpty)
-    precondition(self[f].type(of: source).isAddress)
+    precondition(type(of: source).isAddress)
     return .init(
       capabilities: capabilities,
-      accessedType: self[f].type(of: source).ast,
+      accessedType: type(of: source).ast,
       source: source,
       binding: binding,
       site: site)

--- a/Sources/IR/Operands/Instruction/AddressToPointer.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointer.swift
@@ -33,7 +33,7 @@ public struct AddressToPointer: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `address_to_pointer` anchored at `site` that converts `source` to a built-in
   /// pointer value.

--- a/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytes.swift
@@ -46,15 +46,15 @@ extension AdvancedByBytes: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `advanced by bytes` instruction anchored at `site` computing the `source` address
   /// value advanced by `offset` bytes.
   func makeAdvancedByBytes(
-    source: Operand, offset: Operand, in f: Function.ID, at site: SourceRange
+    source: Operand, offset: Operand, at site: SourceRange
   ) -> AdvancedByBytes {
-    precondition(self[f].type(of: source).isAddress)
-    precondition(self[f].type(of: offset).isAddress)
+    precondition(type(of: source).isAddress)
+    precondition(type(of: offset).isAddress)
     return .init(
       source: source,
       offset: offset,

--- a/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByStrides.swift
@@ -50,14 +50,14 @@ extension AdvancedByStrides: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `advanced by strides` instruction anchored at `site` computing the `source`
   /// address advanced by `n` strides of its referred type.
   func makeAdvanced(
-    _ source: Operand, byStrides n: Int, in f: Function.ID, at site: SourceRange
+    _ source: Operand, byStrides n: Int, at site: SourceRange
   ) -> AdvancedByStrides {
-    guard let b = sourceType(source, in: f) else {
+    guard let b = sourceType(source) else {
       preconditionFailure("source must be the address of a buffer")
     }
 
@@ -65,8 +65,8 @@ extension Module {
   }
 
   /// Returns the AST type of `source` iff it is the address of a buffer.
-  private func sourceType(_ source: Operand, in f: Function.ID) -> BufferType? {
-    let s = self[f].type(of: source)
+  private func sourceType(_ source: Operand) -> BufferType? {
+    let s = type(of: source)
     if s.isAddress {
       return BufferType(s.ast)
     } else {

--- a/Sources/IR/Operands/Instruction/AllocStack.swift
+++ b/Sources/IR/Operands/Instruction/AllocStack.swift
@@ -33,7 +33,7 @@ extension AllocStack: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `alloc_stack` anchored at `site` that allocates storage of type `t`.
   ///

--- a/Sources/IR/Operands/Instruction/Branch.swift
+++ b/Sources/IR/Operands/Instruction/Branch.swift
@@ -40,7 +40,7 @@ extension Branch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `branch` anchored at `site` that unconditionally jumps at the start of a block.
   ///

--- a/Sources/IR/Operands/Instruction/Call.swift
+++ b/Sources/IR/Operands/Instruction/Call.swift
@@ -56,7 +56,7 @@ extension Call: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `call` anchored at `site` that applies `callee` on `arguments` and writes its
   /// result to `output`.
@@ -67,12 +67,12 @@ extension Module {
   ///   - arguments: The arguments of the call; one for each input of `callee`'s type.
   func makeCall(
     applying callee: Operand, to arguments: [Operand], writingResultTo output: Operand,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> Call {
-    let t = ArrowType(self[f].type(of: callee).ast)!.strippingEnvironment
+    let t = ArrowType(type(of: callee).ast)!.strippingEnvironment
     precondition(t.inputs.count == arguments.count)
-    precondition(arguments.allSatisfy({ self[$0, in: f] is Access }))
-    precondition(self[f].isBorrowSet(output))
+    precondition(arguments.allSatisfy({ self[register: $0] is Access }))
+    precondition(isBorrowSet(output))
 
     return .init(callee: callee, output: output, arguments: arguments, site: site)
   }

--- a/Sources/IR/Operands/Instruction/CallBuiltinFunction.swift
+++ b/Sources/IR/Operands/Instruction/CallBuiltinFunction.swift
@@ -37,7 +37,7 @@ extension CallBuiltinFunction: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an instruction anchored at `site` that applies `f` to `operands`.
   ///
@@ -45,11 +45,11 @@ extension Module {
   ///   - f: A built-in function.
   ///   - operands: A collection of built-in objects.
   func makeCallBuiltin(
-    applying s: BuiltinFunction, to operands: [Operand], in f: Function.ID, at site: SourceRange
+    applying s: BuiltinFunction, to operands: [Operand], at site: SourceRange
   ) -> CallBuiltinFunction {
     precondition(
       operands.allSatisfy { (o) in
-        let t = self[f].type(of: o)
+        let t = type(of: o)
         return t.isObject && (t.ast.base is BuiltinType)
       })
 

--- a/Sources/IR/Operands/Instruction/CallBundle.swift
+++ b/Sources/IR/Operands/Instruction/CallBundle.swift
@@ -60,32 +60,23 @@ extension CallBundle: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
-  /// Creates a `call_bundle` anchored at `site` that applies one of the variants defined in `m` to
-  /// arguments `a`, canonicalizing types in `scopeOfUse`.
-  mutating func makeCallBundle(
-    applying m: BundleReference<MethodDecl>, to a: [Operand],
+  /// Creates a `call_bundle` anchored at `site` that applies one of the variants `variants`
+  /// defined in `m` of type `t`, to arguments `a`, canonicalizing types in `scopeOfUse`.
+  func makeCallBundle(
+    applying m: BundleReference<MethodDecl>,
+    bundleType t: MethodType,
+    using variants: [AccessEffect: Function.ID],
+    to a: [Operand],
     writingResultTo o: Operand,
-    in f: Function.ID,
     at site: SourceRange,
     canonicalizingTypesIn scopeOfUse: AnyScopeID
   ) -> CallBundle {
-    var variants: [AccessEffect: Function.ID] = [:]
-    for v in program[m.bundle].impls {
-      let i = program[v].introducer.value
-      if m.capabilities.contains(i) {
-        variants[program[v].introducer.value] = demandDeclaration(lowering: v)
-      }
-    }
-
     precondition(variants.count > 1)
-
-    let t = MethodType(
-      program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!
     precondition((t.inputs.count + 1) == a.count)
-    precondition(a.allSatisfy({ self[$0, in: f] is Access }))
-    precondition(self[f].isBorrowSet(o))
+    precondition(a.allSatisfy({ self[register: $0] is Access }))
+    precondition(isBorrowSet(o))
 
     return .init(bundle: m, bundleType: t, variants: variants, output: o, arguments: a, site: site)
   }

--- a/Sources/IR/Operands/Instruction/CallFFI.swift
+++ b/Sources/IR/Operands/Instruction/CallFFI.swift
@@ -48,7 +48,7 @@ extension CallFFI: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `call_ffi` anchored at `site` that applies `callee` on `arguments` using to return
   /// and returns a value of `returnType`.
@@ -59,10 +59,10 @@ extension Module {
   ///   - arguments: The arguments of the call.
   func makeCallFFI(
     returning returnType: IR.`Type`, applying callee: String, to arguments: [Operand],
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> CallFFI {
     precondition(returnType.isObject)
-    precondition(arguments.allSatisfy({ self[$0, in: f] is Load }))
+    precondition(arguments.allSatisfy({ self[register: $0] is Load }))
     return .init(returnType: returnType, callee: callee, arguments: arguments, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/CaptureIn.swift
+++ b/Sources/IR/Operands/Instruction/CaptureIn.swift
@@ -41,13 +41,13 @@ extension CaptureIn: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `capture ... in` anchored at `site` that captures `source`, which is an access, and
   /// stores it in `target`.
-  func makeCapture(_ source: Operand, in target: Operand, in f: Function.ID, at site: SourceRange) -> CaptureIn {
-    precondition(self[f].type(of: source).isAddress)
-    precondition(self[f].type(of: target).isAddress)
+  func makeCapture(_ source: Operand, in target: Operand, at site: SourceRange) -> CaptureIn {
+    precondition(type(of: source).isAddress)
+    precondition(type(of: target).isAddress)
     return .init(source: source, target: target, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/CloseCapture.swift
+++ b/Sources/IR/Operands/Instruction/CloseCapture.swift
@@ -3,11 +3,11 @@ import FrontEnd
 /// Ends the lifetime of a projection.
 public typealias CloseCapture = RegionExit<OpenCapture>
 
-extension Module {
+extension Function {
 
   /// Creates a `close_capture` anchored at `site` that ends the exposition of a captured access.
-  func makeCloseCapture(_ start: Operand, in f: Function.ID, at site: SourceRange) -> CloseCapture {
-    makeRegionExit(start, in: f, at: site)
+  func makeCloseCapture(_ start: Operand, at site: SourceRange) -> CloseCapture {
+    makeRegionExit(start, at: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CloseUnion.swift
+++ b/Sources/IR/Operands/Instruction/CloseUnion.swift
@@ -3,12 +3,12 @@ import FrontEnd
 /// Ends the lifetime of a projection.
 public typealias CloseUnion = RegionExit<OpenUnion>
 
-extension Module {
+extension Function {
 
   /// Creates an `close_union` anchored at `site` that ends an access to the payload of a union
   /// opened previously by `start`.
-  func makeCloseUnion(_ start: Operand, in f: Function.ID, at site: SourceRange) -> CloseUnion {
-    makeRegionExit(start, in: f, at: site)
+  func makeCloseUnion(_ start: Operand, at site: SourceRange) -> CloseUnion {
+    makeRegionExit(start, at: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/CondBranch.swift
+++ b/Sources/IR/Operands/Instruction/CondBranch.swift
@@ -61,7 +61,7 @@ extension CondBranch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `cond_branch` anchored at `site` that jumps to `targetIfTrue` if `condition` is
   /// true or `targetIfFalse` otherwise.
@@ -75,10 +75,9 @@ extension Module {
     if condition: Operand,
     then targetIfTrue: Block.ID,
     else targetIfFalse: Block.ID,
-    in f: Function.ID,
     at site: SourceRange
   ) -> CondBranch {
-    precondition(self[f].type(of: condition) == .object(BuiltinType.i(1)))
+    precondition(type(of: condition) == .object(BuiltinType.i(1)))
     return .init(
       condition: condition,
       targetIfTrue: targetIfTrue,

--- a/Sources/IR/Operands/Instruction/ConstantString.swift
+++ b/Sources/IR/Operands/Instruction/ConstantString.swift
@@ -38,7 +38,7 @@ extension ConstantString: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `constant_string` anchored at `site` that returns a  string with given `value`,
   /// encoded in UTF8.

--- a/Sources/IR/Operands/Instruction/DeallocStack.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStack.swift
@@ -26,14 +26,14 @@ public struct DeallocStack: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `dealloc_stack` anchored at `site` that deallocates memory allocated by `alloc`.
   ///
   /// - Parameters:
   ///   - alloc: The address of the memory to deallocate. Must be the result of `alloc`.
-  func makeDeallocStack(for alloc: Operand, in f: Function.ID, at site: SourceRange) -> DeallocStack {
-    precondition(alloc.instruction.map({ self[$0, in: f] is AllocStack }) ?? false)
+  func makeDeallocStack(for alloc: Operand, at site: SourceRange) -> DeallocStack {
+    precondition(alloc.instruction.map({ self[$0] is AllocStack }) ?? false)
     return .init(location: alloc, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/EndAccess.swift
+++ b/Sources/IR/Operands/Instruction/EndAccess.swift
@@ -3,11 +3,11 @@ import FrontEnd
 /// Ends the lifetime of a projection.
 public typealias EndAccess = RegionExit<Access>
 
-extension Module {
+extension Function {
 
   /// Creates an `end_access` anchored at `site` that ends the projection created by `start`.
-  func makeEndAccess(_ start: Operand, in f: Function.ID, at site: SourceRange) -> EndAccess {
-    makeRegionExit(start, in: f, at: site)
+  func makeEndAccess(_ start: Operand, at site: SourceRange) -> EndAccess {
+    makeRegionExit(start, at: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/EndProject.swift
+++ b/Sources/IR/Operands/Instruction/EndProject.swift
@@ -3,11 +3,11 @@ import FrontEnd
 /// Ends the lifetime of a projection.
 public typealias EndProject = RegionExit<Project>
 
-extension Module {
+extension Function {
 
   /// Creates an `end_project` anchored at `site` that ends the projection created by `start`.
-  func makeEndProject(_ start: Operand, in f: Function.ID, at site: SourceRange) -> EndProject {
-    makeRegionExit(start, in: f, at: site)
+  func makeEndProject(_ start: Operand, at site: SourceRange) -> EndProject {
+    makeRegionExit(start, at: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/GenericParameter.swift
+++ b/Sources/IR/Operands/Instruction/GenericParameter.swift
@@ -37,14 +37,14 @@ extension GenericParameter: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `generic_parameter` anchored at `site` that returns the address of the generic
-  /// argument passed to `p`.
+  /// argument passed to `p`, having type `t`.
   func makeGenericParameter(
-    passedTo p: GenericParameterDecl.ID, at site: SourceRange
+    passedTo p: GenericParameterDecl.ID, type t: AnyType, at site: SourceRange
   ) -> GenericParameter {
-    .init(parameter: p, result: .address(program[p].type), site: site)
+    .init(parameter: p, result: .address(t), site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/GlobalAddr.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddr.swift
@@ -41,11 +41,10 @@ extension GlobalAddr: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
-  /// Creates an `global_addr` anchored at `site` that returns the address of `binding`.
-  func makeGlobalAddr(of binding: BindingDecl.ID, at anchor: SourceRange) -> GlobalAddr {
-    let t = program.canonical(program[binding].type, in: program[binding].scope)
+  /// Creates an `global_addr` anchored at `site` that returns the address of `binding` with value type `t`.
+  func makeGlobalAddr(of binding: BindingDecl.ID, type t: AnyType, at anchor: SourceRange) -> GlobalAddr {
     return .init(binding: binding, valueType: t, site: anchor)
   }
 

--- a/Sources/IR/Operands/Instruction/Load.swift
+++ b/Sources/IR/Operands/Instruction/Load.swift
@@ -34,16 +34,16 @@ public struct Load: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `load` anchored at `site` that loads the object at `source`.
   ///
   /// - Parameters:
   ///   - source: The location from which the object is loaded. Must be the result of an `access`
   ///     instruction requesting a `sink` capability.
-  func makeLoad(_ source: Operand, in f: Function.ID, at site: SourceRange) -> Load {
-    precondition(self[source, in: f] is Access)
-    return .init(objectType: .object(self[f].type(of: source).ast), from: source, site: site)
+  func makeLoad(_ source: Operand, at site: SourceRange) -> Load {
+    precondition(self[register: source] is Access)
+    return .init(objectType: .object(type(of: source).ast), from: source, site: site)
   }
 
 }

--- a/Sources/IR/Operands/Instruction/MarkState.swift
+++ b/Sources/IR/Operands/Instruction/MarkState.swift
@@ -39,12 +39,12 @@ extension MarkState: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `mark_state` instruction anchored at `site` that marks `storage` has being fully
   /// initialized if `initialized` is `true` or fully uninitialized otherwise.
-  func makeMarkState(_ storage: Operand, initialized: Bool, in f: Function.ID, at site: SourceRange) -> MarkState {
-    precondition(self[f].type(of: storage).isAddress)
+  func makeMarkState(_ storage: Operand, initialized: Bool, at site: SourceRange) -> MarkState {
+    precondition(type(of: storage).isAddress)
     return .init(storage: storage, initialized: initialized, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/MemoryCopy.swift
+++ b/Sources/IR/Operands/Instruction/MemoryCopy.swift
@@ -27,16 +27,16 @@ public struct MemoryCopy: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `memory_copy` anchored at `site` that copies the memory representation of the
   /// value stored at `source` to `target`.
   ///
   /// - Requires: `source` is a `let`-capable access and `target` is a `set`-capable access.
   ///   `source` and `target` have the same type.
-  func makeMemoryCopy(_ source: Operand, _ target: Operand, in f: Function.ID, at site: SourceRange) -> MemoryCopy {
-    let s = self[f].type(of: source)
-    precondition(s.isAddress && (s == self[f].type(of: target)))
+  func makeMemoryCopy(_ source: Operand, _ target: Operand, at site: SourceRange) -> MemoryCopy {
+    let s = type(of: source)
+    precondition(s.isAddress && (s == type(of: target)))
     return .init(source: source, target: target, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/Move.swift
+++ b/Sources/IR/Operands/Instruction/Move.swift
@@ -40,7 +40,7 @@ public struct Move: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `move` anchored at `site` that moves `value` into `storage` using the move
   /// operations defined by `movable`.
@@ -53,10 +53,10 @@ extension Module {
   ///   - storage: The location to initialize or assign. Must have an address type.
   func makeMove(
     _ value: Operand, to storage: Operand, usingConformance movable: FrontEnd.Conformance,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> Move {
-    precondition(self[f].type(of: value).isAddress)
-    precondition(self[f].type(of: storage).isAddress)
+    precondition(type(of: value).isAddress)
+    precondition(type(of: storage).isAddress)
     return .init(object: value, target: storage, movable: movable, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/OpenCapture.swift
+++ b/Sources/IR/Operands/Instruction/OpenCapture.swift
@@ -33,11 +33,11 @@ public struct OpenCapture: RegionEntry {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `open_capture` anchored at `site` that loads the address stored at `source`.
-  func makeOpenCapture(_ source: Operand, in f: Function.ID, at site: SourceRange) -> OpenCapture {
-    let t = RemoteType(self[f].type(of: source).ast) ?? preconditionFailure()
+  func makeOpenCapture(_ source: Operand, at site: SourceRange) -> OpenCapture {
+    let t = RemoteType(type(of: source).ast) ?? preconditionFailure()
     return .init(result: .address(t.bareType), source: source, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/OpenUnion.swift
+++ b/Sources/IR/Operands/Instruction/OpenUnion.swift
@@ -62,7 +62,7 @@ extension OpenUnion: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `open_union` anchored at `site` that projects the address of `container`'s payload
   /// viewed as an instance of `payload`.
@@ -72,9 +72,9 @@ extension Module {
   func makeOpenUnion(
     _ container: Operand, as payload: AnyType,
     forInitialization isUsedForInitialization: Bool = false,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> OpenUnion {
-    precondition(self[f].type(of: container).isAddress)
+    precondition(type(of: container).isAddress)
     precondition(payload.isCanonical)
     return .init(
       container: container,

--- a/Sources/IR/Operands/Instruction/PointerToAddress.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddress.swift
@@ -45,7 +45,7 @@ extension PointerToAddress: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `pointer_to_address` anchored at `site` that converts `source`, which is a
   /// built-in pointer value, to an address of type `target`.

--- a/Sources/IR/Operands/Instruction/Project.swift
+++ b/Sources/IR/Operands/Instruction/Project.swift
@@ -61,7 +61,7 @@ extension Project: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `project` anchored at `site` that projects a value of type `t` by applying `s`,
   /// which is a reference to a lowered subscript, on `arguments`.

--- a/Sources/IR/Operands/Instruction/ProjectBundle.swift
+++ b/Sources/IR/Operands/Instruction/ProjectBundle.swift
@@ -69,27 +69,18 @@ extension ProjectBundle: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
-  /// Creates a `project_bundle` anchored at `site` that applies one of the variants defined in `m`
-  /// to arguments `a`, canonicalizing types in `scopeOfUse`.
-  mutating func makeProjectBundle(
-    applying m: BundleReference<SubscriptDecl>, to a: [Operand],
-    at site: SourceRange,
-    canonicalizingTypesIn scopeOfUse: AnyScopeID
+  /// Creates a `project_bundle` anchored at `site` that applies one of the variants `variants`
+  /// defined in `m`, of type `t`, to arguments `a`.
+  func makeProjectBundle(
+    applying m: BundleReference<SubscriptDecl>,
+    variants: [AccessEffect: Function.ID],
+    type t: ArrowType,
+    to a: [Operand],
+    at site: SourceRange
   ) -> ProjectBundle {
-    var variants: [AccessEffect: Function.ID] = [:]
-    for v in program[m.bundle].impls {
-      let i = program[v].introducer.value
-      if m.capabilities.contains(i) {
-        variants[program[v].introducer.value] = demandDeclaration(lowering: v)
-      }
-    }
     precondition(!variants.isEmpty)
-
-    let t = SubscriptType(
-      program.canonicalType(of: m.bundle, specializedBy: m.arguments, in: scopeOfUse))!.pure
-
     return .init(
       bundle: m, variants: variants,
       parameters: t.inputs.lazy.map({ ParameterType($0.type)! }),

--- a/Sources/IR/Operands/Instruction/RegionExit.swift
+++ b/Sources/IR/Operands/Instruction/RegionExit.swift
@@ -45,13 +45,13 @@ extension RegionExit: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a region exit anchored at `site` marking an exit of the regions started by `start`.
   func makeRegionExit<Entry: RegionEntry>(
-    _ start: Operand, in f: Function.ID, at anchor: SourceRange
+    _ start: Operand, at anchor: SourceRange
   ) -> RegionExit<Entry> {
-    precondition(start.instruction.map({ self[$0, in: f] is Entry }) ?? false)
+    precondition(start.instruction.map({ self[$0] is Entry }) ?? false)
     return .init(start: start, site: anchor)
   }
 

--- a/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
+++ b/Sources/IR/Operands/Instruction/ReleaseCaptures.swift
@@ -25,12 +25,12 @@ public struct ReleaseCaptures: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `release_capture` anchored at `site` that releases the accesses previously captured
   /// in `container`.
-  func makeReleaseCapture(_ container: Operand, in f: Function.ID, at site: SourceRange) -> ReleaseCaptures {
-    precondition(container.instruction.map({ self[$0, in: f] is AllocStack }) ?? false)
+  func makeReleaseCapture(_ container: Operand, at site: SourceRange) -> ReleaseCaptures {
+    precondition(container.instruction.map({ self[$0] is AllocStack }) ?? false)
     return .init(container: container, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/Return.swift
+++ b/Sources/IR/Operands/Instruction/Return.swift
@@ -23,7 +23,7 @@ public struct Return: Terminator {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `return` anchored at `site`.
   func makeReturn(at site: SourceRange) -> Return {

--- a/Sources/IR/Operands/Instruction/Store.swift
+++ b/Sources/IR/Operands/Instruction/Store.swift
@@ -34,16 +34,16 @@ public struct Store: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `record` anchored at `site` that stores `object` at `target.
   ///
   /// - Parameters:
   ///   - object: The object to store. Must have an object type.
   ///   - target: The location at which `object` is stored. Must have an address type.
-  func makeStore(_ object: Operand, at target: Operand, in f: Function.ID, at site: SourceRange) -> Store {
-    precondition(self[f].type(of: object).isObject)
-    precondition(self[f].type(of: target).isAddress)
+  func makeStore(_ object: Operand, at target: Operand, at site: SourceRange) -> Store {
+    precondition(type(of: object).isObject)
+    precondition(type(of: target).isAddress)
     return .init(object: object, at: target, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/SubfieldView.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldView.swift
@@ -53,19 +53,15 @@ extension SubfieldView: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
-  /// Creates a `subfield_view` anchored at `site` computing the address of the given `subfield` of
-  /// some record at `recordAddress`.
-  ///
-  /// - Note: `base` is returned unchanged if `elementPath` is empty.
+  /// Creates a `subfield_view` anchored at `site` computing the address of the given `elementPath` of
+  /// some record at `recordAddress`, using layout `l`.
   func makeSubfieldView(
-    of recordAddress: Operand, subfield elementPath: RecordPath, in f: Function.ID, at site: SourceRange
+    of recordAddress: Operand, subfield elementPath: RecordPath, layout l: AbstractTypeLayout, at site: SourceRange
   ) -> SubfieldView {
-    precondition(self[f].type(of: recordAddress).isAddress)
-    let l = AbstractTypeLayout(of: self[f].type(of: recordAddress).ast, definedIn: program)
+    precondition(type(of: recordAddress).isAddress)
     let t = l[elementPath].type
-
     return .init(
       base: recordAddress,
       subfield: elementPath,

--- a/Sources/IR/Operands/Instruction/Switch.swift
+++ b/Sources/IR/Operands/Instruction/Switch.swift
@@ -48,16 +48,16 @@ extension Switch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `switch` anchored at `site` that jumps to `successors[i]`.
   ///
   /// - Requires: `i` is a valid index in `successors`, expressed as a built-in integer, and
   ///   `successors` is not empty.
   func makeSwitch(
-    on index: Operand, toOneOf successors: [Block.ID], in f: Function.ID, at site: SourceRange
+    on index: Operand, toOneOf successors: [Block.ID], at site: SourceRange
   ) -> Switch {
-    let t = self[f].type(of: index)
+    let t = type(of: index)
     precondition(t.isObject && t.ast.isBuiltinInteger)
     precondition(!successors.isEmpty)
 

--- a/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
+++ b/Sources/IR/Operands/Instruction/UnionDiscriminator.swift
@@ -30,14 +30,14 @@ public struct UnionDiscriminator: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `union_discriminator` anchored at `site` that returns the discriminator of the
   /// element stored in `container`.
   func makeUnionDiscriminator(
-    _ container: Operand, in f: Function.ID, at site: SourceRange
+    _ container: Operand, at site: SourceRange
   ) -> UnionDiscriminator {
-    precondition(self[f].type(of: container).isAddress)
+    precondition(type(of: container).isAddress)
     return .init(container: container, site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/UnionSwitch.swift
+++ b/Sources/IR/Operands/Instruction/UnionSwitch.swift
@@ -63,7 +63,7 @@ extension UnionSwitch: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `union_switch` anchored at `site` that switches over `discriminator`, which is the
   /// discriminator of a container of type `union`, jumping to corresponding block in `target`.
@@ -74,9 +74,9 @@ extension Module {
   /// - Requires: `targets` has a key defined for each of `union`.
   func makeUnionSwitch(
     over discriminator: Operand, of union: UnionType, toOneOf targets: UnionSwitch.Targets,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> UnionSwitch {
-    let t = self[f].type(of: discriminator)
+    let t = type(of: discriminator)
     precondition(t.isObject && t.ast.isBuiltinInteger)
     precondition(union.elements.allSatisfy({ (e) in targets[e] != nil }))
     return .init(discriminator: discriminator, union: union, targets: targets, site: site)

--- a/Sources/IR/Operands/Instruction/Unreachable.swift
+++ b/Sources/IR/Operands/Instruction/Unreachable.swift
@@ -28,7 +28,7 @@ public struct Unreachable: Terminator {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates an `unreachable` anchored at `site` that marks the execution path unreachable.
   func makeUnreachable(at site: SourceRange) -> Unreachable {

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddr.swift
@@ -51,7 +51,7 @@ extension WrapExistentialAddr: CustomStringConvertible {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `wrap_existential_addr` anchored at `site` that creates an existential container of
   /// type `interface` wrapping `witness` and `table`.
@@ -62,9 +62,9 @@ extension Module {
   ///   - table: The witness table of the wrapped value. Must be a pointer to a witness table.
   func makeWrapExistentialAddr(
     _ witness: Operand, _ table: Operand, as interface: ExistentialType,
-    in f: Function.ID, at site: SourceRange
+    at site: SourceRange
   ) -> WrapExistentialAddr {
-    precondition(self[f].type(of: witness).isAddress)
+    precondition(type(of: witness).isAddress)
     return .init(witness: witness, table: table, interface: .address(interface), site: site)
   }
 

--- a/Sources/IR/Operands/Instruction/Yield.swift
+++ b/Sources/IR/Operands/Instruction/Yield.swift
@@ -36,11 +36,11 @@ public struct Yield: Instruction {
 
 }
 
-extension Module {
+extension Function {
 
   /// Creates a `yield` anchored at `site` that projects `a` with capability `c`.
-  func makeYield(_ c: AccessEffect, _ a: Operand, in f: Function.ID, at site: SourceRange) -> Yield {
-    precondition(self[f].type(of: a).isAddress)
+  func makeYield(_ c: AccessEffect, _ a: Operand, at site: SourceRange) -> Yield {
+    precondition(type(of: a).isAddress)
     return .init(capability: c, projection: a, site: site)
   }
 


### PR DESCRIPTION
This PR is an alternative to #1773 

This allow localizing IR changes to Function, if we don't need anything
else from the Module.

The `makeXXX` functions don't require mutation on `Function`.

The following places required very small refactoring:
- `makeProjectbundle` required inout access to the `module`
- `makeCallBundle` required inout access to the `module`
- `makeSubfieldView` required access to the program
- `makeGlobalAddr` required access to the program