### PR TITLE
Adds `Equatable` and `Collection` conformance for `String`

### DIFF
--- a/StandardLibrary/Sources/Core/String.hylo
+++ b/StandardLibrary/Sources/Core/String.hylo
@@ -22,3 +22,31 @@ public conformance String: Copyable {
   }
 
 }
+
+public conformance String: Collection {
+
+  /// A position in an String.
+  public typealias Position = Int
+
+  /// A string containing a single code unit 
+  public typealias Element = String
+
+  public fun start_position() -> Int { 0 }
+
+  public fun end_position() -> Int { count() }
+
+  public fun position(after p: Int) -> Int { p + 1 }
+
+  /// Returns the number of elements in `self`.
+  public fun count() -> Int {
+    utf8.count()
+  }
+
+  /// Accesses the unit at `position` in `self`.
+  public subscript(_ position: Int): String { let {
+    let code_point = utf8[position]
+    let arr = UTF8Array.from_int8(code_point: code_point)
+    yield String.from_arr(arr: arr)
+  } }
+
+}

--- a/StandardLibrary/Sources/Core/String.hylo
+++ b/StandardLibrary/Sources/Core/String.hylo
@@ -23,6 +23,14 @@ public conformance String: Copyable {
 
 }
 
+public conformance String: Equatable {
+
+  public fun infix== (_ other: Self) -> Bool {
+    return self.utf8 == other.utf8
+  }
+
+}
+
 public conformance String: Collection {
 
   /// A position in an String.

--- a/StandardLibrary/Sources/Core/String.hylo
+++ b/StandardLibrary/Sources/Core/String.hylo
@@ -4,7 +4,7 @@ public type String {
   /// The contents of the string, encoded in UTF8.
   public var utf8: UTF8Array
 
-  memberwise init
+  public memberwise init
 
   /// Returns `true` if `self` is empty.
   public fun is_empty() -> Bool {
@@ -45,8 +45,8 @@ public conformance String: Collection {
   /// Accesses the unit at `position` in `self`.
   public subscript(_ position: Int): String { let {
     let code_point = utf8[position]
-    let arr = UTF8Array.from_int8(code_point: code_point)
-    yield String.from_arr(arr: arr)
+    let arr = UTF8Array(code_point: code_point)
+    yield String(utf8: arr)
   } }
 
 }

--- a/StandardLibrary/Sources/Core/String/UTF8Array.hylo
+++ b/StandardLibrary/Sources/Core/String/UTF8Array.hylo
@@ -92,7 +92,7 @@ public type UTF8Array: Regular {
   }
 
   /// Creates an instance with a single UTF8 code point stored inline.
-  public static fun init(code_point: Int8) {
+  public init(code_point: Int8) {
     &self.units = (UInt64(truncating_or_extending: code_point) << 8) + 4
   }
 

--- a/StandardLibrary/Sources/Core/String/UTF8Array.hylo
+++ b/StandardLibrary/Sources/Core/String/UTF8Array.hylo
@@ -91,6 +91,11 @@ public type UTF8Array: Regular {
     }
   }
 
+  /// Creates an instance with a single UTF8 code point stored inline.
+  public static fun init(code_point: Int8) {
+    &self.units = (UInt64(truncating_or_extending: code_point) << 8) + 4
+  }
+
   /// Initializes `self` to an instance with the contents of `source` copied to out-of-line storage
   /// capable of holding at least `minimum_capacity` units.
   ///

--- a/Tests/LibraryTests/TestCases/StringTests.hylo
+++ b/Tests/LibraryTests/TestCases/StringTests.hylo
@@ -1,0 +1,13 @@
+//- compileAndRun expecting: .success
+
+fun test_collection() {
+  let str = "abc"
+  precondition(str.count() == 3)
+  precondition(str[0] == "a")
+  precondition(str[1] == "b")
+  precondition(str[2] == "c")
+}
+
+public fun main() {
+  test_collection()
+}

--- a/Tests/LibraryTests/TestCases/UTF8ArrayTests.hylo
+++ b/Tests/LibraryTests/TestCases/UTF8ArrayTests.hylo
@@ -1,0 +1,11 @@
+//- compileAndRun expecting: .success
+
+fun test_init_from_code_point() {
+  let arr = UTF8Array(code_point: 61)
+  precondition(arr.count() == 1)
+  precondition(arr[0] == 61)
+}
+
+public fun main() {
+  test_init_from_code_point()
+}


### PR DESCRIPTION
Adds `Equatable` and `Collection` conformance for `String`. Two `String`s are equal if and only if their `utf8` properties are equal. `String`s are treated as a collection of single code point strings.

Also adds a new initializer `(code_point:)` to `UTF8Array` which creates an `UTF8Array` instance with a single UTF8 code point stored inline.

Also makes the `memberwise init` of `String` public.

Also adds tests for `String` and `UTF8Array`.