### PR TITLE
Fix error w/ swift 6.3 on AnyType inequality operator.

### DIFF
--- a/Sources/FrontEnd/Types/AnyType.swift
+++ b/Sources/FrontEnd/Types/AnyType.swift
@@ -314,6 +314,11 @@ extension AnyType: Equatable {
     l.wrapped.equals(r.wrapped)
   }
 
+  /// Returns whether `l` is not syntactically equal to `r`.
+  public static func != (l: Self, r: Self) -> Bool {
+    !l.wrapped.equals(r.wrapped)
+  }
+
   /// Returns whether `l` is syntactically equal to `r`.
   public static func == <T: TypeProtocol>(l: Self, r: T) -> Bool {
     l.wrapped.unwrap(as: T.self) == r


### PR DESCRIPTION
Swift 6.3 yields a compilation error when `!=` is used with two `AnyType` objects. Adding a dedicated `!=` operator fixes this issue.