### PR TITLE
[NFC]: refactor function reference creation as extensions on Module

### DIFF
--- a/Sources/IR/Analysis/Module+CallBundleReification.swift
+++ b/Sources/IR/Analysis/Module+CallBundleReification.swift
@@ -21,8 +21,8 @@ extension Module {
     arguments[0] = .register(self[f].insert(r, at: .before(i)))
 
     let b = self[f].block(of: i)
-    let x = FunctionReference(
-      to: s.variants[k]!, in: self, specializedBy: s.bundle.arguments, in: self[b, in: f].scope)
+    let x = makeReference(
+      to: s.variants[k]!, specializedBy: s.bundle.arguments, in: self[b, in: f].scope)
 
     let reified = makeCall(
       applying: .constant(x), to: arguments, writingResultTo: s.output, in: f, at: s.site)

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -61,7 +61,7 @@ extension IR.Program {
     // TODO: Use existentialization unless the function is inlinable
 
     let g = monomorphize(callee, usedIn: modules[m]![f].scope(containing: i))
-    let r = FunctionReference(to: g, in: modules[m]!)
+    let r = modules[m]!.makeReference(to: g)
     let new = modules[m]!.makeCall(
       applying: .constant(r), to: Array(s.arguments), writingResultTo: s.output, in: f, at: s.site)
     modules[m]![f].replace(i, with: new)
@@ -377,7 +377,7 @@ private struct Monomorphizer: InstructionTransformer {
 
     let s = ir.base.module(containing: scopeOfUse)
     let f = transform(c.function, specializedBy: c.specialization, in: &ir)
-    return FunctionReference(to: f, in: ir.modules[s]!)
+    return ir.modules[s]!.makeReference(to: f)
   }
 
   /// Returns a monomorphized copy of `f` specialized by `z` for use in `scopeOfUse`.

--- a/Sources/IR/Analysis/Program+ElaborateProjectionCallers.swift
+++ b/Sources/IR/Analysis/Program+ElaborateProjectionCallers.swift
@@ -97,8 +97,8 @@ extension Module {
     let oldProjectIR = self[d.id][oldProject]
     let t = oldProjectIR.result!.ast
     let ramp = Function.ID(projectionRamp: (oldProjectIR as! Project).callee)
-    let rampReference = FunctionReference(to: ramp, in: self)
-    let plateauReference = FunctionReference(to: p, in: self)
+    let rampReference = makeReference(to: ramp)
+    let plateauReference = makeReference(to: p)
 
     modifyIR(of: d.id, at: .before(oldEndProject)) { (e) in
       let nullCall = e._call_builtin(.zeroinitializer(BuiltinType.ptr), [])

--- a/Sources/IR/Analysis/Program+ElaborateProjections.swift
+++ b/Sources/IR/Analysis/Program+ElaborateProjections.swift
@@ -130,7 +130,7 @@ extension Module {
     in ramp: Function.ID,
     referencing slide: Function.ID
   ) -> Block.ID {
-    let slideReference = FunctionReference(to: slide, in: self)
+    let slideReference = makeReference(to: slide)
     let continuationParameter = continuationParameter(ramp: ramp)
     let b = self[ramp].appendBlock(in: self[ramp][self[ramp].entry!].scope)
     modifyIR(of: ramp, at: .end(of: b)) { (e) in

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1717,8 +1717,8 @@ struct Emitter: Sendable {
   /// Inserts the IR for storing the value of `e` to `storage`.
   private mutating func _emitStore(_ e: LambdaExpr.ID, to storage: Operand) {
     let callee = lower(function: ast[e].decl)
-    let r = FunctionReference(
-      to: callee, in: module,
+    let r = module.makeReference(
+      to: callee,
       specializedBy: module.specialization(in: insertionFunction!), in: insertionScope!)
 
     let x0 = _place_to_pointer(.constant(r))
@@ -2059,7 +2059,7 @@ struct Emitter: Sendable {
 
     // Call is evaluated last.
     let f = Operand.constant(
-      FunctionReference(to: AnyDeclID(d), in: &module, specializedBy: a, in: insertionScope!))
+      module.makeReference(lowering: AnyDeclID(d), specializedBy: a, in: insertionScope!))
     let x0 = _alloc_stack(.void)
     let x1 = _access(.set, from: x0)
 
@@ -2168,8 +2168,8 @@ struct Emitter: Sendable {
     let callee = withClearContext({ $0.lower(syntheticAutoclosure: f) })
 
     // Emit the IR code to reference the function declaration.
-    let r = FunctionReference(
-      to: callee, in: module,
+    let r = module.makeReference(
+      to: callee,
       specializedBy: module.specialization(in: insertionFunction!), in: insertionScope!)
 
     let x0 = _place_to_pointer(.constant(r))
@@ -2276,7 +2276,7 @@ struct Emitter: Sendable {
       guard ArrowType(canonical(program[callee].type))!.environment.isVoid else {
         UNIMPLEMENTED("Generate IR for calls to local functions with captures #1088")
       }
-      let f = FunctionReference(to: d, in: &module, specializedBy: a, in: insertionScope!)
+      let f = module.makeReference(lowering: d, specializedBy: a, in: insertionScope!)
       return (.direct(f), [])
 
     case .member(let d, _, _) where d.isCallable:
@@ -2350,7 +2350,8 @@ struct Emitter: Sendable {
   ) -> (callee: Callee, captures: [Operand]) {
     if let k = b.capabilities.uniqueElement {
       let d = module.demandDeclaration(lowering: program.ast.implementation(k, of: b.bundle)!)
-      let f = FunctionReference(to: d, in: module, specializedBy: b.arguments, in: insertionScope!)
+      let f = module.makeReference(
+        to: d, specializedBy: b.arguments, in: insertionScope!)
       let c = _access([k], from: receiver)
       return (callee: .direct(f), captures: [c])
     } else {

--- a/Sources/IR/InstructionTransformer.swift
+++ b/Sources/IR/InstructionTransformer.swift
@@ -190,9 +190,8 @@ extension IR.Program {
       }
 
     case let s as Project:
-      let r = FunctionReference(
-        to: s.callee, in: modules[m]!,
-        specializedBy: s.specialization, in: modules[m]![f].scope(containing: i))
+      let r = modules[m]!.makeReference(
+        to: s.callee, specializedBy: s.specialization, in: modules[m]![f].scope(containing: i))
       let oldCallee = Operand.constant(r)
       let newCallee = t.transform(oldCallee, in: &self).constant as! FunctionReference
 

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -427,7 +427,7 @@ public struct Module: Sendable {
       assert(a[r] == nil)
       a[r] = .type(witness.model)
     }
-    return FunctionReference(to: d, in: self, specializedBy: a, in: witness.scope)
+    return makeReference(to: d, specializedBy: a, in: witness.scope)
   }
 
   /// Returns a member reference to `d`, which is member of `receiver` accessed with capabilities
@@ -441,11 +441,11 @@ public struct Module: Sendable {
       let t = program.traitDeclaring(d)!
       let c = program.conformance(of: receiver, to: t, exposedTo: scopeOfUse)!
       let f = demandDeclaration(lowering: c.implementations[d]!)
-      return .direct(FunctionReference(to: f, in: self, specializedBy: a, in: scopeOfUse))
+      return .direct(makeReference(to: f, specializedBy: a, in: scopeOfUse))
     } else if let m = MethodDecl.ID(d) {
       return .bundle(BundleReference(to: m, specializedBy: a, requesting: k))
     } else {
-      return .direct(FunctionReference(to: d, in: &self, specializedBy: a, in: scopeOfUse))
+      return .direct(makeReference(lowering: d, specializedBy: a, in: scopeOfUse))
     }
   }
 
@@ -570,7 +570,7 @@ public struct Module: Sendable {
     var implementations = IR.Conformance.ImplementationMap()
     for (r, i) in c.implementations where (r.kind != AssociatedTypeDecl.self) {
       let f = demandDeclaration(lowering: i)
-      implementations[r] = .function(FunctionReference(to: f, in: self))
+      implementations[r] = .function(makeReference(to: f))
     }
     return .init(concept: c.concept, implementations: implementations)
   }

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -16,7 +16,7 @@ public struct FunctionReference: Constant, Hashable, Sendable {
   /// Creates a reference to `f`, which is in `module`, without specialization.
   ///
   /// - Requires: `f` accepts no generic parameters.
-  public init(to f: Function.ID, in module: Module) {
+  fileprivate init(to f: Function.ID, in module: Module) {
     precondition(module[f].genericParameters.isEmpty, "underspecialized function reference")
 
     let v = module[f]
@@ -32,7 +32,7 @@ public struct FunctionReference: Constant, Hashable, Sendable {
   /// `scopeOfUse`.
   ///
   /// - Requires: `specialization` supplies arguments for all generic parameters of `f`.
-  public init(
+  fileprivate init(
     to f: Function.ID, in module: Module,
     specializedBy specialization: GenericArguments, in scopeOfUse: AnyScopeID
   ) {
@@ -52,26 +52,6 @@ public struct FunctionReference: Constant, Hashable, Sendable {
     self.specialization = a
   }
 
-  /// Creates a reference to the lowered form of `d` in `module`, without specialization.
-  ///
-  /// - Requires: `d` can be lowered to an IR function.
-  public init(to d: AnyDeclID, in module: inout Module) {
-    let f = module.demandDeclaration(lowering: d)!
-    self.init(to: f, in: module)
-  }
-
-  /// Creates a reference to the lowered form of `d` in `module`, specialized by `specialization`
-  /// in `scopeOfUse`.
-  ///
-  /// - Requires: `d` can be lowered to an IR function.
-  public init(
-    to d: AnyDeclID, in module: inout Module,
-    specializedBy specialization: GenericArguments, in scopeOfUse: AnyScopeID
-  ) {
-    let f = module.demandDeclaration(lowering: d)!
-    self.init(to: f, in: module, specializedBy: specialization, in: scopeOfUse)
-  }
-
 }
 
 extension FunctionReference: CustomStringConvertible {
@@ -84,4 +64,36 @@ extension FunctionReference: CustomStringConvertible {
     }
   }
 
+}
+
+extension Module {
+
+  /// Creates a reference to `functionID` without specialization.
+  ///
+  /// - Requires: `functionID` accepts no generic parameters.
+  func makeReference(to functionID: Function.ID) -> FunctionReference {
+    .init(to: functionID, in: self)
+  }
+
+  /// Creates a reference to `functionID` specialized by `specialization` in `scopeOfUse`.
+  ///
+  /// - Requires: `specialization` supplies arguments for all generic parameters of `functionID`.
+  func makeReference(
+    to functionID: Function.ID,
+    specializedBy specialization: GenericArguments, in scopeOfUse: AnyScopeID
+  ) -> FunctionReference {
+    .init(to: functionID, in: self, specializedBy: specialization, in: scopeOfUse)
+  }
+
+  /// Creates a reference to the lowered form of `declID` specialized by `specialization` in
+  /// `scopeOfUse`.
+  ///
+  /// - Requires: `declID` can be lowered to an IR function.
+  mutating func makeReference(
+    lowering declID: AnyDeclID,
+    specializedBy specialization: GenericArguments, in scopeOfUse: AnyScopeID
+  ) -> FunctionReference {
+    let f = demandDeclaration(lowering: declID)!
+    return .init(to: f, in: self, specializedBy: specialization, in: scopeOfUse)
+  }
 }


### PR DESCRIPTION
This change picks up where https://github.com/hylo-lang/hylo/pull/1344 left off and attempts to replace various and sundry `FunctionReference` constructor callsites with a few methods on `Module`.

Resolves: https://github.com/hylo-lang/hylo/issues/965