### PR TITLE
Multiline strings draft

### DIFF
--- a/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
+++ b/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
@@ -48,6 +48,14 @@ extension Diagnostic {
     .error("unterminated string", at: p ..< p)
   }
 
+  static func error(emptyMultilineStringAt site: SourceRange) -> Diagnostic {
+    .error("multiline string literal cannot be empty", at: site)
+  }
+
+  static func error(nonHomogeneousIndentationInMultilineStringEndingAt site: SourceRange) -> Diagnostic {
+    .error("indentation characters (tabs/spaces) must be homogeneous", at: site)
+  }
+
   static func error(duplicateAccessModifier m: SourceRepresentable<AccessModifier>) -> Diagnostic {
     .error("duplicate access modifier '\(m.value)'", at: m.site)
   }

--- a/Sources/FrontEnd/Parse/Token.swift
+++ b/Sources/FrontEnd/Parse/Token.swift
@@ -8,12 +8,14 @@ public struct Token: Sendable {
     case invalid = 0
     case unterminatedString
     case unterminatedBlockComment
+    case emptyMultilineString
 
     // Scalar literals
     case bool = 1000
     case exponent
     case int
     case string
+    case multilineString
 
     // Identifiers
     case name = 2000

--- a/Tests/HyloTests/LexerTests.swift
+++ b/Tests/HyloTests/LexerTests.swift
@@ -128,6 +128,43 @@ final class LexerTests: XCTestCase {
       ],
       in: input)
   }
+  
+  func testMultilineString() {
+    let input: SourceFile = """
+      \"\"\"single line\"\"\" 
+      
+      \"\"\"
+      multi
+        line
+      \"\"\"
+
+      \"\"\"\"\"\"
+      
+      \"\"\"
+      escape\\tcodes\\nnewline
+      and another
+      \"\"\"
+
+       \"\"\"
+        Escaped escape: \\\\t
+      \"\"\"
+
+      \"\"\"
+      Hello, \"World!\"!
+      \"\"\"
+      """
+    assert(
+      tokenize(input),
+      matches: [
+        TokenSpecification(.multilineString, "\"\"\"single line\"\"\""),
+        TokenSpecification(.multilineString, "\"\"\"\nmulti\n  line\n\"\"\""),
+        TokenSpecification(.emptyMultilineString, "\"\"\"\"\"\""),
+        TokenSpecification(.multilineString, "\"\"\"\nescape\\tcodes\\nnewline\nand another\n\"\"\""),
+        TokenSpecification(.multilineString, "\"\"\"\n  Escaped escape: \\\\t\n\"\"\""),
+        TokenSpecification(.multilineString, "\"\"\"\nHello, \"World!\"!\n\"\"\""),
+      ],
+      in: input)
+  }
 
   func testKeywords() {
     let input: SourceFile = """


### PR DESCRIPTION
Implements the spec according to https://hylo-lang.org/docs/reference/specification/#string-literals

Adds support for escape sequences in Hylo strings - now they should be unescaped when used as values.

More extensive testing is needed, especially around edge cases and non-`\n` line separators. We need to decide what `hc` should use when outputting line separators into string literals. Maybe we should always use the specified platform's line separator, which may not be the same as the host when cross-compiling. We may also decide to replace `\n` with platform-specific alternative, which some other languages do, but we should investigate the alternatives and see what the tradeoffs are (see C++, Rust - Swift is most likely not well-prepared for multiplatform in this sense)