### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ on:
 env:
   spm-build-options: -Xswiftc -enable-testing --explicit-target-dependency-import-check error
   spm-test-options: --parallel
-  swift-version: '6.2.0'
+  swift-version: '6.2.4'
   HYLO_LLVM_BUILD_RELEASE: 20251207-115516
   HYLO_LLVM_VERSION: '20.1.6'
 
@@ -229,13 +229,13 @@ jobs:
         with:
           swift-version: ${{ env.swift-version }} # already verifies Swift version
 
-      - name: Set up Visual Studio Development Environment (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        uses: compnerd/gha-setup-vsdevenv@main
-        with:
-          winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
-          # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
-          # The Swift compiler team is aware of the issue and they are going to release a fix some time.
+      # - name: Set up Visual Studio Development Environment (Windows)
+      #   if: ${{ runner.os == 'Windows' }}
+      #   uses: compnerd/gha-setup-vsdevenv@main
+      #   with:
+      #     winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
+      #     # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
+      #     # The Swift compiler team is aware of the issue and they are going to release a fix some time.
 
       - name: Set up specific Xcode version
         uses: maxim-lobanov/setup-xcode@v1
@@ -339,13 +339,13 @@ jobs:
         with:
           swift-version: ${{ env.swift-version }} # already verifies Swift version
 
-      - name: Set up Visual Studio Development Environment (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        uses: compnerd/gha-setup-vsdevenv@main
-        with:
-          winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
-          # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
-          # The Swift compiler team is aware of the issue and they are going to release a fix some time.
+      # - name: Set up Visual Studio Development Environment (Windows)
+      #   if: ${{ runner.os == 'Windows' }}
+      #   uses: compnerd/gha-setup-vsdevenv@main
+      #   with:
+      #     winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
+      #     # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
+      #     # The Swift compiler team is aware of the issue and they are going to release a fix some time.
 
       - name: Set up specific Xcode version
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -237,6 +237,38 @@ jobs:
       #     # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
       #     # The Swift compiler team is aware of the issue and they are going to release a fix some time.
 
+      - name: Print Windows SDK version (after vsdevenv setup)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          Write-Host "Windows SDK env vars (if set by VS Dev Env):"
+          "WindowsSdkDir=$env:WindowsSdkDir" | Write-Host
+          "WindowsSDKVersion=$env:WindowsSDKVersion" | Write-Host
+          "UniversalCRTSdkDir=$env:UniversalCRTSdkDir" | Write-Host
+          "UCRTVersion=$env:UCRTVersion" | Write-Host
+
+          Write-Host "" 
+          Write-Host "Windows Kits Installed Roots (registry):"
+          $kitsRootsKey = 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots'
+          if (Test-Path $kitsRootsKey) {
+            $kitsRoots = Get-ItemProperty -Path $kitsRootsKey
+            if ($kitsRoots.KitsRoot10) { "KitsRoot10=$($kitsRoots.KitsRoot10)" | Write-Host }
+            if ($kitsRoots.KitsRoot11) { "KitsRoot11=$($kitsRoots.KitsRoot11)" | Write-Host }
+          } else {
+            Write-Host "Registry key not found: $kitsRootsKey"
+          }
+
+          Write-Host "" 
+          Write-Host "Windows SDK versions found under Windows Kits Include directories:"
+          foreach ($base in @($env:WindowsSdkDir, $kitsRoots.KitsRoot10, $kitsRoots.KitsRoot11, 'C:\Program Files (x86)\Windows Kits\10\')) {
+            if (-not $base) { continue }
+            $includeDir = Join-Path $base 'Include'
+            if (Test-Path $includeDir) {
+              Write-Host "IncludeDir=$includeDir"
+              Get-ChildItem -Path $includeDir -Directory | Select-Object -ExpandProperty Name | Sort-Object | ForEach-Object { "  - $_" | Write-Host }
+            }
+          }
+
       - name: Set up specific Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         if: ${{ runner.os == 'macOS' }}
@@ -346,6 +378,38 @@ jobs:
       #     winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
       #     # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
       #     # The Swift compiler team is aware of the issue and they are going to release a fix some time.
+
+      - name: Print Windows SDK version (after vsdevenv setup)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          Write-Host "Windows SDK env vars (if set by VS Dev Env):"
+          "WindowsSdkDir=$env:WindowsSdkDir" | Write-Host
+          "WindowsSDKVersion=$env:WindowsSDKVersion" | Write-Host
+          "UniversalCRTSdkDir=$env:UniversalCRTSdkDir" | Write-Host
+          "UCRTVersion=$env:UCRTVersion" | Write-Host
+
+          Write-Host "" 
+          Write-Host "Windows Kits Installed Roots (registry):"
+          $kitsRootsKey = 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots'
+          if (Test-Path $kitsRootsKey) {
+            $kitsRoots = Get-ItemProperty -Path $kitsRootsKey
+            if ($kitsRoots.KitsRoot10) { "KitsRoot10=$($kitsRoots.KitsRoot10)" | Write-Host }
+            if ($kitsRoots.KitsRoot11) { "KitsRoot11=$($kitsRoots.KitsRoot11)" | Write-Host }
+          } else {
+            Write-Host "Registry key not found: $kitsRootsKey"
+          }
+
+          Write-Host "" 
+          Write-Host "Windows SDK versions found under Windows Kits Include directories:"
+          foreach ($base in @($env:WindowsSdkDir, $kitsRoots.KitsRoot10, $kitsRoots.KitsRoot11, 'C:\Program Files (x86)\Windows Kits\10\')) {
+            if (-not $base) { continue }
+            $includeDir = Join-Path $base 'Include'
+            if (Test-Path $includeDir) {
+              Write-Host "IncludeDir=$includeDir"
+              Get-ChildItem -Path $includeDir -Directory | Select-Object -ExpandProperty Name | Sort-Object | ForEach-Object { "  - $_" | Write-Host }
+            }
+          }
 
       - name: Set up specific Xcode version
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -232,42 +232,8 @@ jobs:
       - name: Set up Visual Studio Development Environment (Windows)
         if: ${{ runner.os == 'Windows' }}
         uses: compnerd/gha-setup-vsdevenv@main
-      #   with:
-      #     winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
-      #     # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
-      #     # The Swift compiler team is aware of the issue and they are going to release a fix some time.
-
-      - name: Print Windows SDK version (after vsdevenv setup)
-        if: ${{ runner.os == 'Windows' }}
-        shell: pwsh
-        run: |
-          Write-Host "Windows SDK env vars (if set by VS Dev Env):"
-          "WindowsSdkDir=$env:WindowsSdkDir" | Write-Host
-          "WindowsSDKVersion=$env:WindowsSDKVersion" | Write-Host
-          "UniversalCRTSdkDir=$env:UniversalCRTSdkDir" | Write-Host
-          "UCRTVersion=$env:UCRTVersion" | Write-Host
-
-          Write-Host "" 
-          Write-Host "Windows Kits Installed Roots (registry):"
-          $kitsRootsKey = 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots'
-          if (Test-Path $kitsRootsKey) {
-            $kitsRoots = Get-ItemProperty -Path $kitsRootsKey
-            if ($kitsRoots.KitsRoot10) { "KitsRoot10=$($kitsRoots.KitsRoot10)" | Write-Host }
-            if ($kitsRoots.KitsRoot11) { "KitsRoot11=$($kitsRoots.KitsRoot11)" | Write-Host }
-          } else {
-            Write-Host "Registry key not found: $kitsRootsKey"
-          }
-
-          Write-Host "" 
-          Write-Host "Windows SDK versions found under Windows Kits Include directories:"
-          foreach ($base in @($env:WindowsSdkDir, $kitsRoots.KitsRoot10, $kitsRoots.KitsRoot11, 'C:\Program Files (x86)\Windows Kits\10\')) {
-            if (-not $base) { continue }
-            $includeDir = Join-Path $base 'Include'
-            if (Test-Path $includeDir) {
-              Write-Host "IncludeDir=$includeDir"
-              Get-ChildItem -Path $includeDir -Directory | Select-Object -ExpandProperty Name | Sort-Object | ForEach-Object { "  - $_" | Write-Host }
-            }
-          }
+        with:
+          winsdk: "10.0.26100.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
 
       - name: Set up specific Xcode version
         uses: maxim-lobanov/setup-xcode@v1
@@ -374,42 +340,8 @@ jobs:
       - name: Set up Visual Studio Development Environment (Windows)
         if: ${{ runner.os == 'Windows' }}
         uses: compnerd/gha-setup-vsdevenv@main
-      #   with:
-      #     winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
-      #     # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
-      #     # The Swift compiler team is aware of the issue and they are going to release a fix some time.
-
-      - name: Print Windows SDK version (after vsdevenv setup)
-        if: ${{ runner.os == 'Windows' }}
-        shell: pwsh
-        run: |
-          Write-Host "Windows SDK env vars (if set by VS Dev Env):"
-          "WindowsSdkDir=$env:WindowsSdkDir" | Write-Host
-          "WindowsSDKVersion=$env:WindowsSDKVersion" | Write-Host
-          "UniversalCRTSdkDir=$env:UniversalCRTSdkDir" | Write-Host
-          "UCRTVersion=$env:UCRTVersion" | Write-Host
-
-          Write-Host "" 
-          Write-Host "Windows Kits Installed Roots (registry):"
-          $kitsRootsKey = 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots'
-          if (Test-Path $kitsRootsKey) {
-            $kitsRoots = Get-ItemProperty -Path $kitsRootsKey
-            if ($kitsRoots.KitsRoot10) { "KitsRoot10=$($kitsRoots.KitsRoot10)" | Write-Host }
-            if ($kitsRoots.KitsRoot11) { "KitsRoot11=$($kitsRoots.KitsRoot11)" | Write-Host }
-          } else {
-            Write-Host "Registry key not found: $kitsRootsKey"
-          }
-
-          Write-Host "" 
-          Write-Host "Windows SDK versions found under Windows Kits Include directories:"
-          foreach ($base in @($env:WindowsSdkDir, $kitsRoots.KitsRoot10, $kitsRoots.KitsRoot11, 'C:\Program Files (x86)\Windows Kits\10\')) {
-            if (-not $base) { continue }
-            $includeDir = Join-Path $base 'Include'
-            if (Test-Path $includeDir) {
-              Write-Host "IncludeDir=$includeDir"
-              Get-ChildItem -Path $includeDir -Directory | Select-Object -ExpandProperty Name | Sort-Object | ForEach-Object { "  - $_" | Write-Host }
-            }
-          }
+        with:
+         winsdk: "10.0.26100.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
 
       - name: Set up specific Xcode version
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -229,9 +229,9 @@ jobs:
         with:
           swift-version: ${{ env.swift-version }} # already verifies Swift version
 
-      # - name: Set up Visual Studio Development Environment (Windows)
-      #   if: ${{ runner.os == 'Windows' }}
-      #   uses: compnerd/gha-setup-vsdevenv@main
+      - name: Set up Visual Studio Development Environment (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        uses: compnerd/gha-setup-vsdevenv@main
       #   with:
       #     winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
       #     # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
@@ -339,9 +339,9 @@ jobs:
         with:
           swift-version: ${{ env.swift-version }} # already verifies Swift version
 
-      # - name: Set up Visual Studio Development Environment (Windows)
-      #   if: ${{ runner.os == 'Windows' }}
-      #   uses: compnerd/gha-setup-vsdevenv@main
+      - name: Set up Visual Studio Development Environment (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        uses: compnerd/gha-setup-vsdevenv@main
       #   with:
       #     winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
       #     # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.


### PR DESCRIPTION
Swift now requires a different WinSDK version: 10.0.26100.0

See reported issue at: https://github.com/swiftlang/swift/issues/88237