### PR TITLE
Upgrade to LLVM v2 api

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ on:
 env:
   spm-build-options: -Xswiftc -enable-testing --explicit-target-dependency-import-check error
   spm-test-options: --parallel
-  swift-version: '6.2.0'
+  swift-version: '6.2.3'
   HYLO_LLVM_BUILD_RELEASE: 20251207-115516
   HYLO_LLVM_VERSION: '20.1.6'
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "SPMBuildToolSupport"]
 	path = SPMBuildToolSupport
 	url = https://github.com/dabrahams/SPMBuildToolSupport.git
+[submodule "swifty-llvm"]
+	path = Swifty-LLVM
+	url = https://github.com/hylo-lang/Swifty-LLVM
+	branch = ambrus/api-v2

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "07e876a23d566ecda110daa6e654422f23973de83af414a750ed4c98559210b6",
+  "originHash" : "9332b8f918ec01c98ce7ac8e527b909b7d34726e2722ac69c6569e2e7effaf6a",
   "pins" : [
     {
       "identity" : "bigint",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/attaswift/BigInt.git",
+      "location" : "https://github.com/attaswift/BigInt",
       "state" : {
         "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
         "version" : "5.7.0"
@@ -88,14 +88,6 @@
       "state" : {
         "revision" : "b464fcd8d884e599e3202d9bd1eee29a9e504069",
         "version" : "0.7.2"
-      }
-    },
-    {
-      "identity" : "swifty-llvm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/hylo-lang/Swifty-LLVM",
-      "state" : {
-        "revision" : "cff484ecca159d9eec1938cda83a72b57cdfbd08"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -51,8 +51,9 @@ let package = Package(
       url: "https://github.com/attaswift/BigInt",
       from: "5.7.0"),
     .package(
-      url: "https://github.com/hylo-lang/Swifty-LLVM",
-      revision: "cff484ecca159d9eec1938cda83a72b57cdfbd08"),
+      // url: "https://github.com/hylo-lang/Swifty-LLVM",
+      path: "./Swifty-LLVM"),
+      // revision: "cff484ecca159d9eec1938cda83a72b57cdfbd08"),
     .package(
       url: "https://github.com/apple/swift-format",
       from: "508.0.1"),

--- a/Sources/CodeGen/LLVM/ConcreteTypeLayout.swift
+++ b/Sources/CodeGen/LLVM/ConcreteTypeLayout.swift
@@ -53,7 +53,7 @@ struct ConcreteTypeLayout: Sendable {
   /// Creates the layout of `t`, which is defined in `ir`, for use in `m`.
   ///
   /// - Requires: `t` is representable in LLVM.
-  init(of t: AnyType, definedIn ir: IR.Program, forUseIn m: inout SwiftyLLVM.Module) {
+  init(of t: FrontEnd.AnyType, definedIn ir: IR.Program, forUseIn m: inout SwiftyLLVM.Module) {
     self.init(AbstractTypeLayout(of: t, definedIn: ir.base), definedIn: ir, forUseIn: &m)
     checkInvariant()
   }

--- a/Sources/CodeGen/LLVM/LLVM+Word.swift
+++ b/Sources/CodeGen/LLVM/LLVM+Word.swift
@@ -3,7 +3,7 @@ import SwiftyLLVM
 extension SwiftyLLVM.Module {
 
   /// Returns the LLVM type of a machine word.
-  var word: SwiftyLLVM.IntegerType.Reference {
+  var word: SwiftyLLVM.IntegerType.UnsafeReference {
     mutating get {
       integerType(layout.bitWidth(of: ptr))
     }

--- a/Sources/CodeGen/LLVM/LLVM+Word.swift
+++ b/Sources/CodeGen/LLVM/LLVM+Word.swift
@@ -3,8 +3,10 @@ import SwiftyLLVM
 extension SwiftyLLVM.Module {
 
   /// Returns the LLVM type of a machine word.
-  mutating func word() -> SwiftyLLVM.IntegerType {
-    IntegerType(layout.bitWidth(of: ptr), in: &self)
+  var word: SwiftyLLVM.IntegerType.Reference {
+    mutating get {
+      integerType(layout.bitWidth(of: ptr))
+    }
   }
 
 }

--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -4,14 +4,20 @@ import IR
 import SwiftyLLVM
 import Utils
 
+public class ModuleWrapper {
+  public var module: SwiftyLLVM.Module
+  public init(_ module: consuming SwiftyLLVM.Module) {
+    self.module = module
+  }
+}
 /// A Hylo program transpiled to LLVM.
-public struct LLVMProgram: Sendable {
+public struct LLVMProgram: ~Copyable {
 
   /// The machine for which the program is compiled.
   public let target: SwiftyLLVM.TargetMachine
 
   /// The LLVM modules in the program.
-  public private(set) var llvmModules: [ModuleDecl.ID: SwiftyLLVM.Module] = [:]
+  public private(set) var llvmModules: [ModuleDecl.ID: ModuleWrapper] = [:]
 
   /// Creates a transpiling `ir`, whose main module is `mainModule`, for `target`.
   ///
@@ -20,26 +26,26 @@ public struct LLVMProgram: Sendable {
   public init(
     _ ir: IR.Program,
     mainModule: ModuleDecl.ID,
-    for target: SwiftyLLVM.TargetMachine? = nil
+    for target: consuming SwiftyLLVM.TargetMachine
   ) throws {
-    self.target = try target ?? SwiftyLLVM.TargetMachine(for: .host())
+    self.target = target
     for m in ir.modules.keys {
       var context = CodeGenerationContext(forCompiling: m, of: ir)
       let transpilation = SwiftyLLVM.Module(transpiling: m, in: &context)
       do {
         try transpilation.verify()
       } catch {
-        print(transpilation)
+        print(transpilation.description)
         throw error
       }
-      llvmModules[m] = transpilation
+      llvmModules[m] = ModuleWrapper(transpilation)
     }
   }
 
   /// Applies the mandatory IR simplification passes on each module in `self`.
   public mutating func applyMandatoryPasses() {
     for k in llvmModules.keys {
-      llvmModules[k]!.runDefaultModulePasses(optimization: .none, for: target)
+      llvmModules[k]!.module.runDefaultModulePasses(optimization: .none, for: target)
     }
   }
 
@@ -48,7 +54,7 @@ public struct LLVMProgram: Sendable {
   /// Optimization applied are similar to clang's `-O3`.
   public mutating func optimize() {
     for k in llvmModules.keys {
-      llvmModules[k]!.runDefaultModulePasses(optimization: .aggressive, for: target)
+      llvmModules[k]!.module.runDefaultModulePasses(optimization: .aggressive, for: target)
     }
   }
 
@@ -62,8 +68,8 @@ public struct LLVMProgram: Sendable {
     precondition(directory.hasDirectoryPath)
     var result: [URL] = []
     for m in llvmModules.values {
-      let f = directory.appendingPathComponent(m.name).appendingPathExtension("o")
-      try m.write(type, for: target, to: f.fileSystemPath)
+      let f = directory.appendingPathComponent(m.module.name).appendingPathExtension("o")
+      try m.module.write(type, for: target, to: f.fileSystemPath)
       result.append(f)
     }
     return result

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -206,7 +206,7 @@ extension SwiftyLLVM.Module {
     let int32 = context.ir.ast.coreType("Int32")!
     switch context.source[f].output {
     case int32:
-      let t = StructType.Reference(context.ir.llvm(int32, in: &self))  // todo safety check
+      let t = StructType.Reference(context.ir.llvm(int32, in: &self))!
       let s = insertAlloca(t, at: p)
       _ = insertCall(transpilation, on: (s), at: p)
 
@@ -225,7 +225,7 @@ extension SwiftyLLVM.Module {
   /// Returns the LLVM type of a metatype instance.
   private mutating func metatypeType() -> SwiftyLLVM.StructType.Reference {
     if let t = type(named: "_hylo_metatype") {
-      return .init(t)  // todo safety check
+      return StructType.Reference(t)!
     }
 
     return structType((
@@ -239,7 +239,7 @@ extension SwiftyLLVM.Module {
   /// Returns the LLVM type of an existential container.
   private mutating func containerType() -> SwiftyLLVM.StructType.Reference {
     if let t = type(named: "_val_container") {
-      return .init(t)  // todo safety check
+      return SwiftyLLVM.StructType.Reference(t)!
     }
     return structType((ptr, ptr))
   }
@@ -348,7 +348,7 @@ extension SwiftyLLVM.Module {
   private mutating func transpiledConstant(
     _ c: IR.FloatingPointConstant, in context: inout CodeGenerationContext
   ) -> AnyValue.Reference {
-    let t = SwiftyLLVM.FloatingPointType.Reference(context.ir.llvm(c.type.ast, in: &self))  // todo safety check
+    let t = SwiftyLLVM.FloatingPointType.Reference(context.ir.llvm(c.type.ast, in: &self))!
     return t.with { $0.constant(parsing: c.value).erased }
   }
 
@@ -459,7 +459,7 @@ extension SwiftyLLVM.Module {
     setLinkage(.linkOnce, for: instance)
 
     let layout = ConcreteTypeLayout(of: ^t, definedIn: context.ir, forUseIn: &self)
-    let v = structConstant(of: StructType.Reference(instance.with { $0.valueType }),  // todo safety check when downcasting
+    let v = structConstant(of: StructType.Reference(instance.with { $0.valueType })!,
       aggregating: (
         word.with { $0.constant(layout.size) },
         word.with { $0.constant(layout.alignment) },
@@ -488,7 +488,7 @@ extension SwiftyLLVM.Module {
       layout = ConcreteTypeLayout(of: ^t, definedIn: context.ir, forUseIn: &self)
     }
 
-    let v = structConstant(of: StructType.Reference(instance.with { $0.valueType }), aggregating: (
+    let v = structConstant(of: StructType.Reference(instance.with { $0.valueType })!, aggregating: (
       word.with { $0.constant(layout.size) },
       word.with { $0.constant(layout.alignment) },
       word.with { $0.constant(layout.stride) },
@@ -1856,13 +1856,13 @@ extension SwiftyLLVM.Module {
         let f = transpiledConstant(f, in: &context)
         
         // note: may be an intrinsic function, not just a function. In general: any Callable
-        let t = SwiftyLLVM.Function.Reference(f).with { $0.valueType } 
+        let t = SwiftyLLVM.Function.Reference(f)!.with { $0.valueType } 
         return .init(function: f, type: t, environment: [])
       }
 
       // `s` is an arrow.
       let hyloType = ArrowType(context.source[f].type(of: s).ast)!
-      let llvmType = StructType.Reference(context.ir.llvm(hyloType, in: &self)) // todo safe downcast
+      let llvmType = StructType.Reference(context.ir.llvm(hyloType, in: &self))!
       let lambda = llvm(s)
 
       // The first element of the representation is the function pointer.
@@ -1872,7 +1872,7 @@ extension SwiftyLLVM.Module {
 
       let e = insertGetStructElementPointer(
         of: lambda, typed: llvmType, index: 1, at: insertionPoint)
-      let captures = StructType.Reference(context.ir.llvm(hyloType.environment, in: &self)) // todo safe downcast
+      let captures = StructType.Reference(context.ir.llvm(hyloType.environment, in: &self))!
 
       // Following elements constitute the environment.
       var environment: [AnyValue.Reference] = []

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -814,7 +814,7 @@ extension SwiftyLLVM.Module {
       let baseType = context.ir.llvm(context.source[f].type(of: s.base).ast, in: &self)
       let v = insertGetElementPointerInBounds(
         of: base, typed: baseType,
-        indices: (i32.pointee.constant(0), i32.pointee.constant(s.offset)), 
+        indices: (i32.pointee.constant(0), i32.pointee.constant(s.offset)),
         at: insertionPoint)
       register[.register(i)] = v.erased
     }

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -146,8 +146,7 @@ extension IR.Program {
     fields: (inout SwiftyLLVM.Module) -> [SwiftyLLVM.AnyType.Reference]
   ) -> SwiftyLLVM.StructType.Reference {
     if let u = module.type(named: n) {
-      _ = u.with { StructType($0) ?? fatalError("'\(n)' is not a struct") }
-      return StructType.Reference(u)
+      return StructType.Reference(u)!
     } else {
       let fs = fields(&module)
       return module.structType(named: n, fs)

--- a/Sources/Utils/Trie.swift
+++ b/Sources/Utils/Trie.swift
@@ -1,8 +1,8 @@
 /// A trie (a.k.a. prefix tree).
-public struct Trie<Key: Collection & Sendable, Value: Sendable>: Sendable where Key.Element: Hashable & Sendable {
+public struct Trie<Key: Collection & Sendable, Value> where Key.Element: Hashable & Sendable {
 
   /// A node representing either one of the strings in a trie or a prefix thereof.
-  fileprivate struct Node: Sendable {
+  fileprivate struct Node {
 
     /// The identifier of a node in a trie.
     typealias Identifier = Int
@@ -149,6 +149,9 @@ public struct Trie<Key: Collection & Sendable, Value: Sendable>: Sendable where 
   }
 
 }
+
+extension Trie.Node : Sendable where Value: Sendable {}
+extension Trie: Sendable where Value: Sendable {}
 
 extension Trie {
 
@@ -297,7 +300,7 @@ extension Trie: CustomStringConvertible {
 }
 
 /// A part of a trie.
-public struct SubTrie<Key: Collection & Sendable, Value: Sendable>: Sendable where Key.Element: Hashable & Sendable {
+public struct SubTrie<Key: Collection & Sendable, Value> where Key.Element: Hashable & Sendable {
 
   /// The type of a trie projected by an instance of `Self`.
   public typealias Base = Trie<Key, Value>
@@ -364,3 +367,5 @@ extension SubTrie: CustomStringConvertible {
   }
 
 }
+
+extension SubTrie: Sendable where Value: Sendable {}


### PR DESCRIPTION
This PR upgrades the SwiftyLLVM dependency and usages.

The major change is that now `UnsafeReference<T>` is returned instead of `T`. To access `T`'s fields, we must explicitly write `myReference.pointee.someField` or `myReference.with{ $0.someField }`. Initially, [I used the `with` version everywhere](https://github.com/hylo-lang/hylo/compare/main...d114c9aa133f23c411d8c221c997f07961687799#diff-4306f9cc025ba18eb1a6954f99f924f4a1075acf9c3b51ae0bd655fb4c6301fdR491). This added unnecessary syntactic noise, and didn't appear to give any benefits over `pointee`. In the last commit, I changed all usages to `.pointee`.

Since Module is now non-copyable, I had to wrap it in a class so that we can maintain a collection of them. Not the nicest, but it's the best to expose non-copyable types in the library, and remove this wrapper hack when we get non-copyable collections in Swift.

*The CI is failing in CMake because I didn't yet update CMakeModules' dependency references, but I will fix that after review and potential follow-up commits)*