### PR TITLE
Use case-insensitive PATH lookup

### DIFF
--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -540,7 +540,11 @@ public struct Driver: ParsableCommand, Sendable {
       ? invocationName : invocationName + Host.executableSuffix
 
     // Search in the PATH.
-    let path = ProcessInfo.processInfo.environment[Host.pathEnvironmentVariable] ?? ""
+    // Use case-insensitive key lookup to support environments like MSYS2 that use "PATH"
+    // instead of the native Windows "Path".
+    let env = ProcessInfo.processInfo.environment
+    let pathKey = env.keys.first(where: { $0.caseInsensitiveCompare(Host.pathEnvironmentVariable) == .orderedSame }) ?? Host.pathEnvironmentVariable
+    let path = env[pathKey] ?? ""
     for root in path.split(separator: Host.pathEnvironmentSeparator) {
       let candidate = URL(fileURLWithPath: String(root)).appendingPathComponent(executableFileName)
       if FileManager.default.fileExists(atPath: candidate.fileSystemPath) {

--- a/Sources/Driver/Driver.swift
+++ b/Sources/Driver/Driver.swift
@@ -540,10 +540,12 @@ public struct Driver: ParsableCommand, Sendable {
       ? invocationName : invocationName + Host.executableSuffix
 
     // Search in the PATH.
-    // Use case-insensitive key lookup to support environments like MSYS2 that use "PATH"
-    // instead of the native Windows "Path".
+    // On Windows, use case-insensitive key lookup to support environments like MSYS2 that use
+    // "PATH" instead of the native Windows "Path".
     let env = ProcessInfo.processInfo.environment
-    let pathKey = env.keys.first(where: { $0.caseInsensitiveCompare(Host.pathEnvironmentVariable) == .orderedSame }) ?? Host.pathEnvironmentVariable
+    let pathKey = Platform.hostOperatingSystem == .windows
+      ? env.keys.first(where: { $0.caseInsensitiveCompare(Host.pathEnvironmentVariable) == .orderedSame }) ?? Host.pathEnvironmentVariable
+      : Host.pathEnvironmentVariable
     let path = env[pathKey] ?? ""
     for root in path.split(separator: Host.pathEnvironmentSeparator) {
       let candidate = URL(fileURLWithPath: String(root)).appendingPathComponent(executableFileName)


### PR DESCRIPTION
On Windows, environment variable names are case-insensitive at the OS level,
but Swift's Dictionary lookup is case-sensitive. This caused `findExecutable`
to fail in environments like MSYS2, which sets the PATH variable as "PATH"
rather than the native Windows convention "Path".

This change looks up the PATH key case-insensitively, so executable discovery
works correctly regardless of the environment.